### PR TITLE
Complete Rewrite of Plugin

### DIFF
--- a/includes/class-indieauth-authenticate.php
+++ b/includes/class-indieauth-authenticate.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Authentication class
+ * Helper functions for extracting tokens from the WP-API team Oauth2 plugin
+ */
+class IndieAuth_Authenticate {
+
+	public function __construct() {
+		add_filter( 'determine_current_user', array( $this, 'determine_current_user' ), 11 );
+		add_filter( 'rest_authentication_errors', array( $this, 'rest_authentication_errors' ) );
+		add_action( 'authenticate', array( $this, 'authenticate' ) );
+	}
+
+	/**
+	 * Report our errors, if we have any.
+	 *
+	 * Attached to the rest_authentication_errors filter. Passes through existing
+	 * errors registered on the filter.
+	 *
+	 * @param WP_Error|null Current error, or null.
+	 *
+	 * @return WP_Error|null Error if one is set, otherwise null.
+	 */
+	public function rest_authentication_errors( $error = null ) {
+		if ( ! empty( $error ) ) {
+			return $error;
+		}
+		global $indieauth_error;
+		return $indieauth_error;
+	}
+
+	public function determine_current_user( $user_id ) {
+		$token = $this->get_provided_token();
+		if ( ! $token ) {
+			return $user_id;
+		}
+		$args     = array(
+			'headers' => array(
+				'Accept'        => 'application/json',
+				'Authorization' => 'Bearer ' . $token,
+			),
+		);
+		$response = wp_safe_remote_get( get_option( 'indieauth_token_endpoint' ), $args );
+		$code     = wp_remote_retrieve_response_code( $response );
+		$body     = wp_remote_retrieve_body( $response );
+
+		if ( 2 !== (int) ( $code / 100 ) ) {
+			global $indieauth_error;
+			$indieauth_error = new WP_Error(
+				'indieauth.invalid_access_token',
+				__( 'Supplied Token is Invalid', 'indieauth' ),
+				array(
+					'status'   => $code,
+					'response' => $body,
+				)
+			);
+			return $user_id;
+		}
+		$params = json_decode( $body, true );
+		global $indieauth_scopes;
+		$indieauth_scopes = explode( ' ', $params['scope'] );
+		$me               = $params['me'];
+		$user             = $this->get_user_by_identifier( $me );
+		if ( $user ) {
+			return $user->ID;
+		}
+
+		return $user_id;
+	}
+
+	/**
+	 * Authenticate user to WordPress using IndieAuth.
+	 *
+	 * @action: authenticate
+	 * @param mixed $user authenticated user object, or WP_Error or null
+	 * @return mixed authenticated user object, or WP_Error or null
+	 */
+	public function authenticate( $user ) {
+		$args        = array(
+			'headers' => array(
+				'Accept' => 'application/json',
+			),
+		);
+		$redirect_to = array_key_exists( 'redirect_to', $_REQUEST ) ? $_REQUEST['redirect_to'] : null;
+		if ( array_key_exists( 'indieauth_identifier', $_POST ) && $_POST['indieauth_identifier'] ) {
+				$me    = rawurlencode( $_POST['indieauth_identifier'] );
+				$query = build_query(
+					array(
+						'me'           => $me,
+						'redirect_uri' => wp_login_url( $redirect_to ),
+						'client_id'    => home_url(),
+						'state'        => wp_create_nonce( home_url() ),
+					)
+				);
+				// redirect to authentication endpoint
+				wp_redirect( get_option( 'indieauth_authorization_endpoint' ) . '?' . $query );
+		} elseif ( array_key_exists( 'code', $_REQUEST ) && array_key_exists( 'state', $_REQUEST ) ) {
+			if ( ! wp_verify_nonce( $_REQUEST['state'], home_url() ) ) {
+				return new WP_Error( 'indieauth_state_error', __( 'IndieAuth Server did not return the same state parameter', 'indieauth' ) );
+			}
+			$query    = build_query(
+				array(
+					'code'         => rawurlencode( $_REQUEST['code'] ),
+					'redirect_uri' => wp_login_url( $redirect_to ),
+					'client_id'    => home_url(),
+				)
+			);
+			$response = wp_remote_post( get_option( 'indieauth_authorization_endpoint' ) . '?' . $query, $args );
+			$code     = wp_remote_retrieve_response_code( $response );
+			$response = wp_remote_retrieve_body( $response );
+			$response = json_decode( $response, true );
+			// check if response was json or not
+			if ( ! is_array( $response ) ) {
+				$user = new WP_Error( 'indieauth_response_error', __( 'IndieAuth.com seems to have some hiccups, please try it again later.', 'indieauth' ) );
+			}
+
+			if ( 2 !== (int) ( $code / 100 ) ) {
+				return new WP_Error(
+					'indieauth.invalid_access_token',
+					__( 'Supplied Token is Invalid', 'indieauth' ),
+					array(
+						'status'   => $code,
+						'response' => $response,
+					)
+				);
+			}
+
+			if ( array_key_exists( 'me', $response ) ) {
+				$user = $this->get_user_by_identifier( $response['me'] );
+				if ( ! $user ) {
+					$user = new WP_Error( 'indieauth_registration_failure', __( 'Your have entered a valid Domain, but you have no account on this blog.', 'indieauth' ) );
+				}
+			} elseif ( array_key_exists( 'error', $response ) ) {
+				$user = new WP_Error( 'indieauth_' . $response['error'], esc_html( $response['error_description'] ) );
+			}
+		}
+		return $user;
+	}
+
+	/**
+	 * Get the user associated with the specified Identifier-URI.
+	 *
+	 * @param string $$identifier identifier to match
+	 * @return int|null ID of associated user, or null if no associated user
+	 */
+	private function get_user_by_identifier( $identifier ) {
+		// try it without trailing slash
+		$no_slash = untrailingslashit( $identifier );
+
+		$args = array(
+			'search'         => $no_slash,
+			'search_columns' => array( 'user_url' ),
+		);
+
+		$user_query = new WP_User_Query( $args );
+
+			// check result
+		if ( ! empty( $user_query->results ) ) {
+				return $user_query->results[0];
+		}
+
+		// try it with trailing slash
+		$slash = trailingslashit( $identifier );
+
+		$args = array(
+			'search'         => $slash,
+			'search_columns' => array( 'user_url' ),
+		);
+
+		$user_query = new WP_User_Query( $args );
+
+		// check result
+		if ( ! empty( $user_query->results ) ) {
+			return $user_query->results[0];
+		}
+
+		// Check author page
+		global $wp_rewrite;
+		$link = $wp_rewrite->get_author_permastruct();
+		if ( empty( $link ) ) {
+			$login = str_replace( home_url( '/' ) . '?author=', '', $identifier );
+		} else {
+			$link  = str_replace( '%author%', '', $link );
+			$link  = user_trailingslashit( $link );
+			$login = str_replace( $link, '', $link );
+		}
+		$args = array(
+			'login' => $login,
+		);
+
+		$user_query = new WP_User_Query( $args );
+
+		if ( ! empty( $user_query->results ) ) {
+			return $user_query->results[0];
+		}
+
+		return null;
+	}
+
+
+	/**
+	 * Get the authorization header
+	 *
+	 * On certain systems and configurations, the Authorization header will be
+	 * stripped out by the server or PHP. Typically this is then used to
+	 * generate `PHP_AUTH_USER`/`PHP_AUTH_PASS` but not passed on. We use
+	 * `getallheaders` here to try and grab it out instead.
+	 *
+	 * @return string|null Authorization header if set, null otherwise
+	 */
+	public function get_authorization_header() {
+		if ( ! empty( $_SERVER['HTTP_AUTHORIZATION'] ) ) {
+			return wp_unslash( $_SERVER['HTTP_AUTHORIZATION'] );
+		}
+		if ( function_exists( 'getallheaders' ) ) {
+			$headers = getallheaders();
+			// Check for the authorization header case-insensitively
+			foreach ( $headers as $key => $value ) {
+				if ( strtolower( $key ) === 'authorization' ) {
+					return $value;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Extracts the token from the authorization header or the current request.
+	 *
+	 * @return string|null Token on success, null on failure.
+	 */
+	public function get_provided_token() {
+		$header = $this->get_authorization_header();
+		if ( $header ) {
+			return $this->get_token_from_bearer_header( $header );
+		}
+		$token = $this->get_token_from_request();
+		if ( $token ) {
+			return $token;
+		}
+		return null;
+	}
+	/**
+	 * Extracts the token from the given authorization header.
+	 *
+	 * @param string $header Authorization header.
+	 *
+	 * @return string|null Token on success, null on failure.
+	 */
+	public function get_token_from_bearer_header( $header ) {
+		if ( is_string( $header ) && preg_match( '/Bearer ([a-zA-Z0-9\-._~\+\/=]+)/', trim( $header ), $matches ) ) {
+			return $matches[1];
+		}
+		return null;
+	}
+	/**
+	 * Extracts the token from the current request.
+	 *
+	 * @return string|null Token on success, null on failure.
+	 */
+	public function get_token_from_request() {
+		if ( empty( $_GET['access_token'] ) ) {
+			return null;
+		}
+		$token = $_GET['access_token'];
+		if ( is_string( $token ) ) {
+			return $token;
+		}
+		return null;
+	}
+}

--- a/includes/compat-functions.php
+++ b/includes/compat-functions.php
@@ -1,0 +1,20 @@
+<?php
+
+// blatantly stolen from snarfeds micropub plugin who stole it from
+// https://github.com/idno/Known/blob/master/Idno/Pages/File/View.php#L25
+// Used if getallheaders does not exist
+if ( ! function_exists( 'getallheaders' ) ) {
+	function getallheaders() {
+		$headers = array();
+		foreach ( $_SERVER as $name => $value ) {
+			if ( 'HTTP_' === substr( $name, 0, 5 ) ) {
+				$headers[ str_replace( ' ', '-', strtolower( str_replace( '_', ' ', substr( $name, 5 ) ) ) ) ] = $value;
+			} elseif ( 'CONTENT_TYPE' === $name ) {
+				$headers['content-type'] = $value;
+			} elseif ( 'CONTENT_LENGTH' === $name ) {
+				$headers['content-length'] = $value;
+			}
+		}
+		return $headers;
+	}
+}

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -1,32 +1,69 @@
-# Copyright (C) 2017 Matthias Pfefferle
+# Copyright (C) 2018 IndieWebCamp WordPress Outreach Club
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 1.1.3\n"
+"Project-Id-Version: IndieAuth 1.2.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
-"POT-Creation-Date: 2017-12-16 04:43:30+00:00\n"
+"POT-Creation-Date: 2018-01-01 16:00:42+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2018-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 0.5.4\n"
 
-#: indieauth.php:32
-msgid "Or login with your Domain"
+#: includes/class-indieauth-authenticate.php:51
+#: includes/class-indieauth-authenticate.php:120
+msgid "Supplied Token is Invalid"
 msgstr ""
 
-#: indieauth.php:34
-msgid "Learn about IndieAuth"
+#: includes/class-indieauth-authenticate.php:99
+msgid "IndieAuth Server did not return the same state parameter"
 msgstr ""
 
-#: indieauth.php:59
+#: includes/class-indieauth-authenticate.php:114
 msgid "IndieAuth.com seems to have some hiccups, please try it again later."
 msgstr ""
 
-#: indieauth.php:66
+#: includes/class-indieauth-authenticate.php:131
 msgid "Your have entered a valid Domain, but you have no account on this blog."
+msgstr ""
+
+#: indieauth.php:32
+msgid "Offer IndieAuth on Login Form"
+msgstr ""
+
+#: indieauth.php:41
+msgid "IndieAuth Authorization Endpoint"
+msgstr ""
+
+#: indieauth.php:50
+msgid "IndieAuth Token Endpoint"
+msgstr ""
+
+#: indieauth.php:60
+msgid "IndieAuth Settings"
+msgstr ""
+
+#: templates/indieauth-general-settings.php:5
+msgid "Add a option to the login form to login by domain."
+msgstr ""
+
+#: templates/indieauth-general-settings.php:11
+msgid "IndieAuth Authorization Endpoint."
+msgstr ""
+
+#: templates/indieauth-general-settings.php:17
+msgid "IndieAuth Token Endpoint."
+msgstr ""
+
+#: templates/indieauth-login-form.php:2
+msgid "Or login with your Domain"
+msgstr ""
+
+#: templates/indieauth-login-form.php:4
+msgid "Learn about IndieAuth"
 msgstr ""
 
 #. Plugin Name of the plugin/theme
@@ -34,7 +71,7 @@ msgid "IndieAuth"
 msgstr ""
 
 #. Plugin URI of the plugin/theme
-msgid "https://github.com/pfefferle/wordpress-indieauth/"
+msgid "https://github.com/indieweb/wordpress-indieauth/"
 msgstr ""
 
 #. Description of the plugin/theme
@@ -42,9 +79,9 @@ msgid "Login to your site using IndieAuth.com"
 msgstr ""
 
 #. Author of the plugin/theme
-msgid "Matthias Pfefferle"
+msgid "IndieWebCamp WordPress Outreach Club"
 msgstr ""
 
 #. Author URI of the plugin/theme
-msgid "https://notiz.blog"
+msgid "https://indieweb.org/WordPress_Outreach_Club"
 msgstr ""

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,9 @@
 # IndieAuth #
-**Contributors:** [pfefferle](https://profiles.wordpress.org/pfefferle)  
+**Contributors:** [indieweb](https://profiles.wordpress.org/indieweb), [pfefferle](https://profiles.wordpress.org/pfefferle), [dshanske](https://profiles.wordpress.org/dshanske)  
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
-**Requires at least:** 3.6  
+**Requires at least:** 4.7  
 **Tested up to:** 4.9.1  
-**Stable tag:** 1.1.2  
+**Stable tag:** 1.2.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** http://14101978.de  
@@ -12,7 +12,8 @@ An IndieAuth plugin for WordPress. This allows you to login to your website usin
 
 ## Description ##
 
-The plugin lets you login to the WordPress backend via IndieAuth.com. It uses the URL from the profile page to identify the blog user.
+The plugin lets you login to the WordPress backend via IndieAuth.com and allows an Indieauth.com to act as an authentication mechanism for WordPress and its REST API.
+It uses the URL from the profile page to identify the blog user or your author url.
 
 ## Installation ##
 
@@ -20,27 +21,50 @@ The plugin lets you login to the WordPress backend via IndieAuth.com. It uses th
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. That's it
 
-For additional minor set up to be able to actually log in using IndieAuth.com, see [IndieAuth.com](https://indieauth.com/setup). Supported providers include: Twitter, Github, GNUPG, email among others.
+To be able to actually log in using IndieAuth.com, see [IndieAuth.com](https://indieauth.com/setup). Supported providers include: Twitter, Github, GNUPG, email among others.
 
 ## Frequently Asked Questions ##
 
-Taken from [IndieAuth.com](https://indieauth.com)
-
 ### What is IndieAuth? ###
-IndieAuth is a way to use your own domain name to sign in to websites. IndieAuth.com works by linking your website to one or more authentication providers such as Twitter or Github, then entering your domain name in the login form on websites that support IndieAuth. You can link your website to these providers using 'rel-me', which is built into the [Indieweb plugin](https://wordpress.org/plugins/indieweb)
+[IndieAuth](https://indieauth.net) is a way for doing Web sign-in, where you use your own homepage to sign in to other places. 
+
+### What is IndieAuth.com? ###
+
+[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol and available for public use.
 
 ### Why IndieAuth? ###
-IndieAuth is part of the [Indie Web movement](http://indieweb.org/why) to take back control of your online identity. Instead of logging in to websites as "you on Twitter" or "you on Facebook", you should be able to log in as just "you". We should not be relying on other sites to provide our authenticated identities, we should be able to use our own domain names to log in to sites everywhere.
 
-IndieAuth was built to make it as easy as possible for users and for developers to start using this new way of signing in on the web, without the .
+IndieAuth was built on ideas and technology from existing proven technologies like OAuth and OpenID but aims at making it easier for users as well as developers. It also decentralises 
+much of the process so completely separate implementations and services can be used for each part. 
+
+IndieAuth was developed as part of the [Indie Web movement](http://indieweb.org/why) to take back control of your online identity.
 
 ### How is this different from OpenID? ###
-The goals of OpenID and IndieAuth are similar. Both encourage you to sign in to a website using your own domain name. However, OpenID has failed to gain wide adoption, at least in part due to the complexities of the protocol. IndieAuth is a simpler implementation of a similar goal, and IndieAuth.com leverages other OAuth providers and behaviors that people are already accustomed to.
+The goals of OpenID and IndieAuth are similar. Both encourage you to sign in to a website using your own domain name. 
+However, OpenID has failed to gain wide adoption, at least in part due to the complexities of the protocol. 
+
+### How is this different from OAuth? ###
+
+IndieAuth was built on top of the OAuth 2.0 Framework and is a simplified way of verifying the identity of an end user and obtaining an OAuth 2.0 Bearer token.
 
 ### Does this require users to have their own domain name? ###
-Yes, the assumption is that people are willing to [own their online identities](http://indiewebcamp.com/why) in the form of a domain name. It is getting easier and easier to host content on your own domain name. See "[Getting Started on the Indie Web](http://indieweb.org/Getting_Started)" for some suggestions, including mapping your domain to a Tumblr blog, or signing up for a simple web hosting service like Dreamhost.
+No. You can use your author profile URL to login if you do not have a domain name. However how the Indieauth server authenticates you depends on that server.
+
+### How do I authenticate myself to an Indieauth server? ###
+
+That, as mentioned, depends on the server. By default, the plugin uses IndieAuth.com which works by linking your website to one or more authentication providers 
+such as Twitter or Github, then entering your domain name in the login form on websites that support IndieAuth. 
+
+You can link your website to these providers add ['rel-me'](https://indieweb.org/rel-me) links to your site, which can be done manually or by installing 
+the [Indieweb plugin](https://wordpress.org/plugins/indieweb)
+
 
 ## Changelog ##
+
+### 1.2.0 ###
+* Support author profiles in addition to user URLs
+* Change token verification method to match current Indieauth specification
+* Add support for token verification to act as a WordPress authentication mechanism.
 
 ### 1.1.3 ###
 * update README

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === IndieAuth ===
-Contributors: pfefferle
+Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
-Requires at least: 3.6
+Requires at least: 4.7
 Tested up to: 4.9.1
-Stable tag: 1.1.2
+Stable tag: 1.2.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: http://14101978.de
@@ -12,7 +12,8 @@ An IndieAuth plugin for WordPress. This allows you to login to your website usin
 
 == Description ==
 
-The plugin lets you login to the WordPress backend via IndieAuth.com. It uses the URL from the profile page to identify the blog user.
+The plugin lets you login to the WordPress backend via IndieAuth.com and allows an Indieauth.com to act as an authentication mechanism for WordPress and its REST API.
+It uses the URL from the profile page to identify the blog user or your author url.
 
 == Installation ==
 
@@ -20,27 +21,50 @@ The plugin lets you login to the WordPress backend via IndieAuth.com. It uses th
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. That's it
 
-For additional minor set up to be able to actually log in using IndieAuth.com, see [IndieAuth.com](https://indieauth.com/setup). Supported providers include: Twitter, Github, GNUPG, email among others.
+To be able to actually log in using IndieAuth.com, see [IndieAuth.com](https://indieauth.com/setup). Supported providers include: Twitter, Github, GNUPG, email among others.
 
 == Frequently Asked Questions ==
 
-Taken from [IndieAuth.com](https://indieauth.com)
-
 = What is IndieAuth? =
-IndieAuth is a way to use your own domain name to sign in to websites. IndieAuth.com works by linking your website to one or more authentication providers such as Twitter or Github, then entering your domain name in the login form on websites that support IndieAuth. You can link your website to these providers using 'rel-me', which is built into the [Indieweb plugin](https://wordpress.org/plugins/indieweb)
+[IndieAuth](https://indieauth.net) is a way for doing Web sign-in, where you use your own homepage to sign in to other places. 
+
+= What is IndieAuth.com? =
+
+[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol and available for public use.
 
 = Why IndieAuth? =
-IndieAuth is part of the [Indie Web movement](http://indieweb.org/why) to take back control of your online identity. Instead of logging in to websites as "you on Twitter" or "you on Facebook", you should be able to log in as just "you". We should not be relying on other sites to provide our authenticated identities, we should be able to use our own domain names to log in to sites everywhere.
 
-IndieAuth was built to make it as easy as possible for users and for developers to start using this new way of signing in on the web, without the .
+IndieAuth was built on ideas and technology from existing proven technologies like OAuth and OpenID but aims at making it easier for users as well as developers. It also decentralises 
+much of the process so completely separate implementations and services can be used for each part. 
+
+IndieAuth was developed as part of the [Indie Web movement](http://indieweb.org/why) to take back control of your online identity.
 
 = How is this different from OpenID? =
-The goals of OpenID and IndieAuth are similar. Both encourage you to sign in to a website using your own domain name. However, OpenID has failed to gain wide adoption, at least in part due to the complexities of the protocol. IndieAuth is a simpler implementation of a similar goal, and IndieAuth.com leverages other OAuth providers and behaviors that people are already accustomed to.
+The goals of OpenID and IndieAuth are similar. Both encourage you to sign in to a website using your own domain name. 
+However, OpenID has failed to gain wide adoption, at least in part due to the complexities of the protocol. 
+
+= How is this different from OAuth? =
+
+IndieAuth was built on top of the OAuth 2.0 Framework and is a simplified way of verifying the identity of an end user and obtaining an OAuth 2.0 Bearer token.
 
 = Does this require users to have their own domain name? =
-Yes, the assumption is that people are willing to [own their online identities](http://indiewebcamp.com/why) in the form of a domain name. It is getting easier and easier to host content on your own domain name. See "[Getting Started on the Indie Web](http://indieweb.org/Getting_Started)" for some suggestions, including mapping your domain to a Tumblr blog, or signing up for a simple web hosting service like Dreamhost.
+No. You can use your author profile URL to login if you do not have a domain name. However how the Indieauth server authenticates you depends on that server.
+
+= How do I authenticate myself to an Indieauth server? =
+
+That, as mentioned, depends on the server. By default, the plugin uses IndieAuth.com which works by linking your website to one or more authentication providers 
+such as Twitter or Github, then entering your domain name in the login form on websites that support IndieAuth. 
+
+You can link your website to these providers add ['rel-me'](https://indieweb.org/rel-me) links to your site, which can be done manually or by installing 
+the [Indieweb plugin](https://wordpress.org/plugins/indieweb)
+
 
 == Changelog ==
+
+= 1.2.0 =
+* Support author profiles in addition to user URLs
+* Change token verification method to match current Indieauth specification
+* Add support for token verification to act as a WordPress authentication mechanism.
 
 = 1.1.3 =
 * update README

--- a/templates/indieauth-general-settings.php
+++ b/templates/indieauth-general-settings.php
@@ -1,0 +1,21 @@
+<fieldset id="indieauth">
+	<label for="indieauth_show_login_form">
+		<input type="checkbox" name="indieauth_show_login_form" id="indieauth_show_login_form" value="1" <?php
+			echo checked( true, get_option( 'indieauth_show_login_form' ) );  ?> />
+		<?php _e( 'Add a option to the login form to login by domain.', 'indieauth' ) ?>
+	</label>
+	<BR />
+	<label for="indieauth_authorization_endpoint">
+		<input type="text" name="indieauth_authorization_endpoint" id="indieauth_authorization_endpoint" size="60" value="<?php
+			echo get_option( 'indieauth_authorization_endpoint' );  ?>" />
+		<br /><?php _e( 'IndieAuth Authorization Endpoint.', 'indieauth' ) ?>
+	</label>
+	<BR />
+	<label for="indieauth_token_endpoint">
+		<input type="text" name="indieauth_token_endpoint" id="indieauth_token_endpoint" size=60" value="<?php
+			echo get_option( 'indieauth_token_endpoint' );  ?>" />
+		<br /><?php _e( 'IndieAuth Token Endpoint.', 'indieauth' ) ?>
+	</label>
+
+	<br />
+</fieldset>

--- a/templates/indieauth-login-form.php
+++ b/templates/indieauth-login-form.php
@@ -1,0 +1,6 @@
+<p style="margin-bottom: 8px;">
+	<label for="indieauth_identifier"><?php  _e( 'Or login with your Domain', 'indieauth' ); ?> <br />
+	<input type="text" name="indieauth_identifier" placeholder="your-domain.com" id="indieauth_identifier" class="input indieauth_identifier" value="" /></label>
+	<a href="https://indieauth.net/" target="_blank"><?php _e( 'Learn about IndieAuth', 'indieauth' ); ?></a>
+</p>
+


### PR DESCRIPTION
I know it is easier to digest in chunk sized bits, but this is a major rewrite of the plugin, after which my intention is to go smaller for future enhancements. This...

1. Rewrites the README a bit
1. Adds support for login using Indieauth Bearer Tokens, which actually now makes this a supported authentication plugin for the WordPress REST API.
1. Adds using the author profile as your URL
1. Add settings to disable the login form addition and to use endpoints to something other than Indieauth.com
1. Supports setting Indieauth Scope as a global variable for future use as WordPress has no built in scope options
1. Updates functionality to the Indieauth specification at indieauth.net
1. Adds a state parameter being passed, even though it isn't used as required for compliance.

I drew some inspiration from how @snarfed set up IndieAuth logins in Micropub, as well as some proof of concept OAuth2 plugins for WordPress, and read through @aaronpk 's OAuth 2.0 book.

I don't think I'll stop here.