### PR TITLE
Fix an array dereferencing typo

### DIFF
--- a/includes/class-indieauth-client-discovery.php
+++ b/includes/class-indieauth-client-discovery.php
@@ -91,7 +91,7 @@ class IndieAuth_Client_Discovery {
 			return $icons['url'];
 		} else {
 			// Return the first icon
-			return $icons[0]['url'];
+			return $icons['url'][0];
 		}
 	}
 


### PR DESCRIPTION
Found in WP_DEBUG mode.