### PR TITLE
Improve Token Handling

### DIFF
--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -110,22 +110,16 @@ class IndieAuth_Authorize {
 	}
 
 	public function verify_access_token( $token ) {
-		$params = $this->verify_local_access_token( $token );
-
-		if ( is_oauth_error( $params ) ) {
-			$this->error = $params->to_wp_error();
-			return $params;
-		}
-
-		return $params;
-	}
-
-	public function verify_local_access_token( $token ) {
 		$tokens = new Token_User( '_indieauth_token_' );
 		$return = $tokens->get( $token );
 		if ( ! $return ) {
 			return new WP_OAuth_Response( 'invalid_token', __( 'Invalid access token', 'indieauth' ), 401 );
 		}
+		if ( is_oauth_error( $params ) ) {
+			$this->error = $params->to_wp_error();
+		}
+		$return['last_accessed'] = current_time( 'timestamp', 1 );
+		$tokens->update( $token, $return );
 		return $return;
 	}
 

--- a/includes/class-indieauth-token-ui.php
+++ b/includes/class-indieauth-token-ui.php
@@ -50,11 +50,11 @@ class IndieAuth_Token_UI {
 		// As a precaution every time the Token UI page is lost it will check for any expired auth codes and purge them
 		$codes = new Token_User( '_indieauth_code_', get_current_user_id() );
 		$codes->check_expires();
-		$ListTable = new Token_List_Table();
-		echo '<div class="wrap"><h2>' . __( 'Manage IndieAuth Tokens', 'indieauth' ) . '</h2>'; 
-		$ListTable->prepare_items(); 
-		$ListTable->display(); 
-		echo '</div>'; 
+		$token_table = new Token_List_Table();
+		echo '<div class="wrap"><h2>' . esc_html__( 'Manage IndieAuth Tokens', 'indieauth' ) . '</h2>';
+		$token_table->prepare_items();
+		$token_table->display();
+		echo '</div>';
 	}
 
 	/**

--- a/includes/class-token-list-table.php
+++ b/includes/class-token-list-table.php
@@ -7,9 +7,10 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 class Token_List_Table extends WP_List_Table {
 	public function get_columns() {
 		return array(
-			'client_id' => __( 'Client ID', 'indieauth' ),
-			'scope'     => __( 'Scope', 'indieauth' ),
-			'issued_at' => __( 'Issue Date', 'indieauth' ),
+			'client_id'     => __( 'Client ID', 'indieauth' ),
+			'scope'         => __( 'Scope', 'indieauth' ),
+			'issued_at'     => __( 'Issue Date', 'indieauth' ),
+			'last_accessed' => __( 'Last Accessed', 'indieauth' ),
 		);
 	}
 
@@ -49,8 +50,21 @@ class Token_List_Table extends WP_List_Table {
 		}
 	}
 
+	public function column_last_accessed( $item ) {
+		if ( ! isset( $item['last_accessed'] ) ) {
+			return __( 'Never', 'indieauth' );
+		}
+		$time      = (int) $item['last_accessed'];
+		$time_diff = time() - $time;
+		if ( $time_diff > 0 && $time_diff < DAY_IN_SECONDS ) {
+			// translators: Human time difference ago
+			return sprintf( __( '%s ago', 'indieauth' ), human_time_diff( $time ) );
+		}
+		return date_i18n( get_option( 'date_format' ), $time );
+	}
+
 	public function column_issued_at( $item ) {
-		return date_i18n( DATE_W3C, $item['issued_at'] );
+		return date_i18n( get_option( 'date_format' ), $item['issued_at'] );
 	}
 
 	public function column_client_id( $item ) {

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -32,23 +32,29 @@ function log_rest_api_errors( $result, $server, $request ) {
 			// Remove actual code from logs
 			$params['code'] = 'XXXX';
 		}
-		$data = $result->get_data();
+		$headers = $request->get_headers();
+		$token   = isset( $headers['authorization'] ) ? 'Present' : 'Absent';
+		$data    = $result->get_data();
 		if ( isset( $data['access_token'] ) ) {
 			// Remove actual token from logs
 			$data['access_token'] = 'XXXX';
 		}
 		error_log(
 			sprintf(
-				'REST request: %s: %s',
+				'REST request: %s: %s(Header %s)',
 				$request->get_route(),
-				wp_json_encode( $params )
+				wp_json_encode( $params ),
+				$token
 			)
 		);
 		error_log(
 			sprintf(
-				'REST result: %s: %s',
+				'REST result: %s: %s(%s) - %s(User ID: %s)',
 				$result->get_matched_route(),
-				wp_json_encode( $data )
+				wp_json_encode( $data ),
+				$result->get_status(),
+				wp_json_encode( $result->get_headers() ),
+				get_current_user_id()
 			)
 		);
 	}

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: Login to your site using IndieAuth.com
- * Version: 3.1.3
+ * Version: 3.1.4
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 3.1.3\n"
+"Project-Id-Version: IndieAuth 3.1.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
-"POT-Creation-Date: 2018-08-12 02:29:57+00:00\n"
+"POT-Creation-Date: 2018-08-17 17:57:55+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -170,7 +170,7 @@ msgid "Missing Parameter: %1$s"
 msgstr ""
 
 #: includes/class-indieauth-authorization-endpoint.php:146
-#: includes/class-indieauth-authorize.php:157
+#: includes/class-indieauth-authorize.php:130
 #: includes/class-indieauth-token-endpoint.php:163
 msgid "Invalid authorization code"
 msgstr ""
@@ -185,15 +185,11 @@ msgid ""
 "client_id and redirect_uri match the original request."
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:89
-msgid "Missing OAuth Bearer Token"
-msgstr ""
-
-#: includes/class-indieauth-authorize.php:120
+#: includes/class-indieauth-authorize.php:102
 msgid "User Not Found on this Site"
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:148
+#: includes/class-indieauth-authorize.php:116
 #: includes/class-indieauth-token-endpoint.php:83
 msgid "Invalid access token"
 msgstr ""
@@ -245,7 +241,20 @@ msgstr ""
 msgid "Issue Date"
 msgstr ""
 
-#: includes/class-token-list-table.php:58
+#: includes/class-token-list-table.php:13
+msgid "Last Accessed"
+msgstr ""
+
+#: includes/class-token-list-table.php:55
+msgid "Never"
+msgstr ""
+
+#: includes/class-token-list-table.php:61
+#. translators: Human time difference ago
+msgid "%s ago"
+msgstr ""
+
+#: includes/class-token-list-table.php:72
 msgid "Revoke"
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.7  
 **Tested up to:** 4.9.8  
-**Stable tag:** 3.1.3  
+**Stable tag:** 3.1.4  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -88,6 +88,10 @@ endpoint for WordPress. If you wish to use Indieauth.com or another endpoint, yo
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 3.1.4 ###
+* Rearrange token logic so that if a token is provided the system will fail if it is invalid
+* Add last accessed field to token and add that to token management table
 
 ### 3.1.3 ###
 * Allow selection of scopes and add stock descriptions

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.7
 Tested up to: 4.9.8
-Stable tag: 3.1.3
+Stable tag: 3.1.4
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -88,6 +88,10 @@ endpoint for WordPress. If you wish to use Indieauth.com or another endpoint, yo
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 3.1.4 =
+* Rearrange token logic so that if a token is provided the system will fail if it is invalid
+* Add last accessed field to token and add that to token management table
 
 = 3.1.3 =
 * Allow selection of scopes and add stock descriptions


### PR DESCRIPTION
This was prompted by the discovery that Omnibear won't work if you are logged into your site due cookie confllict. Still a problem, but I rearranged the logic to basically fail on a bad token, as opposed to passing control back to WordPress. With no token it will hand control to whatever came in, with a bad token it will hand back 0.

In order to test this, I made some minor modifications to the debug function.

Also, added a last accessed field so I could figure out which tokens I wanted to revoke. Testing generates a lot.