### PR TITLE
Add Token Endpoint and add Authorization Discovery

### DIFF
--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ *
+ *
+ * Implements IndieAuth Token Endpoint
+ */
+
+class IndieAuth_Token_Endpoint {
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+
+	}
+
+
+	/**
+	 * Extracts the token from the given authorization header.
+	 *
+	 * @param string $header Authorization header.
+	 *
+	 * @return string|null Token on success, null on failure.
+	 */
+	public function get_token_from_bearer_header( $header ) {
+		if ( is_string( $header ) && preg_match( '/Bearer ([\x20-\x7E]+)/', trim( $header ), $matches ) ) {
+				return $matches[1];
+		}
+			return null;
+	}
+
+	/**
+	 * Register the Route.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'indieauth/1.0', '/token', array(
+				array(
+					'methods'  => WP_REST_Server::CREATABLE,
+					'callback' => array( $this, 'post' ),
+					'args'     => array(
+						'grant_type'   => array(),
+						'code'         => array(),
+						'client_id'    => array(
+							'validate_callback' => array( $this, 'is_valid_url' ),
+							'sanitize_callback' => 'esc_url_raw',
+						),
+						'redirect_uri' => array(
+							'validate_callback' => array( $this, 'is_valid_url' ),
+							'sanitize_callback' => 'esc_url_raw',
+						),
+						'me'           => array(
+							'validate_callback' => array( $this, 'is_valid_url' ),
+							'sanitize_callback' => 'esc_url_raw',
+						),
+						'action'       => array(),
+						'token'        => array(),
+					),
+				),
+			)
+		);
+		register_rest_route(
+			'indieauth/1.0', '/token', array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'get' ),
+					'args'     => array(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Returns if valid URL for REST validation
+	 *
+	 * @param string $url
+	 *
+	 * @return boolean
+	 */
+	public static function is_valid_url( $url, $request = null, $key = null ) {
+		if ( ! is_string( $url ) || empty( $url ) ) {
+			return false;
+		}
+		return filter_var( $url, FILTER_VALIDATE_URL );
+	}
+
+	public function generate() {
+		return wp_generate_password( 128, false );
+	}
+
+	public function hash( $string ) {
+		return base64_encode( wp_hash( $string, 'secure_auth' ) );
+	}
+
+	public function get_token( $token, $hash = true ) {
+		$key = '_indieauth_token_';
+		// Either token is already hashed or is not
+		$key    .= $hash ? $this->hash( $token ) : $token;
+		$args    = array(
+			'number'      => 1,
+			'count_total' => false,
+			'meta_query'  => array(
+				array(
+					'key'     => $key,
+					'compare' => 'EXISTS',
+				),
+			),
+		);
+		$query   = new WP_User_Query( $args );
+		$results = $query->get_results();
+		if ( empty( $results ) ) {
+			return null;
+		}
+		$user  = $results[0];
+		$value = get_user_meta( $user->ID, $key, true );
+		if ( empty( $value ) ) {
+				return null;
+		}
+		$value['user'] = $user->ID;
+		return $value;
+	}
+
+	public function get( $request ) {
+		$params       = $request->get_params();
+		$access_token = $this->get_token_from_bearer_header( $request->get_header( 'Authorization' ) );
+		if ( ! $access_token ) {
+			return new WP_Error(
+				'invalid_request', __( 'Bearer Token Not Supplied', 'indieauth' ),
+				array(
+					'status' => '401',
+				)
+			);
+		}
+		$token = $this->get_token( $access_token );
+		if ( ! $token ) {
+			return new WP_Error(
+				'invalid_access_token', __( 'Invalid Token', 'indieauth' ),
+				array(
+					'status'   => '401',
+					'response' => $access_token,
+				)
+			);
+		}
+		return rest_ensure_response( $token );
+	}
+
+	public function set_token( $token ) {
+		// Token consists of properties at minimum: access_token, me, scope
+		if ( ! isset( $token['access_token'] ) || ! isset( $token['me'] ) ) {
+			return false;
+		}
+		$access_token = $this->hash( $token['access_token'] );
+		unset( $token['access_token'] );
+		$user = get_user_by_identifier( $token['me'] );
+		if ( ! $user ) {
+			return false;
+		}
+		return add_user_meta( $user->ID, '_indieauth_token_' . $access_token, $token );
+	}
+
+	public function delete_token( $id, $user_id = null ) {
+		if ( ! $user_id ) {
+			$token = $this->get_token( $id );
+			if ( ! isset( $token ) ) {
+				$token = $this->get_token( $id, false );
+			}
+			if ( isset( $token['user'] ) ) {
+				$user_id = $token['user'];
+			} else {
+				return false;
+			}
+		}
+		$id = $hash ? $this->hash( $id ) : $id;
+		return delete_user_meta( $user_id, '_indieauth_token_' . $id );
+	}
+
+	// Request or revoke a token
+	public function post( $request ) {
+		$params = $request->get_params();
+		// Revoke Token
+		if ( isset( $params['action'] ) && isset( $params['token'] ) && 'revoke' === $params['action'] ) {
+			$this->delete_token( $params['token'] );
+			return __( 'The Token Provided is No Longer Valid', 'indieauth' );
+		}
+		// Request Token
+		if ( isset( $params['grant_type'] ) && 'authorization_code' === $params['grant_type'] ) {
+			return $this->request( $params );
+		}
+		// Everything Failed
+		return new WP_Error(
+			'invalid_request', __( 'Invalid Request', 'indieauth' ),
+			array(
+				'status'   => '400',
+				'response' => $params,
+			)
+		);
+
+	}
+
+	// Request a Token
+	public function request( $params ) {
+		$diff = array_diff( array( 'code', 'client_id', 'redirect_uri', 'me' ), array_keys( $params ) );
+		if ( ! empty( $diff ) ) {
+			return new WP_Error(
+				'invalid_request', __( 'Invalid Request', 'indieauth' ),
+				array(
+					'status'   => '400',
+					'response' => $params,
+				)
+			);
+		}
+		$response = IndieAuth_Authenticate::verify_authorization_code( $params['code'], $params['redirect_uri'], $params['client_id'] );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$token  = array(
+			'access_token' => $this->generate(),
+			'token_type'   => 'Bearer',
+			'scope'        => $response['scope'],
+			'me'           => $response['me'],
+			'issued_by'    => rest_url( 'indieauth/1.0/token' ),
+			'client_id'    => $params['client_id'],
+			'issued_at'    => current_time( 'timestamp', 1 ),
+		);
+		$return = $this->set_token( $token );
+		if ( $token ) {
+			return( $token );
+		}
+		return new WP_Error( 'error', __( 'Set Token Error', 'indieauth' ) );
+	}
+}
+

--- a/includes/class-indieauth-token-ui.php
+++ b/includes/class-indieauth-token-ui.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Generates page for token UI.
+ *
+ * @package IndieAuth
+ */
+class IndieAuth_Token_UI {
+
+	/**
+	 * Function to Initialize the Configuration.
+	 *
+	 * @access public
+	 */
+	public function __construct() {
+		add_action( 'admin_init', array( $this, 'admin_init' ) );
+		add_action( 'admin_menu', array( $this, 'admin_menu' ), 11 );
+	}
+
+	/**
+	 * Function to Set up Settings.
+	 *
+	 * @access public
+	 */
+	public function admin_init() {
+	}
+
+	/**
+	 * Adds Options Page for Plugin Options.
+	 *
+	 * @access public
+	 */
+	public function admin_menu() {
+		add_users_page( __( 'Manage IndieAuth Tokens', 'indieauth' ), __( 'Manage Tokens', 'indieauth' ), 'read', 'indieauth_user_token', array( $this, 'options_form' ) );
+	}
+
+	/**
+	 * Callback for Options on Options Page.
+	 *
+	 * @access public
+	 */
+	public function options_callback() {
+	}
+
+
+	/**
+	 * Generate Options Form.
+	 *
+	 * @access public
+	 */
+	public function options_form() {
+		load_template( plugin_dir_path( __DIR__ ) . 'templates/indieauth-token-ui.php' );
+	}
+
+	/**
+	 * Is prefix in string.
+	 *
+	 * @param  string $source The source string.
+	 * @param  string $prefix The prefix you wish to check for in source.
+	 * @return boolean The result.
+	 */
+	public static function str_prefix( $source, $prefix ) {
+		return strncmp( $source, $prefix, strlen( $prefix ) ) === 0;
+	}
+
+	public static function token_form_table( $tokens ) {
+		if ( ! is_array( $tokens ) ) {
+			return;
+		}
+		echo '<div>';
+		foreach ( $tokens as $key => $value ) {
+			echo '<input type="radio" name="token" value="' . $key . '" />';
+			printf( __( 'Issued for %1$1s at %2$2s', 'indieauth' ), $value['client_id'], date_i18n( DATE_W3C, $value['issued_at'] ) );
+			echo '<br />';
+		}
+		echo '</div>';
+	}
+
+	public static function get_all_tokens( $user_id ) {
+		$meta   = get_user_meta( $user_id, '' );
+		$tokens = array();
+		foreach ( $meta as $key => $value ) {
+			if ( self::str_prefix( $key, '_indieauth_token_' ) ) {
+				$tokens[ str_replace( '_indieauth_token_', '', $key ) ] = maybe_unserialize( array_pop( $value ) );
+			}
+		}
+		return $tokens;
+	}
+
+	public static function delete_all_tokens( $user_id ) {
+		$meta   = get_user_meta( $user_id, '' );
+		$tokens = array();
+		foreach ( $meta as $key => $value ) {
+			if ( $this->str_prefix( $key, '_indieauth_token_' ) ) {
+				delete_user_meta( $user_id, $key );
+			}
+		}
+		return $tokens;
+	}
+
+} // End Class
+
+

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Allow localhost URLs if WP_DEBUG is true
+ *
+ * @param string       $url  The request URL.
+ * @param string|array $args Array or string of HTTP request arguments.
+ */
+function indieauth_allow_localhost( $r, $url ) {
+	$r['reject_unsafe_urls'] = false;
+
+	return $r;
+}
+add_filter( 'http_request_args', 'indieauth_allow_localhost', 10, 2 );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * Finds Indieauth server URIs based on the given URL
+ *
+ * Checks the HTML for the rel="authorization_endpoint", rel="token_endpoint" link or headers. It does
+ * a check for the headers first and returns that, if available
+ *
+ * @param string $me URL
+ *
+ * @return bool|array False on failure, array containing one or both or the headers on success
+ */
+function indieauth_discover_endpoint( $me ) {
+	/** @todo Should use Filter Extension or custom preg_match instead. */
+	$parsed_url = wp_parse_url( $me );
+	if ( ! isset( $parsed_url['host'] ) ) { // Not an URL. This should never happen.
+		return false;
+	}
+	// do not search for an Indieauth server on our own uploads
+	$uploads_dir = wp_upload_dir();
+	if ( 0 === strpos( $me, $uploads_dir['baseurl'] ) ) {
+		return false;
+	}
+	$wp_version = get_bloginfo( 'version' );
+	$user_agent = apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . get_bloginfo( 'url' ) );
+	$args       = array(
+		'timeout'             => 100,
+		'limit_response_size' => 1048576,
+		'redirection'         => 3,
+		'user-agent'          => "$user_agent; finding Indieauth endpoints",
+	);
+	$response   = wp_safe_remote_head( $me, $args );
+	if ( is_wp_error( $response ) ) {
+		return false;
+	}
+	$return = array();
+	$code   = (int) wp_remote_retrieve_response_code( $response );
+	switch ( $code ) {
+		case 301:
+		case 308:
+			$return['me'] = wp_remote_retrieve_header( $response, 'Location' );
+			break;
+	}
+	if ( isset( $return['me'] ) ) {
+		$me = $return['me'];
+	}
+	// check link header
+	$links = wp_remote_retrieve_header( $response, 'link' );
+	if ( $links ) {
+		if ( is_array( $links ) ) {
+			foreach ( $links as $link ) {
+				if ( preg_match( '/<(.[^>]+)>;\s+rel\s?=\s?[\"\']?authorization_endpoint[\"\']?/i', $link, $result ) ) {
+					$return['authorization_endpoint'] = WP_Http::make_absolute_url( $result[1], $me );
+				}
+				if ( preg_match( '/<(.[^>]+)>;\s+rel\s?=\s?[\"\']?token_endpoint[\"\']?/i', $link, $result ) ) {
+					$return['token_endpoint'] = WP_Http::make_absolute_url( $result[1], $me );
+				}
+			}
+		} else {
+			if ( preg_match( '/<(.[^>]+)>;\s+rel\s?=\s?[\"\']?authorization_endpoint[\"\']?/i', $links, $result ) ) {
+				$return['authorization_endpoint'] = WP_Http::make_absolute_url( $result[1], $me );
+			}
+			if ( preg_match( '/<(.[^>]+)>;\s+rel\s?=\s?[\"\']?token_endpoint[\"\']?/i', $links, $result ) ) {
+				$return['token_endpoint'] = WP_Http::make_absolute_url( $result[1], $me );
+			}
+		}
+		if ( isset( $return['token_endpoint'] ) && isset( $return['authorization_endpoint'] ) ) {
+			return array_filter( $return );
+		}
+	}
+	// not an (x)html, sgml, or xml page, no use going further
+	if ( preg_match( '#(image|audio|video|model)/#is', wp_remote_retrieve_header( $response, 'content-type' ) ) ) {
+		return false;
+	}
+	// now do a GET since we're going to look in the html headers (and we're sure its not a binary file)
+	$response = wp_safe_remote_get( $me, $args );
+	if ( is_wp_error( $response ) ) {
+		return false;
+	}
+	$contents = wp_remote_retrieve_body( $response );
+	// unicode to HTML entities
+	$contents = mb_convert_encoding( $contents, 'HTML-ENTITIES', mb_detect_encoding( $contents ) );
+	libxml_use_internal_errors( true );
+	$doc = new DOMDocument();
+	$doc->loadHTML( $contents );
+	$xpath = new DOMXPath( $doc );
+	// check <link> and <a> elements
+	// checks only body>a-links
+	foreach ( $xpath->query( '(//link|//a)[contains(concat(" ", @rel, " "), " authorization_endpoint ")]/@href' ) as $result ) {
+		$return['authorization_endpoint'] = WP_Http::make_absolute_url( $result->value, $me );
+	}
+	foreach ( $xpath->query( '(//link|//a)[contains(concat(" ", @rel, " "), " token_endpoint ")]/@href' ) as $result ) {
+		$return['token_endpoint'] = WP_Http::make_absolute_url( $result->value, $me );
+	}
+	if ( isset( $return['token_endpoint'] ) || isset( $return['authorization_endpoint'] ) ) {
+		return array_filter( $return );
+	}
+	return false;
+}
+
+/**
+ * Get the user associated with the specified Identifier-URI.
+ *
+ * @param string $$identifier identifier to match
+ * @return int|null ID of associated user, or null if no associated user
+ */
+function get_user_by_identifier( $identifier ) {
+	if ( empty( $identifier ) ) {
+		return null;
+	}
+	// try it without trailing slash
+	$no_slash   = untrailingslashit( $identifier );
+	$args       = array(
+		'search'         => $no_slash,
+		'search_columns' => array( 'user_url' ),
+	);
+	$user_query = new WP_User_Query( $args );
+		// check result
+	if ( ! empty( $user_query->results ) ) {
+			return $user_query->results[0];
+	}
+	// try it with trailing slash
+	$slash      = trailingslashit( $identifier );
+	$args       = array(
+		'search'         => $slash,
+		'search_columns' => array( 'user_url' ),
+	);
+	$user_query = new WP_User_Query( $args );
+	// check result
+	if ( ! empty( $user_query->results ) ) {
+		return $user_query->results[0];
+	}
+	// Check author page
+	global $wp_rewrite;
+	$link = $wp_rewrite->get_author_permastruct();
+	if ( empty( $link ) ) {
+		$login = str_replace( home_url( '/' ) . '?author=', '', $identifier );
+	} else {
+		$link  = str_replace( '%author%', '', $link );
+		$link  = home_url( user_trailingslashit( $link ) );
+		$login = str_replace( $link, '', $identifier );
+	}
+	if ( ! $login ) {
+		return null;
+	}
+	$args       = array(
+		'login' => $login,
+	);
+	$user_query = new WP_User_Query( $args );
+	if ( ! empty( $user_query->results ) ) {
+		return $user_query->results[0];
+	}
+	return null;
+}

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 1.2.0\n"
+"Project-Id-Version: IndieAuth 2.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
-"POT-Creation-Date: 2018-01-01 16:00:42+00:00\n"
+"POT-Creation-Date: 2018-01-22 04:34:40+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,36 +13,90 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 0.5.4\n"
 
-#: includes/class-indieauth-authenticate.php:51
-#: includes/class-indieauth-authenticate.php:120
+#: includes/class-indieauth-authenticate.php:63
+msgid "User Not Found on this Site"
+msgstr ""
+
+#: includes/class-indieauth-authenticate.php:86
+#: includes/class-indieauth-authenticate.php:175
 msgid "Supplied Token is Invalid"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:99
+#: includes/class-indieauth-authenticate.php:119
+msgid "<strong>ERROR</strong>: Could not discover endpoints"
+msgstr ""
+
+#: includes/class-indieauth-authenticate.php:164
+msgid "Your Authorization Endpoint Did Not Return a Correct Response"
+msgstr ""
+
+#: includes/class-indieauth-authenticate.php:199
 msgid "IndieAuth Server did not return the same state parameter"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:114
-msgid "IndieAuth.com seems to have some hiccups, please try it again later."
+#: includes/class-indieauth-authenticate.php:217
+msgid "Invalid User Profile URL"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:131
+#: includes/class-indieauth-authenticate.php:234
 msgid "Your have entered a valid Domain, but you have no account on this blog."
 msgstr ""
 
-#: indieauth.php:32
+#: includes/class-indieauth-token-endpoint.php:125
+msgid "Bearer Token Not Supplied"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:134
+msgid "Invalid Token"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:180
+msgid "The Token Provided is No Longer Valid"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:188
+#: includes/class-indieauth-token-endpoint.php:202
+msgid "Invalid Request"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:226
+msgid "Set Token Error"
+msgstr ""
+
+#: includes/class-indieauth-token-ui.php:33
+#: includes/class-indieauth-token-ui.php:54
+msgid "Manage IndieAuth Tokens"
+msgstr ""
+
+#: includes/class-indieauth-token-ui.php:33
+msgid "Manage Tokens"
+msgstr ""
+
+#: includes/class-indieauth-token-ui.php:52
+msgid "IndieAuth Tokens"
+msgstr ""
+
+#: includes/class-indieauth-token-ui.php:60
+msgid "Revoke"
+msgstr ""
+
+#: includes/class-indieauth-token-ui.php:82
+msgid "Issued for %1$1s at %2$2s"
+msgstr ""
+
+#: indieauth.php:47
 msgid "Offer IndieAuth on Login Form"
 msgstr ""
 
-#: indieauth.php:41
+#: indieauth.php:56
 msgid "IndieAuth Authorization Endpoint"
 msgstr ""
 
-#: indieauth.php:50
+#: indieauth.php:66
 msgid "IndieAuth Token Endpoint"
 msgstr ""
 
-#: indieauth.php:60
+#: indieauth.php:75
 msgid "IndieAuth Settings"
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -2,17 +2,17 @@
 **Contributors:** [indieweb](https://profiles.wordpress.org/indieweb), [pfefferle](https://profiles.wordpress.org/pfefferle), [dshanske](https://profiles.wordpress.org/dshanske)  
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.7  
-**Tested up to:** 4.9.1  
-**Stable tag:** 1.2.0  
+**Tested up to:** 4.9.2  
+**Stable tag:** 2.0.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** http://14101978.de  
 
-An IndieAuth plugin for WordPress. This allows you to login to your website using an IndieAuth server, defaultly IndieAuth.com.
+An IndieAuth plugin for WordPress. This allows you to login to your website using an IndieAuth server.
 
 ## Description ##
 
-The plugin lets you login to the WordPress backend via IndieAuth.com and allows an Indieauth.com to act as an authentication mechanism for WordPress and its REST API.
+The plugin lets you login to the WordPress backend via an Indieauth server and for it to act as an authentication mechanism for WordPress and its REST API.
 It uses the URL from the profile page to identify the blog user or your author url.
 
 ## Installation ##
@@ -21,12 +21,14 @@ It uses the URL from the profile page to identify the blog user or your author u
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. That's it
 
-To be able to actually log in using IndieAuth.com, see [IndieAuth.com](https://indieauth.com/setup). Supported providers include: Twitter, Github, GNUPG, email among others.
+If authorizing logins using the default, [IndieAuth.com](https://indieauth.com/setup), supported providers include: Twitter, Github, GNUPG, email among others.
 
 ## Frequently Asked Questions ##
 
 ### What is IndieAuth? ###
-[IndieAuth](https://indieauth.net) is a way for doing Web sign-in, where you use your own homepage to sign in to other places. 
+
+[IndieAuth](https://indieauth.net) is a way for doing Web sign-in, where you use your own homepage to sign in to other places. It is built on top of OAuth 2.0,
+which is used by many websites.
 
 ### What is IndieAuth.com? ###
 
@@ -40,14 +42,17 @@ much of the process so completely separate implementations and services can be u
 IndieAuth was developed as part of the [Indie Web movement](http://indieweb.org/why) to take back control of your online identity.
 
 ### How is this different from OpenID? ###
+
 The goals of OpenID and IndieAuth are similar. Both encourage you to sign in to a website using your own domain name. 
 However, OpenID has failed to gain wide adoption, at least in part due to the complexities of the protocol. 
 
 ### How is this different from OAuth? ###
 
-IndieAuth was built on top of the OAuth 2.0 Framework and is a simplified way of verifying the identity of an end user and obtaining an OAuth 2.0 Bearer token.
+IndieAuth was built on top of the OAuth 2.0 Framework and differs in that users and clients are represented by URLs.  Clients can verify the identity of 
+a user and obtain an OAuth 2.0 Bearer token that can be used to access user resources..
 
 ### Does this require users to have their own domain name? ###
+
 No. You can use your author profile URL to login if you do not have a domain name. However how the Indieauth server authenticates you depends on that server.
 
 ### How do I authenticate myself to an Indieauth server? ###
@@ -58,13 +63,21 @@ such as Twitter or Github, then entering your domain name in the login form on w
 You can link your website to these providers add ['rel-me'](https://indieweb.org/rel-me) links to your site, which can be done manually or by installing 
 the [Indieweb plugin](https://wordpress.org/plugins/indieweb)
 
+### What is this built in token endpoint thing? ###
+
+Once you have proven your identity to the authorization endpoint, the token endpoint issues a token, which applications can use to authenticate as you to your site.
+The plugin supports you using an external token endpoint if you want, but by having it built into your WordPress site, it is under your control.
+
 
 ## Changelog ##
 
-### 1.2.0 ###
+### 2.0.0 ###
 * Support author profiles in addition to user URLs
 * Change token verification method to match current Indieauth specification
 * Add support for token verification to act as a WordPress authentication mechanism.
+* Add ability to set any token or authorization endpoint
+* Add authorization and token endpoint headers to the site
+* Discover and use authorization endpoint for provided URL when logging in
 
 ### 1.1.3 ###
 * update README

--- a/readme.txt
+++ b/readme.txt
@@ -2,17 +2,17 @@
 Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.7
-Tested up to: 4.9.1
-Stable tag: 1.2.0
+Tested up to: 4.9.2
+Stable tag: 2.0.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: http://14101978.de
 
-An IndieAuth plugin for WordPress. This allows you to login to your website using an IndieAuth server, defaultly IndieAuth.com.
+An IndieAuth plugin for WordPress. This allows you to login to your website using an IndieAuth server.
 
 == Description ==
 
-The plugin lets you login to the WordPress backend via IndieAuth.com and allows an Indieauth.com to act as an authentication mechanism for WordPress and its REST API.
+The plugin lets you login to the WordPress backend via an Indieauth server and for it to act as an authentication mechanism for WordPress and its REST API.
 It uses the URL from the profile page to identify the blog user or your author url.
 
 == Installation ==
@@ -21,12 +21,14 @@ It uses the URL from the profile page to identify the blog user or your author u
 2. Activate the plugin through the 'Plugins' menu in WordPress
 3. That's it
 
-To be able to actually log in using IndieAuth.com, see [IndieAuth.com](https://indieauth.com/setup). Supported providers include: Twitter, Github, GNUPG, email among others.
+If authorizing logins using the default, [IndieAuth.com](https://indieauth.com/setup), supported providers include: Twitter, Github, GNUPG, email among others.
 
 == Frequently Asked Questions ==
 
 = What is IndieAuth? =
-[IndieAuth](https://indieauth.net) is a way for doing Web sign-in, where you use your own homepage to sign in to other places. 
+
+[IndieAuth](https://indieauth.net) is a way for doing Web sign-in, where you use your own homepage to sign in to other places. It is built on top of OAuth 2.0,
+which is used by many websites.
 
 = What is IndieAuth.com? =
 
@@ -40,14 +42,17 @@ much of the process so completely separate implementations and services can be u
 IndieAuth was developed as part of the [Indie Web movement](http://indieweb.org/why) to take back control of your online identity.
 
 = How is this different from OpenID? =
+
 The goals of OpenID and IndieAuth are similar. Both encourage you to sign in to a website using your own domain name. 
 However, OpenID has failed to gain wide adoption, at least in part due to the complexities of the protocol. 
 
 = How is this different from OAuth? =
 
-IndieAuth was built on top of the OAuth 2.0 Framework and is a simplified way of verifying the identity of an end user and obtaining an OAuth 2.0 Bearer token.
+IndieAuth was built on top of the OAuth 2.0 Framework and differs in that users and clients are represented by URLs.  Clients can verify the identity of 
+a user and obtain an OAuth 2.0 Bearer token that can be used to access user resources..
 
 = Does this require users to have their own domain name? =
+
 No. You can use your author profile URL to login if you do not have a domain name. However how the Indieauth server authenticates you depends on that server.
 
 = How do I authenticate myself to an Indieauth server? =
@@ -58,13 +63,21 @@ such as Twitter or Github, then entering your domain name in the login form on w
 You can link your website to these providers add ['rel-me'](https://indieweb.org/rel-me) links to your site, which can be done manually or by installing 
 the [Indieweb plugin](https://wordpress.org/plugins/indieweb)
 
+= What is this built in token endpoint thing? =
+
+Once you have proven your identity to the authorization endpoint, the token endpoint issues a token, which applications can use to authenticate as you to your site.
+The plugin supports you using an external token endpoint if you want, but by having it built into your WordPress site, it is under your control.
+
 
 == Changelog ==
 
-= 1.2.0 =
+= 2.0.0 =
 * Support author profiles in addition to user URLs
 * Change token verification method to match current Indieauth specification
 * Add support for token verification to act as a WordPress authentication mechanism.
+* Add ability to set any token or authorization endpoint
+* Add authorization and token endpoint headers to the site
+* Discover and use authorization endpoint for provided URL when logging in
 
 = 1.1.3 =
 * update README

--- a/templates/indieauth-token-ui.php
+++ b/templates/indieauth-token-ui.php
@@ -1,0 +1,11 @@
+<div class="wrap">
+<h2><?php esc_html_e( 'IndieAuth Tokens', 'indieauth' ); ?></h2>
+<hr />
+<?php $tokens = IndieAuth_Token_UI::get_all_tokens( get_current_user_id() ); ?>
+
+<form method="post" action="<?php rest_url( 'indieauth/1.0/token' ); ?>">
+   <?php IndieAuth_Token_UI::token_form_table( $tokens ); ?>
+<input type="hidden" name="action" value="revoke" />
+   <?php submit_button( __( 'Revoke', 'indieauth' ) ); ?>
+</form></div>
+

--- a/tests/test-authenticate.php
+++ b/tests/test-authenticate.php
@@ -22,12 +22,6 @@ class AuthenticateTest extends WP_UnitTestCase {
 		return compact( 'headers', 'response', 'body' );
 	}
 
-	public function test_verify_state() {
-		$authenticate = new IndieAuth_Authenticate();
-		$state        = wp_create_nonce( 'indieauth-' . home_url() );
-		$this->assertTrue( 1 === $authenticate->verify_state( $state ) );
-	}
-
 	public function verification_token() {
 		return array(
 			'me'        => 'http://example.com/',

--- a/tests/test-discovery.php
+++ b/tests/test-discovery.php
@@ -1,0 +1,187 @@
+<?php
+class DiscoveryTest extends WP_UnitTestCase {
+
+	public function headers( $link ) {
+		$headers = array(
+			'server' => 'nginx/1.9.15',
+			'date' => 'Mon, 16 May 2016 01:21:08 GMT',
+			'content-type' => 'text/html; charset=UTF-8',
+			'link' => $link,
+		);
+		return $headers;
+	}
+
+	public function response( $code, $response ) {
+		$response = array(
+			'code' => $code,
+			'response' => $response,
+		);
+		return $response;
+	}
+
+	public function httpreturn( $headers, $response, $body ) {
+		return compact( 'headers', 'response', 'body' );
+	}
+
+	public function discover_relative_httplink() {
+		$link = array( 
+			'</test/1/authorization_endpoint>; rel=authorization_endpoint',
+			'</test/1/token_endpoint>; rel=token_endpoint',
+
+		);
+		$headers = $this->headers( $link );
+		$response = $this->response( 200, 'OK' );
+		$body = '<html></html>';
+		return $this->httpreturn( $headers, $response, $body );
+	}
+
+	public function test_discover_relative_httplink() {
+		$url = 'http://www.example.com/test/1';
+		$return = array( 
+			'authorization_endpoint' => 'http://www.example.com/test/1/authorization_endpoint',
+			'token_endpoint' => 'http://www.example.com/test/1/token_endpoint'
+		);
+
+		add_filter( 'pre_http_request', array( $this, 'discover_relative_httplink' ) );
+		$endpoint = indieauth_discover_endpoint( $url );
+		$this->assertSame( $return, $endpoint );
+	}
+
+	public function discover_absolute_httplink() {
+		$link = array( 
+			'<http://www.example.com/test/2/authorization_endpoint>; rel=authorization_endpoint',
+			'<http://www.example.com/test/2/token_endpoint>; rel=token_endpoint',
+
+		);
+		$headers = $this->headers( $link );
+		$response = $this->response( 200, 'OK' );
+		$body = '<html></html>';
+		return $this->httpreturn( $headers, $response, $body );
+	}
+
+	public function test_discover_absolute_httplink() {
+		$url = 'http://www.example.com/test/2';
+		$return = array( 
+			'authorization_endpoint' => 'http://www.example.com/test/2/authorization_endpoint',
+			'token_endpoint' => 'http://www.example.com/test/2/token_endpoint'
+		);
+		add_filter( 'pre_http_request', array( $this, 'discover_absolute_httplink' ) );
+		$endpoint = indieauth_discover_endpoint( $url );
+		$this->assertSame( $return, $endpoint );
+	}
+
+
+	public function discover_quoted_httplink() {
+		$link = array( 
+			'<http://www.example.com/test/8/authorization_endpoint>; rel="authorization_endpoint"',
+			'<http://www.example.com/test/8/token_endpoint>; rel="token_endpoint"',
+
+		);
+		$headers = $this->headers( $link );
+		$response = $this->response( 200, 'OK' );
+		$body = '<html></html>';
+		return $this->httpreturn( $headers, $response, $body );
+	}
+
+	public function test_discover_quoted_httplink() {
+		$url = 'http://www.example.com/test/2';
+		$return = array( 
+			'authorization_endpoint' => 'http://www.example.com/test/8/authorization_endpoint',
+			'token_endpoint' => 'http://www.example.com/test/8/token_endpoint'
+		);
+		add_filter( 'pre_http_request', array( $this, 'discover_quoted_httplink' ) );
+		$endpoint = indieauth_discover_endpoint( $url );
+		$this->assertSame( $return, $endpoint );
+	}
+
+	public function discover_multiple_httplink() {
+		$link = array( 
+			'<http://www.example.com/test/10/authorization_endpoint>; rel="authorization_endpoint somethingelse"',
+			'<http://www.example.com/test/10/token_endpoint>; rel="token_endpoint somethingelse"',
+
+		);
+		$headers = $this->headers( $link );
+		$response = $this->response( 200, 'OK' );
+		$body = '<html></html>';
+		return $this->httpreturn( $headers, $response, $body );
+	}
+
+	public function test_discover_multiple_httplink() {
+		$url = 'http://www.example.com/test/10';
+		$return = array( 
+			'authorization_endpoint' => 'http://www.example.com/test/10/authorization_endpoint',
+			'token_endpoint' => 'http://www.example.com/test/10/token_endpoint'
+		);
+		add_filter( 'pre_http_request', array( $this, 'discover_multiple_httplink' ) );
+		$endpoint = indieauth_discover_endpoint( $url );
+		$this->assertSame( $return, $endpoint );
+	}
+
+	public function discover_relative_htmllink() {
+		$headers = $this->headers( array() );
+		$response = $this->response( 200, 'OK' );
+
+		$body = '<!DOCTYPE html><html lang="en"><head><link rel="authorization_endpoint" href="/test/3/authorization_endpoint">';
+		$body .= '<link rel="token_endpoint" href="/test/3/token_endpoint"></head><body>This is a test</body></html>';
+		return $this->httpreturn( $headers, $response, $body );
+	}
+
+	public function test_discover_relative_htmllink() {
+		$url = 'http://www.example.com/test/3';
+		$return = array( 
+			'authorization_endpoint' => 'http://www.example.com/test/3/authorization_endpoint',
+			'token_endpoint' => 'http://www.example.com/test/3/token_endpoint'
+		);
+		add_filter( 'pre_http_request', array( $this, 'discover_relative_htmllink' ) );
+		$endpoint = indieauth_discover_endpoint( $url );
+		$this->assertSame( $return, $endpoint );
+	}
+
+	public function discover_absolute_htmllink() {
+		$headers = $this->headers( array() );
+		$response = $this->response( 200, 'OK' );
+		$body = '<!DOCTYPE html><html lang="en"><head><link rel="authorization_endpoint" href="http://www.example.com/test/4/authorization_endpoint">';
+		$body .= '<link rel="token_endpoint" href="http://www.example.com/test/4/token_endpoint"></head><body>This is a test</body></html>';
+		return $this->httpreturn( $headers, $response, $body );
+	}
+
+	public function test_discover_absolute_htmllink() {
+		$url = 'http://www.example.com/test/4';
+		$return = array( 
+			'authorization_endpoint' => 'http://www.example.com/test/4/authorization_endpoint',
+			'token_endpoint' => 'http://www.example.com/test/4/token_endpoint'
+		);
+		add_filter( 'pre_http_request', array( $this, 'discover_absolute_htmllink' ) );
+		$endpoint = indieauth_discover_endpoint( $url );
+		$this->assertSame( $return, $endpoint );
+	}
+
+	public function discover_redirect() {
+		$link = array( 
+			'<https://www.example.com/test/2/authorization_endpoint>; rel=authorization_endpoint',
+			'<https://www.example.com/test/2/token_endpoint>; rel=token_endpoint',
+
+		);
+		$headers = $this->headers( $link );
+		$headers['Location'] = 'https://www.example.com/test/2';
+		$response = $this->response( 301, 'Permanent Redirect' );
+		$body = '<html></html>';
+		return $this->httpreturn( $headers, $response, $body );
+	}
+
+	public function test_discover_redirect() {
+		$url = 'http://www.example.com/test/2';
+		$return = array( 
+			'me' => 'https://www.example.com/test/2',
+			'authorization_endpoint' => 'https://www.example.com/test/2/authorization_endpoint',
+			'token_endpoint' => 'https://www.example.com/test/2/token_endpoint'
+		);
+		add_filter( 'pre_http_request', array( $this, 'discover_redirect' ) );
+		$endpoint = indieauth_discover_endpoint( $url );
+		$this->assertSame( $return, $endpoint );
+	}
+
+
+
+
+}


### PR DESCRIPTION
This adds the discovery stuff from previous with the token endpoint items for today. It makes a bunch of changes recommended by @aaronpk as well.

Will likely hide the option to use an external token endpoint in a future version, as it seems that most people would want the built-in.