### PR TITLE
Update functions.php

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -113,7 +113,7 @@ function get_user_by_identifier( $identifier ) {
 	// Try to save the expense of a search query if the URL is the site URL
 	if ( home_url( '/' ) === $identifier ) {
 		// Use the Indieweb settings to set the default author
-		if ( class_exists( 'Indieweb_Plugin' ) && get_option( 'iw_single_author' ) ) {
+		if ( class_exists( 'Indieweb_Plugin' ) && (get_option( 'iw_single_author' ) || !is_multi_author() )) {
 			return get_user_by( 'id', get_option( 'iw_default_author' ) );
 		}
 		$users = get_users( array( 'role__not_in' => array( 'subscriber' ) ) );


### PR DESCRIPTION
wordpress-indieweb as of https://github.com/indieweb/wordpress-indieweb/commit/cbc315dfab312b543f863cd673de6240883f9ef7 completely deletes the iw_single_author option whenever `!is_multi_author()` as my blog is not multi author and at some point recently I resaved that settings page, this caused indieauth to break and never be able to auth me.