### PR TITLE
Add setting for site URL user

### DIFF
--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -170,6 +170,16 @@ class IndieAuth_Admin {
 				'default'      => 0,
 			)
 		);
+		register_setting(
+			'indieauth',
+			'indieauth_root_user',
+			array(
+				'type'         => 'int',
+				'description'  => __( 'User Who is Represented by the Site URL', 'indieauth' ),
+				'show_in_rest' => true,
+				'default'      => get_option( 'iw_default_author', 0 ),
+			)
+		);
 	}
 
 	public function admin_init() {
@@ -180,7 +190,7 @@ class IndieAuth_Admin {
 	 * Add IndieAuth options to the WordPress general settings page.
 	 */
 	public function general_settings() {
-		if ( class_exists( 'Indieweb_Plugin' ) ) {
+		if ( class_exists( 'IndieWeb_Plugin' ) ) {
 			$path = 'admin.php?page=indieauth';
 		} else {
 			$path = 'options-general.php?page=indieauth';

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -178,9 +178,9 @@ if ( ! function_exists( 'get_user_by_identifier' ) ) {
 		}
 		// Try to save the expense of a search query if the URL is the site URL
 		if ( home_url( '/' ) === $identifier ) {
-			// Use the Indieweb settings to set the default author
-			if ( class_exists( 'Indieweb_Plugin' ) && get_option( 'iw_single_author' ) ) {
-				return get_user_by( 'id', get_option( 'iw_default_author' ) );
+			// Use the settings to set the root user
+			if ( 0 !== (int) get_option( 'indieauth_root_user' ) ) {
+				return get_user_by( 'id', (int) get_option( 'indieauth_root_user' ) );
 			}
 			$author = get_single_author();
 			//  If there is only a single author then they will get the root url
@@ -221,10 +221,8 @@ if ( ! function_exists( 'get_user_by_identifier' ) ) {
  */
 if ( ! function_exists( 'get_url_from_user' ) ) {
 	function get_url_from_user( $user_id ) {
-		if ( class_exists( 'Indieweb_Plugin' ) && get_option( 'iw_single_author' ) ) {
-			if ( get_option( 'iw_default_author' ) === $user_id ) {
-				return home_url( '/' );
-			}
+		if ( (int) get_option( 'indieauth_root_user' ) === $user_id ) {
+			return home_url( '/' );
 		}
 		$user = get_user_by( 'ID', $user_id );
 		return get_author_posts_url( $user_id );

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 3.4.0
+ * Version: 3.4.1
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 3.4.0\n"
+"Project-Id-Version: IndieAuth 3.4.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2019-07-14 18:16:43+00:00\n"
+"POT-Creation-Date: 2019-08-03 03:59:19+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -34,7 +34,7 @@ msgstr ""
 msgid "IndieAuth Test"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:52
+#: includes/class-indieauth-admin.php:47
 msgid "Authorization Header Passed"
 msgstr ""
 
@@ -42,67 +42,71 @@ msgstr ""
 msgid "IndieAuth"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:60
+#: includes/class-indieauth-admin.php:55
 msgid ""
 "Your hosting provider allows authorization headers to pass so IndieAuth "
 "should work"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:68
+#: includes/class-indieauth-admin.php:63
 msgid "Authorization Test Failed"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:71
+#: includes/class-indieauth-admin.php:66
 msgid ""
 "Authorization Headers are being blocked by your hosting provider. This will "
 "cause IndieAuth to fail."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:73
+#: includes/class-indieauth-admin.php:68
 msgid "Visit the Settings page for guidance on how to resolve."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:83
+#: includes/class-indieauth-admin.php:78 templates/indieauth-settings.php:68
 msgid "None"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:92
+#: includes/class-indieauth-admin.php:87
 msgid "Website"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:140
+#: includes/class-indieauth-admin.php:135
 msgid "Authorization Header Found. You should be able to use all clients."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:143
+#: includes/class-indieauth-admin.php:138
 msgid "Alternate Header Found. You should be able to use all clients."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:173
+#: includes/class-indieauth-admin.php:168
 msgid "Offer IndieAuth on Login Form"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:181 templates/indieauth-settings.php:2
+#: includes/class-indieauth-admin.php:178
+msgid "User Who is Represented by the Site URL"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:186 templates/indieauth-settings.php:2
 msgid "IndieAuth Settings"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:194
+#: includes/class-indieauth-admin.php:199
 msgid ""
 "Based on your feedback and to improve the user experience, we decided to "
 "move the settings to a separate <a href=\"%1$s\">settings-page</a>."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:267
+#: includes/class-indieauth-admin.php:272
 msgid "Overview"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:269
+#: includes/class-indieauth-admin.php:274
 msgid ""
 "IndieAuth is a way for doing Web sign-in, where you use your own homepage "
 "to sign in to other places."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:270
+#: includes/class-indieauth-admin.php:275
 msgid ""
 "IndieAuth was built on ideas and technology from existing proven "
 "technologies like OAuth and OpenID but aims at making it easier for users "
@@ -110,19 +114,19 @@ msgid ""
 "completely separate implementations and services can be used for each part."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:277
+#: includes/class-indieauth-admin.php:282
 msgid "The IndieWeb"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:279
+#: includes/class-indieauth-admin.php:284
 msgid "The IndieWeb is a people-focused alternative to the \"corporate web\"."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:281
+#: includes/class-indieauth-admin.php:286
 msgid "Your content is yours"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:282
+#: includes/class-indieauth-admin.php:287
 msgid ""
 "When you post something on the web, it should belong to you, not a "
 "corporation. Too many companies have gone out of business and lost all of "
@@ -130,41 +134,41 @@ msgid ""
 "your control."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:285
+#: includes/class-indieauth-admin.php:290
 msgid "You are better connected"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:286
+#: includes/class-indieauth-admin.php:291
 msgid ""
 "Your articles and status messages can go to all services, not just one, "
 "allowing you to engage with everyone. Even replies and likes on other "
 "services can come back to your site so they’re all in one place."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:289
+#: includes/class-indieauth-admin.php:294
 msgid "You are in control"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:290
+#: includes/class-indieauth-admin.php:295
 msgid ""
 "You can post anything you want, in any format you want, with no one "
 "monitoring you. In addition, you share simple readable links such as "
 "example.com/ideas. These links are permanent and will always work."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:296
+#: includes/class-indieauth-admin.php:301
 msgid "For more information:"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:297
+#: includes/class-indieauth-admin.php:302
 msgid "<a href=\"https://indieweb.org/IndieAuth\">IndieWeb Wiki page</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:298
+#: includes/class-indieauth-admin.php:303
 msgid "<a href=\"https://indieauth.rocks/\">Test suite</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:299
+#: includes/class-indieauth-admin.php:304
 msgid "<a href=\"https://www.w3.org/TR/indieauth/\">W3C Spec</a>"
 msgstr ""
 
@@ -633,6 +637,14 @@ msgstr ""
 
 #: templates/indieauth-settings.php:57
 msgid "Add a link to the login form to authenticate using an IndieAuth endpoint."
+msgstr ""
+
+#: templates/indieauth-settings.php:62
+msgid "Set User to Represent Site URL"
+msgstr ""
+
+#: templates/indieauth-settings.php:75
+msgid "Set a User who will represent the URL of the site"
 msgstr ""
 
 #: templates/websignin-form.php:4

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.4  
 **Tested up to:** 5.2.2  
-**Stable tag:** 3.4.0  
+**Stable tag:** 3.4.1  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -53,9 +53,10 @@ This plugin only supports searching an external site for an authorization endpoi
 
 As of version 3.2, the endpoints return the display name, avatar, and URL from your user profile.
 
-### Does this require users to have their own domain name? ###
+### Does this require each user to have their own unique domain name? ###
 
-No. You can use your author profile URL to login if you do not have a domain name. However how the Indieauth server authenticates you depends on that server.
+No. When you provide the URL of the WordPress site and authenticate to WordPress, it will return the URL of your author profile as your unique URL. Only one user may use the URL of the site itself.
+This setting is set in the plugin settings page, or if there is only a single user, it will default to them.
 
 ### How do I authenticate myself to an Indieauth server? ###
 
@@ -141,6 +142,9 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 3.4.1 ###
+* Add setting to set the user who will be using the site URL as their URL as opposed to their author URL which removes dependency on Indieweb plugin for this.
 
 ### 3.4.0 ###
 * Enforce unique URLs for user accounts

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.4
 Tested up to: 5.2.2
-Stable tag: 3.4.0
+Stable tag: 3.4.1
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -53,9 +53,10 @@ This plugin only supports searching an external site for an authorization endpoi
 
 As of version 3.2, the endpoints return the display name, avatar, and URL from your user profile.
 
-= Does this require users to have their own domain name? =
+= Does this require each user to have their own unique domain name? =
 
-No. You can use your author profile URL to login if you do not have a domain name. However how the Indieauth server authenticates you depends on that server.
+No. When you provide the URL of the WordPress site and authenticate to WordPress, it will return the URL of your author profile as your unique URL. Only one user may use the URL of the site itself.
+This setting is set in the plugin settings page, or if there is only a single user, it will default to them.
 
 = How do I authenticate myself to an Indieauth server? =
 
@@ -141,6 +142,9 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 3.4.1 =
+* Add setting to set the user who will be using the site URL as their URL as opposed to their author URL which removes dependency on Indieweb plugin for this.
 
 = 3.4.0 =
 * Enforce unique URLs for user accounts

--- a/templates/indieauth-settings.php
+++ b/templates/indieauth-settings.php
@@ -57,6 +57,25 @@ if ( $message ) {
 							<?php _e( 'Add a link to the login form to authenticate using an IndieAuth endpoint.', 'indieauth' ); ?>
 						</label>
 					</td>
+				<tr>
+					<th>
+						<?php _e( 'Set User to Represent Site URL', 'indieauth' ); ?>
+					</th>
+					<td>
+						<label for="indieauth_root_user">
+							<?php wp_dropdown_users(
+								array(
+									'show_option_all' => __( 'None', 'indieauth' ),
+									'name' => 'indieauth_root_user',
+									'id' => 'indieauth_root_user',
+									'show' => 'display_name_with_login',
+									'selected' => get_option( 'indieauth_root_user' )
+								)
+							); ?>
+							<?php _e( 'Set a User who will represent the URL of the site', 'indieauth' ); ?>
+						</label>
+					</td>
+				</tr>
 				</tr>
 			</tbody>
 		</table>


### PR DESCRIPTION
The recent changes to the plugin exposed a problem with using the Indieweb plugin's single author setting. So this plugin now has a setting for deciding who gets to use the site's URL, removing the dependency. It still, if no value is set, wil use the Indieweb plugin value or if there is only one user, that user. But this is much more reliable.