### PR TITLE
Endpoint Fixes

### DIFF
--- a/includes/class-indieauth-authenticate.php
+++ b/includes/class-indieauth-authenticate.php
@@ -77,6 +77,9 @@ class IndieAuth_Authenticate {
 				if ( is_wp_error( $return ) ) {
 					return $return;
 				}
+				if ( is_oauth_error( $return ) ) {
+					return $return->to_wp_error();
+				}
 			}
 		}
 				exit;
@@ -121,6 +124,9 @@ class IndieAuth_Authenticate {
 		$response = wp_safe_remote_get( get_option( 'indieauth_token_endpoint', rest_url( 'indieauth/1.0/token' ) ), $args );
 		if ( is_wp_error( $response ) ) {
 			return $response;
+		}
+		if ( is_oauth_error( $response ) ) {
+			return $response->to_wp_error();
 		}
 		$code = wp_remote_retrieve_response_code( $response );
 		$body = wp_remote_retrieve_body( $response );
@@ -202,7 +208,7 @@ class IndieAuth_Authenticate {
 		);
 		$response = wp_remote_post( get_option( 'indieauth_authorization_endpoint' ), $args );
 		$error    = get_oauth_error( $response );
-		if ( $error ) {
+		if ( is_oauth_error( $error ) ) {
 			// Pass through well-formed error messages from the authorization endpoint
 			return $error;
 		}
@@ -341,6 +347,9 @@ class IndieAuth_Authenticate {
 			$response = $this->verify_authorization_code( $_REQUEST['code'], wp_login_url( $redirect_to ) );
 			if ( is_wp_error( $response ) ) {
 				return $response;
+			}
+			if ( is_oauth_error( $response ) ) {
+				return $response->to_wp_error();
 			}
 			$user = get_user_by_identifier( $response['me'] );
 			if ( ! $user ) {

--- a/includes/class-indieauth-authenticate.php
+++ b/includes/class-indieauth-authenticate.php
@@ -114,10 +114,8 @@ class IndieAuth_Authenticate {
 
 	}
 
-	public function verify_access_token( $token, $endpoint = null ) {
-		if ( ! $endpoint ) {
-			$endpoint = get_option( 'indieauth_token_endpoint', rest_url( 'indieauth/1.0/token' ) );
-		}
+	public function verify_access_token( $token ) {
+		$endpoint = get_option( 'indieauth_token_endpoint', rest_url( 'indieauth/1.0/token' ) );
 		$args     = array(
 			'headers' => array(
 				'Accept'        => 'application/json',
@@ -192,10 +190,7 @@ class IndieAuth_Authenticate {
 	}
 
 	// $args must consist of redirect_uri, client_id, and code
-	public static function verify_authorization_code( $post_args, $endpoint = null ) {
-		if ( ! $endpoint ) {
-			$endpoint = get_option( 'indieauth_authorization_endpoint' );
-		}
+	public static function verify_authorization_code( $post_args, $endpoint ) {
 		$defaults = array(
 			'client_id' => home_url(),
 		);

--- a/includes/class-indieauth-authenticate.php
+++ b/includes/class-indieauth-authenticate.php
@@ -173,6 +173,7 @@ class IndieAuth_Authenticate {
 		$authorization_endpoint = null;
 		if ( isset( $endpoints['authorization_endpoint'] ) ) {
 			$authorization_endpoint = $endpoints['authorization_endpoint'];
+			setcookie( 'indieauth_authorization_endpoint', $authorization_endpoint, current_time( 'timestamp' ) + 120, '/', false, true );
 		}
 		$state = $this->generate_state();
 		$query = add_query_arg(
@@ -348,7 +349,8 @@ class IndieAuth_Authenticate {
 				array(
 					'code'         => $_REQUEST['code'],
 					'redirect_uri' => wp_login_url( $redirect_to ),
-				)
+				),
+				$_COOKIE['indieauth_authorization_endpoint']
 			);
 			if ( is_wp_error( $response ) ) {
 				return $response;

--- a/includes/class-indieauth-authenticate.php
+++ b/includes/class-indieauth-authenticate.php
@@ -122,11 +122,8 @@ class IndieAuth_Authenticate {
 			),
 		);
 		$response = wp_safe_remote_get( get_option( 'indieauth_token_endpoint', rest_url( 'indieauth/1.0/token' ) ), $args );
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
 		if ( is_oauth_error( $response ) ) {
-			return $response->to_wp_error();
+			return $response;
 		}
 		$code = wp_remote_retrieve_response_code( $response );
 		$body = wp_remote_retrieve_body( $response );
@@ -263,6 +260,9 @@ class IndieAuth_Authenticate {
 		if ( empty( $url ) || empty( $password ) ) {
 			if ( is_wp_error( $user ) ) {
 				return $user;
+			}
+			if ( is_oauth_error( $user ) ) {
+				return $user->to_wp_error();
 			}
 			$error = new WP_Error();
 

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -123,10 +123,10 @@ class IndieAuth_Authorization_Endpoint {
 		$params = wp_array_slice_assoc( $request->get_params(), array( 'client_id', 'redirect_uri' ) );
 		$code   = $request->get_param( 'code' );
 		$token  = $this->get_code( $code );
-		if ( !$token ) {
+		if ( ! $token ) {
 			return new WP_OAuth_Response( 'invalid_grant', __( 'Invalid authorization code', 'indieauth' ), 400 );
 		}
-		$user   = get_user_by( 'id', $token['user'] );
+		$user = get_user_by( 'id', $token['user'] );
 		if ( $token['expiration'] <= time() ) {
 			$this->delete_code( $code, $token['user'] );
 			return new WP_OAuth_Response( 'invalid_grant', __( 'The authorization code expired', 'indieauth' ), 400 );

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -136,8 +136,17 @@ class IndieAuth_Token_Endpoint {
 		if ( ! empty( $diff ) ) {
 			return new WP_OAuth_Response( 'invalid_request', __( 'The request is missing one or more required parameters', 'indieauth' ), 400 );
 		}
-		$response = IndieAuth_Authenticate::verify_authorization_code( $params['code'], $params['redirect_uri'], $params['client_id'] );
-		if ( $error = get_oauth_error( $response ) ) {
+		$endpoint = indieauth_discover_endpoint( $params['me'] );
+		$endpoint = isset( $endpoint['authorization_endpoint'] ) ? $endpoint['authorization_endpoint'] : null;
+		$response = IndieAuth_Authenticate::verify_authorization_code(
+			array(
+				'code'         => $params['code'],
+				'redirect_url' => $params['redirect_uri'],
+				'client_id'    => $params['client_id'],
+			), $endpoint
+		);
+		$error    = get_oauth_error( $response );
+		if ( $error ) {
 			return $error;
 		}
 		// Do not issue a token if the authorization code contains no scope

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -154,7 +154,7 @@ class IndieAuth_Token_Endpoint {
 			$return = $this->set_token( $token );
 			if ( $token ) {
 				// Return only the standard keys in the response
-				return( wp_array_slice_assoc($token, array( 'access_token', 'token_type', 'scope', 'me' ) ) );
+				return( wp_array_slice_assoc( $token, array( 'access_token', 'token_type', 'scope', 'me' ) ) );
 			}
 		} else {
 			return new WP_OAuth_Response( 'invalid_grant', __( 'This authorization code was issued with no scope, so it cannot be used to obtain an access token', 'indieauth' ), 400 );

--- a/includes/class-oauth-response.php
+++ b/includes/class-oauth-response.php
@@ -17,6 +17,12 @@ class WP_OAuth_Response extends WP_REST_Response {
 		$this->set_data( array_merge( $data, $array ) );
 	}
 
+	public function to_wp_error() {
+		$data   = $this->get_data();
+		$status = $this->get_status();
+		return new WP_Error( $data['error'], $data['error_description'], array( 'status' => $status ) );
+	}
+
 }
 
 function get_oauth_error( $obj ) {
@@ -39,4 +45,8 @@ function get_oauth_error( $obj ) {
 		}
 	}
 	return false;
+}
+
+function is_oauth_error( $obj ) {
+	return ( $obj instanceof WP_OAuth_Response );
 }

--- a/indieauth.php
+++ b/indieauth.php
@@ -91,7 +91,7 @@ class IndieAuth_Plugin {
 		 * render the login form
 		 */
 	public static function login_form() {
-		$template = plugin_dir_path( __FILE__ ) . 'templates/indieauth-login-form.php';
+		$template = plugin_dir_path( __FILE__ ) . 'templates/indieauth-domain-login.php';
 		if ( 1 === (int) get_option( 'indieauth_show_login_form' ) ) {
 				load_template( $template );
 		}

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IndieAuth 2.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
-"POT-Creation-Date: 2018-04-05 18:39:38+00:00\n"
+"POT-Creation-Date: 2018-04-06 23:35:07+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,66 +13,67 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 0.5.4\n"
 
-#: includes/class-indieauth-authenticate.php:49
-#: includes/class-indieauth-authenticate.php:55
+#: includes/class-indieauth-authenticate.php:51
+#: includes/class-indieauth-authenticate.php:57
 msgid "Username, Email Address, or URL"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:78
+#: includes/class-indieauth-authenticate.php:74
+#: includes/class-indieauth-authenticate.php:336
+msgid "Invalid User Profile URL"
+msgstr ""
+
+#: includes/class-indieauth-authenticate.php:107
 msgid "User Not Found on this Site"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:104
+#: includes/class-indieauth-authenticate.php:136
 msgid "Supplied Token is Invalid"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:137
+#: includes/class-indieauth-authenticate.php:169
 msgid "<strong>ERROR</strong>: Could not discover endpoints"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:188
+#: includes/class-indieauth-authenticate.php:221
 msgid "The authorization endpoint did not return a JSON response"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:198
+#: includes/class-indieauth-authenticate.php:231
 msgid ""
 "There was an error verifying the authorization code, the authorization "
 "server return an expected response"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:219
+#: includes/class-indieauth-authenticate.php:252
 msgid "IndieAuth Server did not return the same state parameter"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:237
+#: includes/class-indieauth-authenticate.php:270
 msgid "<strong>ERROR</strong>: The URL field is empty."
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:241
+#: includes/class-indieauth-authenticate.php:274
 msgid "<strong>ERROR</strong>: The password field is empty."
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:255
+#: includes/class-indieauth-authenticate.php:288
 msgid "<strong>ERROR</strong>: Invalid URL."
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:257
-#: includes/class-indieauth-authenticate.php:278
+#: includes/class-indieauth-authenticate.php:290
+#: includes/class-indieauth-authenticate.php:311
 msgid "Lost your password?"
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:274
+#: includes/class-indieauth-authenticate.php:307
 #. translators: %s: url
 msgid ""
 "<strong>ERROR</strong>: The password you entered for the URL %s is "
 "incorrect."
 msgstr ""
 
-#: includes/class-indieauth-authenticate.php:303
-msgid "Invalid User Profile URL"
-msgstr ""
-
-#: includes/class-indieauth-authenticate.php:320
+#: includes/class-indieauth-authenticate.php:356
 msgid "Your have entered a valid Domain, but you have no account on this blog."
 msgstr ""
 
@@ -144,11 +145,11 @@ msgstr ""
 msgid "Offer IndieAuth on Login Form"
 msgstr ""
 
-#: indieauth.php:68
+#: indieauth.php:68 templates/indieauth-general-settings.php:13
 msgid "IndieAuth Authorization Endpoint"
 msgstr ""
 
-#: indieauth.php:78
+#: indieauth.php:78 templates/indieauth-general-settings.php:30
 msgid "IndieAuth Token Endpoint"
 msgstr ""
 
@@ -157,7 +158,7 @@ msgid "IndieAuth Settings"
 msgstr ""
 
 #: templates/indieauth-authenticate-form.php:4
-#: templates/indieauth-authenticate-form.php:30
+#: templates/indieauth-authenticate-form.php:31
 msgid "Authenticate"
 msgstr ""
 
@@ -167,12 +168,12 @@ msgid ""
 "<strong>%2$s</strong>."
 msgstr ""
 
-#: templates/indieauth-authenticate-form.php:31
+#: templates/indieauth-authenticate-form.php:32
 #: templates/indieauth-authorize-form.php:46
 msgid "Cancel"
 msgstr ""
 
-#: templates/indieauth-authenticate-form.php:34
+#: templates/indieauth-authenticate-form.php:35
 msgid "You will be redirected to <code>%1$s</code> after authenticating."
 msgstr ""
 
@@ -199,25 +200,49 @@ msgid ""
 "application."
 msgstr ""
 
+#: templates/indieauth-domain-login.php:4
+msgid "Sign in with your Domain"
+msgstr ""
+
 #: templates/indieauth-general-settings.php:5
-msgid ""
-"Add a checkbox to the login form to authenticate using an IndieAuth "
-"endpoint."
+msgid "Add a link to the login form to authenticate using an IndieAuth endpoint."
 msgstr ""
 
-#: templates/indieauth-general-settings.php:14
-msgid "IndieAuth Authorization Endpoint."
+#: templates/indieauth-general-settings.php:15
+#: templates/indieauth-general-settings.php:32
+msgid "Custom"
 msgstr ""
 
-#: templates/indieauth-general-settings.php:23
-msgid "IndieAuth Token Endpoint."
+#: templates/indieauth-general-settings.php:18
+msgid "Built in Authorization Endpoint"
+msgstr ""
+
+#: templates/indieauth-general-settings.php:20
+#: templates/indieauth-general-settings.php:37
+msgid "Indieauth.com"
+msgstr ""
+
+#: templates/indieauth-general-settings.php:35
+msgid "Built in token Endpoint"
 msgstr ""
 
 #: templates/indieauth-login-form.php:4
-msgid "Login with your Domain"
+msgid "Sign in with your website"
 msgstr ""
 
-#: templates/indieauth-login-form.php:5
+#: templates/indieauth-login-form.php:11
+msgid "Sign in with your domain"
+msgstr ""
+
+#: templates/indieauth-login-form.php:13
+msgid "https://example.com"
+msgstr ""
+
+#: templates/indieauth-login-form.php:22
+msgid "Sign in"
+msgstr ""
+
+#: templates/indieauth-login-form.php:25
 msgid "Learn about IndieAuth"
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,8 @@ You can revoke tokens under User->Manage Tokens.
 * Allow login using URL
 * Add built-in token endpoint ( props to @aaronpk for support on this )
 * Add built-in authorization endpoint ( props to @aaronpk for support on this )
+* Hide option to login with your domain by default
+* Option to sign into your domain is now a separate form
 
 ### 1.1.3 ###
 * update README

--- a/readme.txt
+++ b/readme.txt
@@ -88,6 +88,8 @@ You can revoke tokens under User->Manage Tokens.
 * Allow login using URL
 * Add built-in token endpoint ( props to @aaronpk for support on this )
 * Add built-in authorization endpoint ( props to @aaronpk for support on this )
+* Hide option to login with your domain by default
+* Option to sign into your domain is now a separate form
 
 = 1.1.3 =
 * update README

--- a/templates/indieauth-auth-footer.php
+++ b/templates/indieauth-auth-footer.php
@@ -6,7 +6,7 @@
         border-radius: 6px;
 }
 .login-info p {
-        margin-top: 1em;
+	margin-top: 1em;
 }
 .scope-info ul {
         margin-top: 1em;
@@ -15,6 +15,11 @@
 .redirect-info {
         margin-top: 1em;
 }
+
+form input {
+	width: 100%;
+}
+
 </style>
 <?php
 login_footer();

--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -19,16 +19,17 @@ login_header(
 </div>
 <br />
 <p class="submit">
-<?php // Hook to allow adding to form
+<?php
+// Hook to allow adding to form
 	add_action( 'indieauth_authentication_form', $current_user->user_id, $class_id );
 ?>
 	<input type="hidden" name="client_id" value="<?php echo $client_id; ?>" />
-        <input type="hidden" name="redirect_uri" value="<?php echo $redirect_uri; ?>" />
-        <input type="hidden" name="state" value="<?php echo $state; ?>" />
-        <input type="hidden" name="me" value="<?php echo $me; ?>" />
-        <input type="hidden" name="response_type" value="<?php echo $response_type; ?>" />
-                <button name="wp-submit" value="authorize" class="button button-primary button-large"><?php _e( 'Authenticate', 'indieauth' ); ?></button>
-                <a name="wp-submit" value="cancel" class="button button-large" href="<?php echo home_url(); ?>"><?php _e( 'Cancel', 'indieauth' ); ?></a>
+		<input type="hidden" name="redirect_uri" value="<?php echo $redirect_uri; ?>" />
+		<input type="hidden" name="state" value="<?php echo $state; ?>" />
+		<input type="hidden" name="me" value="<?php echo $me; ?>" />
+		<input type="hidden" name="response_type" value="<?php echo $response_type; ?>" />
+				<button name="wp-submit" value="authorize" class="button button-primary button-large"><?php _e( 'Authenticate', 'indieauth' ); ?></button>
+				<a name="wp-submit" value="cancel" class="button button-large" href="<?php echo home_url(); ?>"><?php _e( 'Cancel', 'indieauth' ); ?></a>
 </p>
 </form>
 <p class="redirect-info"><?php printf( __( 'You will be redirected to <code>%1$s</code> after authenticating.', 'indieauth' ), $redirect_uri ); ?></p>

--- a/templates/indieauth-domain-login.php
+++ b/templates/indieauth-domain-login.php
@@ -1,0 +1,7 @@
+<p style="margin-bottom: 8px;">
+	<label for="indieauth_identifier">
+	<a href="<?php echo add_query_arg( 'action', 'indielogin', wp_login_url() ); ?>">
+	<?php _e( 'Sign in with your Domain', 'indieauth' ); ?></a>
+	<br />
+</p>
+

--- a/templates/indieauth-general-settings.php
+++ b/templates/indieauth-general-settings.php
@@ -2,22 +2,39 @@
 	<label for="indieauth_show_login_form">
 		<input type="checkbox" name="indieauth_show_login_form" id="indieauth_show_login_form" value="1" <?php
 			echo checked( true, get_option( 'indieauth_show_login_form' ) );  ?> />
-		<?php _e( 'Add a checkbox to the login form to authenticate using an IndieAuth endpoint.', 'indieauth' ); ?>
+		<?php _e( 'Add a link to the login form to authenticate using an IndieAuth endpoint.', 'indieauth' ); ?>
 	</label>
 	<BR />
+<?php
+$authorization = get_option( 'indieauth_authorization_endpoint' );
+$other         = ( rest_url( 'indieauth/1.0/auth' ) !== $authorization && 'https://indieauth.com/auth' !== $authorization );
+?>
 	<label for="indieauth_authorization_endpoint">
-		<input type="text" name="indieauth_authorization_endpoint" id="indieauth_authorization_endpoint" size="60" value="<?php
-			echo get_option( 'indieauth_authorization_endpoint' );
-			?>" />
-		<br /><?php _e( 'IndieAuth Authorization Endpoint.', 'indieauth' ); ?>
+	<br /><?php _e( 'IndieAuth Authorization Endpoint', 'indieauth' ); ?>
+	<br />
+		<input type="radio" name="indieauth_authorization_endpoint" id="indieauth_authorization_endpoint" value="" <?php checked( $other ); ?> /><?php _e( 'Custom', 'indieauth' ); ?>
+		<input type="text" name="indieauth_authorization_endpoint" id="indieauth_authorization_endpoint" size="60" value="<?php echo $other ? $authorization : ''; ?>" />
+	<br />
+	<input type="radio" name="indieauth_authorization_endpoint" id="indieauth_authorization_endpoint" value="<?php echo rest_url( '/indieauth/1.0/auth' ); ?>" <?php checked( $authorization, rest_url( '/indieauth/1.0/auth' ) ); ?> /> <?php _e( 'Built in Authorization Endpoint', 'indieauth' ); ?>
+	<br />
+	<input type="radio" name="indieauth_authorization_endpoint" id="indieauth_authorization_endpoint" value="https://indieauth.com/auth" <?php checked( $authorization, 'https://indieauth.com/auth' ); ?> /> <?php _e( 'Indieauth.com', 'indieauth' ); ?>
+	<br />
+
 	</label>
 	<BR />
+<?php
+$token = get_option( 'indieauth_token_endpoint' );
+$other = ( rest_url( 'indieauth/1.0/token' ) !== $token && 'https://tokens.indieauth.com/token' !== $authorization );
+?>
 	<label for="indieauth_token_endpoint">
-		<input type="text" name="indieauth_token_endpoint" id="indieauth_token_endpoint" size=60" value="<?php
-			echo get_option( 'indieauth_token_endpoint' );
-			?>" />
-		<br /><?php _e( 'IndieAuth Token Endpoint.', 'indieauth' ); ?>
-	</label>
-
+	<br /><?php _e( 'IndieAuth Token Endpoint', 'indieauth' ); ?>
 	<br />
+		<input type="radio" name="indieauth_token_endpoint" id="indieauth_token_endpoint" value="" <?php checked( $other ); ?> /><?php _e( 'Custom', 'indieauth' ); ?>
+		<input type="text" name="indieauth_token_endpoint" id="indieauth_token_endpoint" size="60" value="<?php echo $other ? $token : ''; ?>" />
+	<br />
+	<input type="radio" name="indieauth_token_endpoint" id="indieauth_token_endpoint" value="<?php echo rest_url( '/indieauth/1.0/token' ); ?>" <?php checked( $token, rest_url( '/indieauth/1.0/token' ) ); ?> /> <?php _e( 'Built in token Endpoint', 'indieauth' ); ?>
+	<br />
+	<input type="radio" name="indieauth_token_endpoint" id="indieauth_token_endpoint" value="https://tokens.indieauth.com/token" <?php checked( $token, 'https://tokens.indieauth.com/token' ); ?> /> <?php _e( 'Indieauth.com', 'indieauth' ); ?>
+	</label>
+	<BR />
 </fieldset>

--- a/templates/indieauth-login-form.php
+++ b/templates/indieauth-login-form.php
@@ -15,8 +15,8 @@ login_header(
 </div>
 <p class="submit">
 <?php
-// Hook to allow adding to form
-	add_action( 'indieauth_login_form' );
+	// Hook to allow adding to form
+	do_action( 'indieauth_login_form' );
 ?>
 <br />
 	<input class="input" type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php _e( 'Sign in', 'indieauth' ); ?>" />

--- a/templates/indieauth-login-form.php
+++ b/templates/indieauth-login-form.php
@@ -16,7 +16,7 @@ login_header(
 	// Hook to allow adding to form
 	do_action( 'indieauth_login_form' );
 ?>
-	<input class="input" type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php _e( 'Sign in', 'indieauth' ); ?>" />
+	<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php _e( 'Sign in', 'indieauth' ); ?>" />
 </p>
 <a href="https://indieauth.net/" target="_blank"><?php _e( 'Learn about IndieAuth', 'indieauth' ); ?></a>
 </form>

--- a/templates/indieauth-login-form.php
+++ b/templates/indieauth-login-form.php
@@ -9,18 +9,14 @@ login_header(
 <form name="loginform" id="loginform" action="<?php add_query_arg( 'action', 'indielogin', wp_login_url() ); ?>" method="post">
 <div class="login-info">
 <p><?php _e( 'Sign in with your domain', 'indieauth' ); ?></p>
-<br />
-	<input type="url" name="indieauth_identifier" placeholder="<?php _e( 'https://example.com', 'indieauth' ); ?>" />
-<br />
+	<input class="input" type="url" name="indieauth_identifier" placeholder="<?php _e( 'https://example.com', 'indieauth' ); ?>" />
 </div>
 <p class="submit">
 <?php
 	// Hook to allow adding to form
 	do_action( 'indieauth_login_form' );
 ?>
-<br />
 	<input class="input" type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php _e( 'Sign in', 'indieauth' ); ?>" />
 </p>
-<br />
 <a href="https://indieauth.net/" target="_blank"><?php _e( 'Learn about IndieAuth', 'indieauth' ); ?></a>
 </form>

--- a/templates/indieauth-login-form.php
+++ b/templates/indieauth-login-form.php
@@ -1,7 +1,26 @@
-<p style="margin-bottom: 8px;">
-	<label for="indieauth_identifier">
-	<input type="checkbox" name="indieauth_identifier" id="indieauth_identifier" class="indieauth_identifier" value="1" />
-<?php _e( 'Login with your Domain', 'indieauth' ); ?></label><br />
-	<a href="https://indieauth.net/" target="_blank"><?php _e( 'Learn about IndieAuth', 'indieauth' ); ?></a>
+<?php
+$errors = new WP_Error();
+login_header(
+	__( 'Sign in with your website', 'indieauth' ),
+	'',
+	$errors
+);
+?>
+<form name="loginform" id="loginform" action="<?php add_query_arg( 'action', 'indielogin', wp_login_url() ); ?>" method="post">
+<div class="login-info">
+<p><?php _e( 'Sign in with your domain', 'indieauth' ); ?></p>
+<br />
+	<input type="url" name="indieauth_identifier" placeholder="<?php _e( 'https://example.com', 'indieauth' ); ?>" />
+<br />
+</div>
+<p class="submit">
+<?php
+// Hook to allow adding to form
+	add_action( 'indieauth_login_form' );
+?>
+<br />
+	<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php _e( 'Sign in', 'indieauth' ); ?>" />
 </p>
-
+<br />
+<a href="https://indieauth.net/" target="_blank"><?php _e( 'Learn about IndieAuth', 'indieauth' ); ?></a>
+</form>

--- a/templates/indieauth-login-form.php
+++ b/templates/indieauth-login-form.php
@@ -19,7 +19,7 @@ login_header(
 	add_action( 'indieauth_login_form' );
 ?>
 <br />
-	<input type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php _e( 'Sign in', 'indieauth' ); ?>" />
+	<input class="input" type="submit" name="wp-submit" id="wp-submit" class="button button-primary button-large" value="<?php _e( 'Sign in', 'indieauth' ); ?>" />
 </p>
 <br />
 <a href="https://indieauth.net/" target="_blank"><?php _e( 'Learn about IndieAuth', 'indieauth' ); ?></a>


### PR DESCRIPTION
This tries to address the Error Logging issue by adding a conversion back to WP_Error in the Oauth Error Response function and adds checks to convert back.

It also changes the settings options to show radio buttons for custom, built-in, or Indieauth.com.

The login form to login with your domain is no longer shared with the regular login form and is accessed at wp-login.php?action=indielogin . There is a setting to show a link to it on the regular login form.