### PR TITLE
Change priority

### DIFF
--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -10,7 +10,9 @@ class IndieAuth_Authorize {
 	public $response = array();
 
 	public function __construct() {
-		add_filter( 'determine_current_user', array( $this, 'determine_current_user' ), 30 );
+		// WordPress validates the auth cookie at priority 10 and this cannot be overridden by an earlier priority
+		// It validates the logged in cookie at 20 and can be overridden by something with a higher priority
+		add_filter( 'determine_current_user', array( $this, 'determine_current_user' ), 15 );
 		add_filter( 'rest_authentication_errors', array( $this, 'rest_authentication_errors' ) );
 		add_filter( 'rest_index', array( $this, 'register_index' ) );
 


### PR DESCRIPTION
add_filter( 'determine_current_user', 'wp_validate_auth_cookie' );
add_filter( 'determine_current_user', 'wp_validate_logged_in_cookie', 20 );

These are the only filters called against determine_current_user. wp_validate_auth_cookie ignores anything with a lower priority, but wp_validate_logged_in_cookie doesn't, so the ideal place is in between.

