### PR TITLE
Add variable for token

### DIFF
--- a/includes/class-indieauth-authenticate.php
+++ b/includes/class-indieauth-authenticate.php
@@ -143,6 +143,8 @@ class IndieAuth_Authenticate {
 		$params = json_decode( $body, true );
 		global $indieauth_scopes;
 		$indieauth_scopes = explode( ' ', $params['scope'] );
+		global $indieauth_token;
+		$indieauth_token = $params;
 		return $params['me'];
 	}
 

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: Login to your site using IndieAuth.com
- * Version: 2.0.1
+ * Version: 2.0.2
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.7  
 **Tested up to:** 4.9.5  
-**Stable tag:** 2.0.1  
+**Stable tag:** 2.0.2  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -77,6 +77,9 @@ You can revoke tokens under User->Manage Tokens.
 
 
 ## Changelog ##
+
+### 2.0.2 ###
+* Make token available as a global variable so the parameters can be accessed
 
 ### 2.0.1 ###
 * Improve error handling if null endpoint sent through

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.7
 Tested up to: 4.9.5
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -77,6 +77,9 @@ You can revoke tokens under User->Manage Tokens.
 
 
 == Changelog ==
+
+= 2.0.2 =
+* Make token available as a global variable so the parameters can be accessed
 
 = 2.0.1 =
 * Improve error handling if null endpoint sent through


### PR DESCRIPTION
The Micropub server can't access the client_id, which it currently embeds inside the post if it handles authorization. This adds the token data as a global variable so it can be accessed.

The Micropub plugin already uses a global variable to share scope, which in the latest version, the Micropub plugin honors.