### PR TITLE
Update Me Property During Local Verification

### DIFF
--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -19,7 +19,9 @@ class IndieAuth_Authorization_Endpoint {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			'indieauth/1.0', '/auth', array(
+			'indieauth/1.0',
+			'/auth',
+			array(
 				array(
 					'methods'  => WP_REST_Server::READABLE,
 					'callback' => array( $this, 'request' ),
@@ -156,7 +158,7 @@ class IndieAuth_Authorization_Endpoint {
 		if ( array() === array_diff_assoc( $params, $token ) ) {
 			$this->delete_code( $code );
 
-			if ( class_exists( 'Indieweb_Plugin' ) && ( get_option( 'iw_single_author' ) || ! is_multi_author() ) ) {
+			if ( ( class_exists( 'Indieweb_Plugin' ) && get_option( 'iw_single_author' ) ) || ! is_multi_author() ) {
 				$return = array( 'me' => home_url( '/' ) );
 			} else {
 				// Return the user profile URL and scope

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -156,7 +156,7 @@ class IndieAuth_Authorization_Endpoint {
 		unset( $token['expiration'] );
 
 		if ( array() === array_diff_assoc( $params, $token ) ) {
-			$this->delete_code( $code );
+			$this->delete_code( $code, $token['user'] );
 
 			if ( ( class_exists( 'Indieweb_Plugin' ) && get_option( 'iw_single_author' ) ) || ! is_multi_author() ) {
 				$return = array( 'me' => home_url( '/' ) );

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -96,14 +96,9 @@ class IndieAuth_Authorize {
 		if ( is_array( $params ) ) {
 			$this->response = $params;
 			$this->scopes   = explode( ' ', $params['scope'] );
-			// If the user ID is passed in the token use it
+			// The User ID must be passed in the request
 			if ( isset( $params['user'] ) ) {
 				return (int) $params['user'];
-			} elseif ( isset( $params['me'] ) ) {
-				$user = get_user_by_identifier( $me );
-				if ( $user instanceof WP_User ) {
-					return $user->ID;
-				}
 			}
 		}
 

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -32,7 +32,9 @@ class IndieAuth_Token_Endpoint {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			'indieauth/1.0', '/token', array(
+			'indieauth/1.0',
+			'/token',
+			array(
 				array(
 					'methods'  => WP_REST_Server::CREATABLE,
 					'callback' => array( $this, 'post' ),
@@ -58,7 +60,9 @@ class IndieAuth_Token_Endpoint {
 			)
 		);
 		register_rest_route(
-			'indieauth/1.0', '/token', array(
+			'indieauth/1.0',
+			'/token',
+			array(
 				array(
 					'methods'  => WP_REST_Server::READABLE,
 					'callback' => array( $this, 'get' ),
@@ -162,6 +166,13 @@ class IndieAuth_Token_Endpoint {
 		if ( ! $return ) {
 			return new WP_OAuth_Response( 'invalid_code', __( 'Invalid authorization code', 'indieauth' ), 401 );
 		}
+		if ( ( class_exists( 'Indieweb_Plugin' ) && get_option( 'iw_single_author' ) ) || ! is_multi_author() ) {
+			$return['me'] = home_url( '/' );
+		} else {
+			// Return the user profile URL and scope
+			$return['me'] = get_author_posts_url( $return['user'] );
+		}
+
 		$tokens->destroy( $post_args['code'] );
 		return $return;
 	}

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -82,7 +82,9 @@ class Token_User extends Token_Generic {
 
 		foreach ( $meta as $key => $value ) {
 			if ( 0 === strncmp( $key, $this->prefix, strlen( $this->prefix ) ) ) {
-				$tokens[ str_replace( $this->prefix, '', $key ) ] = maybe_unserialize( array_pop( $value ) );
+				$value         = maybe_unserialize( array_pop( $value ) );
+				$value['user'] = $this->user_id;
+				$tokens[ str_replace( $this->prefix, '', $key ) ] = $value;
 			}
 		}
 		return $tokens;

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: Login to your site using IndieAuth.com
- * Version: 3.1.7
+ * Version: 3.1.8
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 3.1.6\n"
+"Project-Id-Version: IndieAuth 3.1.8\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
-"POT-Creation-Date: 2018-09-23 17:00:59+00:00\n"
+"POT-Creation-Date: 2018-10-08 04:26:08+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -107,90 +107,90 @@ msgstr ""
 msgid "<a href=\"https://www.w3.org/TR/indieauth/\">W3C Spec</a>"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:66
+#: includes/class-indieauth-authorization-endpoint.php:68
 msgid "Legacy Scope (Deprecated)"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:67
+#: includes/class-indieauth-authorization-endpoint.php:69
 msgid "Allows the application to create posts and upload to the Media Endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:68
+#: includes/class-indieauth-authorization-endpoint.php:70
 msgid "Allows the application to update posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:69
+#: includes/class-indieauth-authorization-endpoint.php:71
 msgid "Allows the application to delete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:70
+#: includes/class-indieauth-authorization-endpoint.php:72
 msgid "Allows the application to undelete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:71
+#: includes/class-indieauth-authorization-endpoint.php:73
 msgid "Allows the application to upload to the media endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:73
+#: includes/class-indieauth-authorization-endpoint.php:75
 msgid "Allows the application read access to channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:74
+#: includes/class-indieauth-authorization-endpoint.php:76
 msgid "Allows the application to manage a follow list"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:75
+#: includes/class-indieauth-authorization-endpoint.php:77
 msgid "Allows the application to mute and unmute users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:76
+#: includes/class-indieauth-authorization-endpoint.php:78
 msgid "Allows the application to block and unlock users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:77
+#: includes/class-indieauth-authorization-endpoint.php:79
 msgid "Allows the application to manage channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:78
+#: includes/class-indieauth-authorization-endpoint.php:80
 msgid "Allows the application to save content for later retrieval"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:83
+#: includes/class-indieauth-authorization-endpoint.php:85
 msgid "No Description Available"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:93
+#: includes/class-indieauth-authorization-endpoint.php:95
 msgid "Unsupported Response Type"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:99
-#: includes/class-indieauth-authorization-endpoint.php:140
+#: includes/class-indieauth-authorization-endpoint.php:101
+#: includes/class-indieauth-authorization-endpoint.php:142
 #. translators: Name of missing parameter
 msgid "Missing Parameter: %1$s"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:147
-#: includes/class-indieauth-authorize.php:146
-#: includes/class-indieauth-token-endpoint.php:163
+#: includes/class-indieauth-authorization-endpoint.php:149
+#: includes/class-indieauth-authorize.php:141
+#: includes/class-indieauth-token-endpoint.php:167
 msgid "Invalid authorization code"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:152
+#: includes/class-indieauth-authorization-endpoint.php:154
 msgid "The authorization code expired"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:171
+#: includes/class-indieauth-authorization-endpoint.php:173
 msgid ""
 "There was an error verifying the authorization code. Check that the "
 "client_id and redirect_uri match the original request."
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:112
+#: includes/class-indieauth-authorize.php:107
 msgid "User Not Found on this Site"
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:128
-#: includes/class-indieauth-token-endpoint.php:83
+#: includes/class-indieauth-authorize.php:123
+#: includes/class-indieauth-token-endpoint.php:87
 msgid "Invalid access token"
 msgstr ""
 
@@ -216,29 +216,29 @@ msgid ""
 "showing you as logged in"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:79
+#: includes/class-indieauth-token-endpoint.php:83
 msgid "Bearer Token Not Supplied"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:111
+#: includes/class-indieauth-token-endpoint.php:115
 msgid "The Token Provided is No Longer Valid"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:118
+#: includes/class-indieauth-token-endpoint.php:122
 msgid "Invalid Request"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:125
+#: includes/class-indieauth-token-endpoint.php:129
 msgid "The request is missing one or more required parameters"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:154
+#: includes/class-indieauth-token-endpoint.php:158
 msgid ""
 "This authorization code was issued with no scope, so it cannot be used to "
 "obtain an access token"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:156
+#: includes/class-indieauth-token-endpoint.php:160
 msgid "There was an error issuing the access token"
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.7  
 **Tested up to:** 4.9.8  
-**Stable tag:** 3.1.7  
+**Stable tag:** 3.1.8  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -129,6 +129,10 @@ endpoint for WordPress. If you wish to use Indieauth.com or another endpoint, yo
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 3.1.8 ###
+* When local verification is performed the code was not updating the profile URL and passing through the URL from the original request. This code was in
+the remote verification portion of the token endpoint and is now mirrored in the verify local code.
 
 ### 3.1.7 ###
 * Add authdiag.php script written by @Zegnat

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.7
 Tested up to: 4.9.8
-Stable tag: 3.1.7
+Stable tag: 3.1.8
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -129,6 +129,10 @@ endpoint for WordPress. If you wish to use Indieauth.com or another endpoint, yo
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 3.1.8 =
+* When local verification is performed the code was not updating the profile URL and passing through the URL from the original request. This code was in
+the remote verification portion of the token endpoint and is now mirrored in the verify local code.
 
 = 3.1.7 =
 * Add authdiag.php script written by @Zegnat


### PR DESCRIPTION
Trying to track down the issues with auth for some people, and came across the fact that the me property isn't updated after login for local verification. As this was added subsequent to the original design, it was overlooked.

It also removes the attempt of the system to verify by URL. As the verification is always from the built-in system, the user id can always be passed and this should error out if it isn't found.