### PR TITLE
Split Authorize Class 

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
 	exit 1
 fi
 
@@ -10,9 +10,12 @@ DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
 WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
 
-WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 
 download() {
     if [ `which curl` ]; then
@@ -22,8 +25,19 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
-	WP_TESTS_TAG="tags/$WP_VERSION"
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
 elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 	WP_TESTS_TAG="trunk"
 else
@@ -37,7 +51,6 @@ else
 	fi
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
-
 set -ex
 
 install_wp() {
@@ -49,18 +62,34 @@ install_wp() {
 	mkdir -p $WP_CORE_DIR
 
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-		mkdir -p /tmp/wordpress-nightly
-		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
-		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
-		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+		mkdir -p $TMPDIR/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  $TMPDIR/wordpress-nightly/wordpress-nightly.zip
+		unzip -q $TMPDIR/wordpress-nightly/wordpress-nightly.zip -d $TMPDIR/wordpress-nightly/
+		mv $TMPDIR/wordpress-nightly/wordpress/* $WP_CORE_DIR
 	else
 		if [ $WP_VERSION == 'latest' ]; then
 			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
 		else
 			local ARCHIVE_NAME="wordpress-$WP_VERSION"
 		fi
-		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
-		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
 	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
@@ -69,7 +98,7 @@ install_wp() {
 install_test_suite() {
 	# portable in-place argument for both GNU sed and Mac OSX sed
 	if [[ $(uname -s) == 'Darwin' ]]; then
-		local ioption='-i .bak'
+		local ioption='-i.bak'
 	else
 		local ioption='-i'
 	fi
@@ -79,13 +108,14 @@ install_test_suite() {
 		# set up testing suite
 		mkdir -p $WP_TESTS_DIR
 		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
-
-	cd $WP_TESTS_DIR
 
 	if [ ! -f wp-tests-config.php ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
@@ -95,6 +125,11 @@ install_test_suite() {
 }
 
 install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
 	# parse DB_HOST for port or socket references
 	local PARTS=(${DB_HOST//\:/ })
 	local DB_HOSTNAME=${PARTS[0]};

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Authorize class
+ * Helper functions for extracting tokens from the WP-API team Oauth2 plugin
+ */
+class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
+
+
+	public function __construct() {
+		$this->load();
+	}
+
+	public function get_authorization_endpoint() {
+		return rest_url( '/indieauth/1.0/auth' );
+	}
+
+	public function get_token_endpoint() {
+		return rest_url( '/indieauth/1.0/token' );
+	}
+
+
+	public function verify_access_token( $token ) {
+		$tokens = new Token_User( '_indieauth_token_' );
+		$return = $tokens->get( $token );
+		if ( ! $return ) {
+			return new WP_OAuth_Response(
+				'invalid_token',
+				__( 'Invalid access token', 'indieauth' ),
+				401
+			);
+		}
+		if ( is_oauth_error( $return ) ) {
+			return $return;
+		}
+		$return['last_accessed'] = time();
+		$tokens->update( $token, $return );
+		return $return;
+	}
+
+	public static function verify_authorization_code( $code ) {
+		$tokens = new Token_User( '_indieauth_code_' );
+		$return = $tokens->get( $code );
+		if ( ! $return ) {
+			return new WP_OAuth_Response(
+				'invalid_code',
+				__( 'Invalid authorization code', 'indieauth' ),
+				401
+			);
+		}
+		// Once the code is verified destroy it
+		$tokens->destroy( $code );
+		return $return;
+	}
+
+}
+
+new IndieAuth_Local_Authorize();

--- a/includes/class-oauth-response.php
+++ b/includes/class-oauth-response.php
@@ -69,3 +69,16 @@ function get_oauth_error( $obj ) {
 function is_oauth_error( $obj ) {
 	return ( $obj instanceof WP_OAuth_Response );
 }
+
+
+function wp_error_to_oauth_response( $error ) {
+	if ( is_wp_error( $error ) ) {
+		$data   = $error->get_error_data();
+		$status = isset( $data['status'] ) ? $data['status'] : 200;
+		if ( is_array( $data ) ) {
+			unset( $data['status'] );
+		}
+		return new WP_OAuth_Response( $error->get_error_code(), $error->get_error_message(), $status, $data );
+	}
+	return null;
+}

--- a/indieauth.php
+++ b/indieauth.php
@@ -32,6 +32,7 @@ class IndieAuth_Plugin {
 
 		// Indieauth Authorize Functions
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-indieauth-authorize.php';
+		require_once plugin_dir_path( __FILE__ ) . 'includes/class-indieauth-local-authorize.php';
 
 		// Web Sign-In
 		require_once plugin_dir_path( __FILE__ ) . 'includes/class-web-signin.php';

--- a/tests/test-authenticate.php
+++ b/tests/test-authenticate.php
@@ -46,7 +46,7 @@ class AuthenticateTest extends WP_UnitTestCase {
 		$token = self::set_token();
 		$_REQUEST['micropub']       = 'endpoint';
 		$_REQUEST['access_token'] = $token;
-		$authorize = new Indieauth_Authorize();
+		$authorize = new Indieauth_Local_Authorize();
 		$user_id = $authorize->determine_current_user( 0 );
 		$this->assertEquals( $user_id, self::$author_id );
 	}


### PR DESCRIPTION
This splits the authorize class into two pieces. One is the local version, the other is the universal bits. The purpose for this is to allow for an alternative class that would use a remote endpoint instead of the local one. Also improved the documentation for the functions.