### PR TITLE
Fix issue with token error

### DIFF
--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -83,14 +83,16 @@ class IndieAuth_Authorize {
 		}
 		$token = $this->get_provided_token();
 		if ( ! $token ) {
-			$this->error = new WP_Error(
-				'missing_bearer_token',
-				__( 'Missing OAuth Bearer Token', 'indieauth' ),
-				array(
-					'status' => '401',
-					'server' => $_SERVER,
-				)
-			);
+			if ( defined( 'INDIEAUTH_TOKEN_ERROR' )  && INDIEAUTH_TOKEN_ERROR ) {
+				$this->error = new WP_Error(
+					'missing_bearer_token',
+					__( 'Missing OAuth Bearer Token', 'indieauth' ),
+					array(
+						'status' => '401',
+						'server' => $_SERVER,
+					)
+				);
+			}
 			return $user_id;
 		}
 

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: Login to your site using IndieAuth.com
- * Version: 3.0.0
+ * Version: 3.0.1
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 3.0.0\n"
+"Project-Id-Version: IndieAuth 3.0.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
-"POT-Creation-Date: 2018-06-13 07:44:12+00:00\n"
+"POT-Creation-Date: 2018-06-16 14:53:09+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -117,7 +117,7 @@ msgid "Missing Parameter: %1$s"
 msgstr ""
 
 #: includes/class-indieauth-authorization-endpoint.php:120
-#: includes/class-indieauth-authorize.php:146
+#: includes/class-indieauth-authorize.php:148
 #: includes/class-indieauth-token-endpoint.php:164
 msgid "Invalid authorization code"
 msgstr ""
@@ -132,15 +132,15 @@ msgid ""
 "client_id and redirect_uri match the original request."
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:88
+#: includes/class-indieauth-authorize.php:89
 msgid "Missing OAuth Bearer Token"
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:110
+#: includes/class-indieauth-authorize.php:112
 msgid "User Not Found on this Site"
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:137
+#: includes/class-indieauth-authorize.php:139
 #: includes/class-indieauth-token-endpoint.php:83
 msgid "Invalid access token"
 msgstr ""

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.7  
 **Tested up to:** 4.9.6  
-**Stable tag:** 3.0.0  
+**Stable tag:** 3.0.1  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -68,6 +68,14 @@ The plugin supports you using an external token endpoint if you want, but by hav
 
 You can revoke local tokens under User->Manage Tokens.
 
+### I keep getting the response that my request is Unauthorized ###
+
+Many server configurations will not pass bearer tokens. The plugin attempts to work with this as best possible, but there may be cases we have not encounter.
+Please temporarily enable [WP_DEBUG](https://codex.wordpress.org/Debugging_in_WordPress) which will surface some errors, and enable 
+`define( 'INDIEAUTH_TOKEN_ERROR', true );` to your wp-config.php file. The `INDIEAUTH_TOKEN_ERROR` flag will return an error if there is not a token passed
+allowing you to troubleshoot this issue, however it will require authentication for all REST API functions even those that do not require them, therefore this
+is off by default.
+
 ## Upgrade Notice ##
 
 ### 3.0.0 ###
@@ -78,6 +86,10 @@ feature, it will look for the IndieAuth endpoint for the URL you provide. If you
 endpoint for WordPress. If you wish to use Indieauth.com or another endpoint, you can disable this plugin and Micropub will use Indieauth.com by default.
 
 ## Changelog ##
+
+### 3.0.1 ###
+* In previous version fixed issue where error message was not returned if there was a missing bearer token. This was needed due fact that some servers filter tokens. However, this meant that it would do this for all API requests, even ones not requiring authentication such as webmentions. Reverted change with flag
+* Added constant `INDIEAUTH_TOKEN_ERROR` which if set to true will return an error if it cannot find a token.
 
 ### 3.0.0 ###
 * Major refactor to abstract out and improve token generation code

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.7
 Tested up to: 4.9.6
-Stable tag: 3.0.0
+Stable tag: 3.0.1
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -68,6 +68,14 @@ The plugin supports you using an external token endpoint if you want, but by hav
 
 You can revoke local tokens under User->Manage Tokens.
 
+= I keep getting the response that my request is Unauthorized =
+
+Many server configurations will not pass bearer tokens. The plugin attempts to work with this as best possible, but there may be cases we have not encounter.
+Please temporarily enable [WP_DEBUG](https://codex.wordpress.org/Debugging_in_WordPress) which will surface some errors, and enable 
+`define( 'INDIEAUTH_TOKEN_ERROR', true );` to your wp-config.php file. The `INDIEAUTH_TOKEN_ERROR` flag will return an error if there is not a token passed
+allowing you to troubleshoot this issue, however it will require authentication for all REST API functions even those that do not require them, therefore this
+is off by default.
+
 == Upgrade Notice ==
 
 = 3.0.0 =
@@ -78,6 +86,10 @@ feature, it will look for the IndieAuth endpoint for the URL you provide. If you
 endpoint for WordPress. If you wish to use Indieauth.com or another endpoint, you can disable this plugin and Micropub will use Indieauth.com by default.
 
 == Changelog ==
+
+= 3.0.1 =
+* In previous version fixed issue where error message was not returned if there was a missing bearer token. This was needed due fact that some servers filter tokens. However, this meant that it would do this for all API requests, even ones not requiring authentication such as webmentions. Reverted change with flag
+* Added constant `INDIEAUTH_TOKEN_ERROR` which if set to true will return an error if it cannot find a token.
 
 = 3.0.0 =
 * Major refactor to abstract out and improve token generation code


### PR DESCRIPTION
This was part of my attempt to surface failed  tokens, but it looks  like I ended up requiring auth for all queries, including webmentions. This hides this behind a constant.