### PR TITLE
PKCE Support

### DIFF
--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -165,11 +165,7 @@ class IndieAuth_Authorization_Endpoint {
 				$this->delete_code( $code, $token['user'] );
 				return new WP_OAuth_Response( 'invalid_grant', __( 'Failed PKCE Validation', 'indieauth' ), 400 );
 			}
-			if ( 'plain' === $token['code_challenge_method'] && $code_verifier !== $token['code_challenge'] ) {
-				$this->delete_code( $code, $token['user'] );
-				return new WP_OAuth_Response( 'invalid_grant', __( 'Failed PKCE Validation', 'indieauth' ), 400 );
-			}
-			if ( 'SHA256' === $token['code_challenge_method'] && base64_encode( indieauth_hash( $code_verifier ) ) !== $token['code_challenge'] ) {
+			if ( ! pkce_verifier( $token['code_challenge'], $code_verifier, $token['code_challenge_method'] ) ) {
 				$this->delete_code( $code, $token['user'] );
 				return new WP_OAuth_Response( 'invalid_grant', __( 'Failed PKCE Validation', 'indieauth' ), 400 );
 			}

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -102,13 +102,17 @@ class IndieAuth_Authorization_Endpoint {
 			}
 		}
 		$url  = wp_login_url( $params['redirect_uri'], true );
-		$args = array(
-			'action'        => 'indieauth',
-			'_wpnonce'      => wp_create_nonce( 'wp_rest' ),
-			'response_type' => $params['response_type'],
-			'client_id'     => $params['client_id'],
-			'me'            => $params['me'],
-			'state'         => $params['state'],
+		$args = array_filter(
+			array(
+				'action'                => 'indieauth',
+				'_wpnonce'              => wp_create_nonce( 'wp_rest' ),
+				'response_type'         => $params['response_type'],
+				'client_id'             => $params['client_id'],
+				'me'                    => $params['me'],
+				'state'                 => $params['state'],
+				'code_challenge'        => isset( $params['code_challenge'] ) ? $params['code_challenge'] : null,
+				'code_challenge_method' => isset( $params['code_challenge_method'] ) ? $params['code_challenge_method'] : null,
+			)
 		);
 		if ( 'code' === $params['response_type'] ) {
 			$args['scope'] = isset( $params['scope'] ) ? $params['scope'] : 'create update';
@@ -154,6 +158,24 @@ class IndieAuth_Authorization_Endpoint {
 			return new WP_OAuth_Response( 'invalid_grant', __( 'The authorization code expired', 'indieauth' ), 400 );
 		}
 		unset( $token['expiration'] );
+		// If there is a code challenge
+		if ( isset( $token['code_challenge'] ) ) {
+			$code_verifier = $request->get_param( 'code_verifier' );
+			if ( ! $code_verifier ) {
+				$this->delete_code( $code, $token['user'] );
+				return new WP_OAuth_Response( 'invalid_grant', __( 'Failed PKCE Validation', 'indieauth' ), 400 );
+			}
+			if ( 'plain' === $token['code_challenge_method'] && $code_verifier !== $token['code_challenge'] ) {
+				$this->delete_code( $code, $token['user'] );
+				return new WP_OAuth_Response( 'invalid_grant', __( 'Failed PKCE Validation', 'indieauth' ), 400 );
+			}
+			if ( 'SHA256' === $token['code_challenge_method'] && base64_encode( indieauth_hash( $code_verifier ) ) !== $token['code_challenge'] ) {
+				$this->delete_code( $code, $token['user'] );
+				return new WP_OAuth_Response( 'invalid_grant', __( 'Failed PKCE Validation', 'indieauth' ), 400 );
+			}
+			unset( $token['code_challenge'] );
+			unset( $token['code_challenge_method'] );
+		}
 
 		if ( array() === array_diff_assoc( $params, $token ) ) {
 			$this->delete_code( $code, $token['user'] );
@@ -200,9 +222,12 @@ class IndieAuth_Authorization_Endpoint {
 		$state         = isset( $_GET['state'] ) ? $_GET['state'] : null;
 		$me            = isset( $_GET['me'] ) ? wp_unslash( $_GET['me'] ) : null;
 		$response_type = isset( $_GET['response_type'] ) ? wp_unslash( $_GET['response_type'] ) : null;
+		$code_challenge = isset( $_GET['code_challenge'] ) ? wp_unslash( $_GET['code_challenge'] ) : null;
+		$code_challenge_method = isset( $_GET['code_challenge_method'] ) ? wp_unslash( $_GET['code_challenge_method'] ) : null;
+
 		// phpcs:enable
 		$action = 'indieauth';
-		$url    = add_query_params_to_url(
+		$args   = array_filter(
 			compact(
 				'client_id',
 				'redirect_uri',
@@ -210,9 +235,9 @@ class IndieAuth_Authorization_Endpoint {
 				'me',
 				'response_type',
 				'action'
-			),
-			wp_login_url()
+			)
 		);
+		$url    = add_query_params_to_url( $args, wp_login_url() );
 		if ( 'code' === $_GET['response_type'] ) {
 			include plugin_dir_path( __DIR__ ) . 'templates/indieauth-authorize-form.php';
 		} elseif ( 'id' === $_GET['response_type'] ) {
@@ -227,6 +252,8 @@ class IndieAuth_Authorization_Endpoint {
 		$client_id     = wp_unslash( $_POST['client_id'] ); // WPCS: CSRF OK
 		$redirect_uri  = isset( $_POST['redirect_uri'] ) ? wp_unslash( $_POST['redirect_uri'] ) : null;
 		$scope         = isset( $_POST['scope'] ) ? $_POST['scope'] : array();
+		$code_challenge  = isset( $_POST['code_challenge'] ) ? wp_unslash( $_POST['code_challenge'] ) : null;
+		$code_challenge_method  = isset( $_POST['code_challenge_method'] ) ? wp_unslash( $_POST['code_challenge_method'] ) : null;
 		$search = array_search( 'post', $scope, true );
 		if ( is_numeric( $search ) ) {
 			unset( $scope[ $search ] );
@@ -238,7 +265,7 @@ class IndieAuth_Authorization_Endpoint {
 		$me            = isset( $_POST['me'] ) ? wp_unslash( $_POST['me'] ) : null;
 		$response_type = isset( $_POST['response_type'] ) ? wp_unslash( $_POST['response_type'] ) : null;
 		/// phpcs:enable
-		$token = compact( 'response_type', 'client_id', 'redirect_uri', 'scope', 'me' );
+		$token = compact( 'response_type', 'client_id', 'redirect_uri', 'scope', 'me', 'code_challenge', 'code_challenge_method' );
 		$token = array_filter( $token );
 		$code  = self::set_code( $current_user->ID, $token );
 		$url   = add_query_params_to_url(

--- a/includes/class-token-generic.php
+++ b/includes/class-token-generic.php
@@ -77,8 +77,8 @@ abstract class Token_Generic {
 	 * @param string $scheme Hashing sceheme
 	 * @return string A hash of the string encoded to base64.
 	 */
-	protected function hash( $string, $scheme = 'secure_auth' ) {
-		return base64_encode( wp_hash( $string, $scheme ) );
+	protected function hash( $string ) {
+		return base64_encode( indieauth_hash( $string ) );
 	}
 
 	/**

--- a/includes/class-token-transient.php
+++ b/includes/class-token-transient.php
@@ -69,8 +69,8 @@ class Token_Transient extends Token_Generic {
 		$this->destroy( $key );
 	}
 
-	protected function hash( $string, $scheme = 'nonce' ) {
-		return parent::hash( $string, $scheme );
+	protected function hash( $string ) {
+		return parent::hash( $string );
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -415,6 +415,18 @@ function indieauth_hash( $data ) {
 	return hash( 'sha256', $data, true );
 }
 
+function pkce_verifier( $code_challenge, $code_verifier, $method ) {
+	if ( 'S256' === $method ) {
+		$code_verifier = base64_urlencode( indieauth_hash( $code_verifier ) );
+	}
+	return ( 0 === strcmp( $code_challenge, $code_verifier ) );
+}
+
+function base64_urlencode( $string ) {
+	return rtrim( strtr( base64_encode( $string ), '+/', '-_' ), '=' );
+}
+
+
 /* Returns jf2 formatted user data
  *
  */

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -411,6 +411,10 @@ function indieauth_get_me() {
 	return $response['me'];
 }
 
+function indieauth_hash( $data ) {
+	return hash( 'sha256', $data, true );
+}
+
 /* Returns jf2 formatted user data
  *
  */

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: IndieAuth 3.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
-"POT-Creation-Date: 2019-02-24 17:00:09+00:00\n"
+"POT-Creation-Date: 2019-03-11 05:27:16+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -164,22 +164,28 @@ msgid "Unsupported Response Type"
 msgstr ""
 
 #: includes/class-indieauth-authorization-endpoint.php:101
-#: includes/class-indieauth-authorization-endpoint.php:142
+#: includes/class-indieauth-authorization-endpoint.php:146
 #. translators: Name of missing parameter
 msgid "Missing Parameter: %1$s"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:149
+#: includes/class-indieauth-authorization-endpoint.php:153
 #: includes/class-indieauth-authorize.php:145
 #: includes/class-indieauth-token-endpoint.php:176
 msgid "Invalid authorization code"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:154
+#: includes/class-indieauth-authorization-endpoint.php:158
 msgid "The authorization code expired"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:173
+#: includes/class-indieauth-authorization-endpoint.php:166
+#: includes/class-indieauth-authorization-endpoint.php:170
+#: includes/class-indieauth-authorization-endpoint.php:174
+msgid "Failed PKCE Validation"
+msgstr ""
+
+#: includes/class-indieauth-authorization-endpoint.php:195
 msgid ""
 "There was an error verifying the authorization code. Check that the "
 "client_id and redirect_uri match the original request."
@@ -410,7 +416,7 @@ msgid ""
 msgstr ""
 
 #: templates/indieauth-authenticate-form.php:37
-#: templates/indieauth-authorize-form.php:53
+#: templates/indieauth-authorize-form.php:58
 msgid "Cancel"
 msgstr ""
 
@@ -419,7 +425,7 @@ msgid "You will be redirected to <code>%1$s</code> after authenticating."
 msgstr ""
 
 #: templates/indieauth-authorize-form.php:4
-#: templates/indieauth-authorize-form.php:52
+#: templates/indieauth-authorize-form.php:57
 msgid "Authorize"
 msgstr ""
 
@@ -435,7 +441,7 @@ msgid ""
 "href=\"https://indieweb.org/scope\">scopes</a>"
 msgstr ""
 
-#: templates/indieauth-authorize-form.php:56
+#: templates/indieauth-authorize-form.php:61
 msgid ""
 "You will be redirected to <code>%1$s</code> after authorizing this "
 "application."

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
 	<exclude-pattern>*/includes/*\.(inc|css|js|svg)</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="5.4-"/>
 	<rule ref="PHPCompatibilityWP"/>
 	<config name="minimum_supported_wp_version" value="4.7"/>
 	<rule ref="WordPress.WP.DeprecatedFunctions" />

--- a/readme.md
+++ b/readme.md
@@ -2,8 +2,9 @@
 **Contributors:** [indieweb](https://profiles.wordpress.org/indieweb), [pfefferle](https://profiles.wordpress.org/pfefferle), [dshanske](https://profiles.wordpress.org/dshanske)  
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.7  
+**Requires PHP:** 5.4  
 **Tested up to:** 5.1  
-**Stable tag:** 3.2  
+**Stable tag:** 3.3  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -129,6 +130,10 @@ endpoint for WordPress. If you wish to use Indieauth.com or another endpoint, yo
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 3.3 ###
+* Switch to SHA256 hashing from built in salted hash used by WordPress passwords
+* Add PKCE Support
 
 ### 3.2 ###
 * Only add headers to front page and author archive pages

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,9 @@
 Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.7
+Requires PHP: 5.4
 Tested up to: 5.1
-Stable tag: 3.2
+Stable tag: 3.3
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -129,6 +130,10 @@ endpoint for WordPress. If you wish to use Indieauth.com or another endpoint, yo
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 3.3 =
+* Switch to SHA256 hashing from built in salted hash used by WordPress passwords
+* Add PKCE Support
 
 = 3.2 = 
 * Only add headers to front page and author archive pages

--- a/templates/indieauth-authorize-form.php
+++ b/templates/indieauth-authorize-form.php
@@ -49,6 +49,11 @@ login_header(
 		<input type="hidden" name="state" value="<?php echo $state; ?>" />
 		<input type="hidden" name="me" value="<?php echo $me; ?>" />
 		<input type="hidden" name="response_type" value="<?php echo $response_type; ?>" />
+
+		<?php if ( ! is_null( $code_challenge ) ) { ?>
+			<input type="hidden" name="code_challenge" value="<?php echo $code_challenge; ?>" />
+			<input type="hidden" name="code_challenge_method" value="<?php echo $code_challenge_method; ?>" />
+		<?php } ?>
 		<button name="wp-submit" value="authorize" class="button button-primary button-large"><?php _e( 'Authorize', 'indieauth' ); ?></button>
 		<a name="wp-submit" value="cancel" class="button button-large" href="<?php echo home_url(); ?>"><?php _e( 'Cancel', 'indieauth' ); ?></a>
 	</p>


### PR DESCRIPTION
This is a first pass at adding PKCE Support. Also switches all code and token generate to SHA256 from the default WordPress salted MD5. It also bumps the minimum PHP version to 5.4.

Looking to see if this appears to be implemented correctly as this is my first time trying this.