### PR TITLE
Restore Remote Capability

### DIFF
--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -14,7 +14,7 @@ class IndieAuth_Admin {
 		add_filter( 'wp_pre_insert_user_data', array( $this, 'unique_user_url' ), 10, 3 );
 		add_filter( 'manage_users_columns', array( $this, 'add_user_url_column' ) );
 		add_filter( 'manage_users_custom_column', array( $this, 'user_url_column' ), 10, 3 );
-		add_filter( 'site_status_tests', array( $this, 'add_indieauth_test' ) );
+		add_filter( 'site_status_tests', array( $this, 'add_indieauth_tests' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 	}
 
@@ -34,15 +34,49 @@ class IndieAuth_Admin {
 		}
 	}
 
-	public function add_indieauth_test( $tests ) {
-		$tests['direct']['indieauth_plugin'] = array(
+	public function add_indieauth_tests( $tests ) {
+		$tests['direct']['indieauth_header'] = array(
 			'label' => __( 'IndieAuth Test', 'indieauth' ),
-			'test'  => array( $this, 'site_health_test' ),
+			'test'  => array( $this, 'site_health_header_test' ),
+		);
+		$tests['direct']['indieauth_https']  = array(
+			'label' => __( 'SSL Test', 'indieauth' ),
+			'test'  => array( $this, 'site_health_https_test' ),
 		);
 		return $tests;
 	}
 
-	public function site_health_test() {
+
+	public function site_health_https_test() {
+		$result = array(
+			'label'       => __( 'HTTPS Check Passed', 'indieauth' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'IndieAuth', 'indieauth' ),
+				'color' => 'green',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				__( 'You are using HTTPS and IndieAuth will be secure', 'indieauth' )
+			),
+			'actions'     => '',
+			'test'        => 'indieauth_headers',
+		);
+
+		if ( ! is_ssl() ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'HTTPS Test Failed', 'indieauth' );
+			$result['description'] = sprintf(
+				'<p>%s</p>',
+				__( 'You are not serving your site via HTTPS. This is a security risk if running IndieAuth.', 'indieauth' )
+			);
+			$result['actions']     = __( 'We recommend you acquire an SSL Certificate. You can do this for free through Lets Encrypt', 'indieauth' );
+		}
+
+		return $result;
+	}
+
+	public function site_health_header_test() {
 		$result = array(
 			'label'       => __( 'Authorization Header Passed', 'indieauth' ),
 			'status'      => 'good',

--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -145,7 +145,7 @@ class IndieAuth_Admin {
 				$data['user_url'] = '';
 			}
 		}
-			return $data;
+		return $data;
 	}
 
 	public function check_dupe_user_urls() {

--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -196,6 +196,16 @@ class IndieAuth_Admin {
 	public function settings() {
 		register_setting(
 			'indieauth',
+			'indieauth_config',
+			array(
+				'type'         => 'string',
+				'description'  => __( 'Configuration option for IndieAuth Plugin', 'indieauth' ),
+				'show_in_rest' => true,
+				'default'      => 'local',
+			)
+		);
+		register_setting(
+			'indieauth',
 			'indieauth_show_login_form',
 			array(
 				'type'         => 'boolean',

--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -15,23 +15,6 @@ class IndieAuth_Admin {
 		add_filter( 'manage_users_columns', array( $this, 'add_user_url_column' ) );
 		add_filter( 'manage_users_custom_column', array( $this, 'user_url_column' ), 10, 3 );
 		add_filter( 'site_status_tests', array( $this, 'add_indieauth_tests' ) );
-		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
-	}
-
-
-	public function admin_notices() {
-		if ( ! get_option( 'indieauth_header_check', 0 ) ) {
-			echo '<div class="notice notice-warning"><p>';
-			esc_html_e( 'In order to ensure IndieAuth tokens will work please visit the settings page to check:', 'indieauth' );
-			printf( ' <a href="%1s">%2$s</a>', esc_url( menu_page_url( 'indieauth', false ) ), esc_html__( 'Visit Settings Page', 'indieauth' ) );
-			echo '</p></div>';
-		}
-		$screen = get_current_screen();
-		if ( ( 'users' === $screen->id ) && $this->check_dupe_user_urls() ) {
-			echo '<div class="notice notice-error"><p>';
-			esc_html_e( 'Multiple user accounts have the same URL set. This is not permitted as this value is used by IndieAuth for login. Please resolve', 'indieauth' );
-			echo '</p></div>';
-		}
 	}
 
 	public function add_indieauth_tests( $tests ) {
@@ -42,6 +25,10 @@ class IndieAuth_Admin {
 		$tests['direct']['indieauth_https']  = array(
 			'label' => __( 'SSL Test', 'indieauth' ),
 			'test'  => array( $this, 'site_health_https_test' ),
+		);
+		$tests['direct']['indieauth_users']  = array(
+			'label' => __( 'Unique User URL Test', 'indieauth' ),
+			'test'  => array( $this, 'site_health_users_test' ),
 		);
 		return $tests;
 	}
@@ -76,6 +63,34 @@ class IndieAuth_Admin {
 		return $result;
 	}
 
+	public function site_health_users_test() {
+		$result = array(
+			'label'       => __( 'Unique User URLs Check Passed', 'indieauth' ),
+			'status'      => 'good',
+			'badge'       => array(
+				'label' => __( 'IndieAuth', 'indieauth' ),
+				'color' => 'green',
+			),
+			'description' => sprintf(
+				'<p>%s</p>',
+				__( 'You are using HTTPS and IndieAuth will be secure', 'indieauth' )
+			),
+			'actions'     => '',
+			'test'        => 'indieauth_headers',
+		);
+
+		if ( $this->check_dupe_user_urls() ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'Unique User URLs Test Failed', 'indieauth' );
+			$result['description'] = sprintf(
+				'<p>%s</p>',
+				__( 'Multiple user accounts have the same URL set. This is not permitted as this value is used by IndieAuth for login. Please resolve', 'indieauth' )
+			);
+			$result['actions']     = __( 'Under IndieAuth, your URL is your identity. Two accounts cannot have the same website URL in their user profile as this might allow one user to gain the credentials of another', 'indieauth' );
+		}
+		return $result;
+	}
+
 	public function site_health_header_test() {
 		$result = array(
 			'label'       => __( 'Authorization Header Passed', 'indieauth' ),
@@ -93,13 +108,13 @@ class IndieAuth_Admin {
 		);
 
 		if ( ! self::test_auth() ) {
-			$result['status']      = 'critical';
-			$result['label']       = __( 'Authorization Test Failed', 'indieauth' );
-			$result['description'] = sprintf(
-				'<p>%s</p>',
-				__( 'Authorization Headers are being blocked by your hosting provider. This will cause IndieAuth to fail.', 'indieauth' )
-			);
-			$result['actions']     = sprintf( '<a href="%1$s" >%2$s</a>', menu_page_url( 'indieauth', false ), __( 'Visit the Settings page for guidance on how to resolve.', 'indieauth' ) );
+			$result['status'] = 'critical';
+			$result['label']  = __( 'Authorization Test Failed', 'indieauth' );
+			ob_start();
+			include plugin_dir_path( __DIR__ ) . 'templates/authdiagfail.php';
+			$result['description'] = ob_get_contents();
+			ob_end_clean();
+			$result['actions'] = sprintf( '<a href="%1$s" >%2$s</a>', 'https://github.com/indieweb/wordpress-indieauth/issues', __( 'If contacting your hosting provider does not work you can open an issue on GitHub and we will try to assist', 'indieauth' ) );
 		}
 
 		return $result;
@@ -167,10 +182,8 @@ class IndieAuth_Admin {
 		if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
 			if ( ! empty( $_SERVER['HTTP_AUTHORIZATION'] ) && 'Bearer abc123' === $_SERVER['HTTP_AUTHORIZATION'] ) {
 				$return = '<div class="notice notice-success"><p>' . esc_html__( 'Authorization Header Found. You should be able to use all clients.', 'indieauth' ) . '</p></div>';
-				update_option( 'indieauth_header_check', 1 );
 			} elseif ( ! empty( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) && 'Bearer abc123' === $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) {
 				$return = '<div class="notice-success"><p>' . esc_html__( 'Alternate Header Found. You should be able to use all clients.', 'indieauth' ) . '</p></div>';
-				update_option( 'indieauth_header_check', 1 );
 			}
 			if ( empty( $return ) ) {
 				ob_start();

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -46,12 +46,17 @@ abstract class IndieAuth_Authorize {
 	 * @return WP_REST_Response Response object with endpoint info added
 	 **/
 	public function register_index( WP_REST_Response $response ) {
-		$data                                = $response->get_data();
+		$data      = $response->get_data();
+		$endpoints = array(
+			'authorization' => $this->get_authorization_endpoint(),
+			'token'         => $this->get_token_endpoint(),
+		);
+		$endpoints = array_filter( $endpoints );
+		if ( empty( $endpoints ) ) {
+			return $response;
+		}
 		$data['authentication']['indieauth'] = array(
-			'endpoints' => array(
-				'authorization' => $this->get_authorization_endpoint(),
-				'token'         => $this->get_token_endpoint(),
-			),
+			'endpoints' => $endpoints,
 		);
 		$response->set_data( $data );
 		return $response;
@@ -66,18 +71,27 @@ abstract class IndieAuth_Authorize {
 	}
 
 	public function http_header() {
+		$auth  = static::get_authorization_endpoint();
+		$token = static::get_token_endpoint();
+		if ( empty( $auth ) || empty( $token ) ) {
+			return;
+		}
 		if ( is_author() || is_front_page() ) {
 			header( sprintf( 'Link: <%s>; rel="authorization_endpoint"', static::get_authorization_endpoint(), false ) );
 			header( sprintf( 'Link: <%s>; rel="token_endpoint"', static::get_token_endpoint(), false ) );
 		}
 	}
 	public static function html_header() {
+		$auth  = static::get_authorization_endpoint();
+		$token = static::get_token_endpoint();
+		if ( empty( $auth ) || empty( $token ) ) {
+			return;
+		}
 		if ( is_author() || is_front_page() ) {
-			printf( '<link rel="authorization_endpoint" href="%s" />' . PHP_EOL, static::get_authorization_endpoint() ); // phpcs:ignore
-			printf( '<link rel="token_endpoint" href="%s" />' . PHP_EOL, static::get_token_endpoint() ); //phpcs:ignore
+			printf( '<link rel="authorization_endpoint" href="%s" />' . PHP_EOL, $auth ); // phpcs:ignore
+			printf( '<link rel="token_endpoint" href="%s" />' . PHP_EOL, $token ); //phpcs:ignore
 		}
 	}
-
 
 	/**
 	 * Report our errors, if we have any.

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -29,14 +29,14 @@ abstract class IndieAuth_Authorize {
 	 *
 	 * @return string Authorization Endpoint.
 	 **/
-	abstract public function get_authorization_endpoint();
+	abstract public static function get_authorization_endpoint();
 
 	/**
 	 * Returns the URL for the token endpoint.
 	 *
 	 * @return string Token Endpoint.
 	 **/
-	abstract public function get_token_endpoint();
+	abstract public static function get_token_endpoint();
 
 	/**
 	 * Add authentication information into the REST API Index
@@ -67,14 +67,14 @@ abstract class IndieAuth_Authorize {
 
 	public function http_header() {
 		if ( is_author() || is_front_page() ) {
-			header( sprintf( 'Link: <%s>; rel="authorization_endpoint"', $this->get_authorization_endpoint(), false ) );
-			header( sprintf( 'Link: <%s>; rel="token_endpoint"', $this->get_token_endpoint(), false ) );
+			header( sprintf( 'Link: <%s>; rel="authorization_endpoint"', static::get_authorization_endpoint(), false ) );
+			header( sprintf( 'Link: <%s>; rel="token_endpoint"', static::get_token_endpoint(), false ) );
 		}
 	}
 	public static function html_header() {
 		if ( is_author() || is_front_page() ) {
-			printf( '<link rel="authorization_endpoint" href="%s" />' . PHP_EOL, $this->get_authorization_endpoint() ); // phpcs:ignore
-			printf( '<link rel="token_endpoint" href="%s" />' . PHP_EOL, $this->get_token_endpoint() ); //phpcs:ignore
+			printf( '<link rel="authorization_endpoint" href="%s" />' . PHP_EOL, static::get_authorization_endpoint() ); // phpcs:ignore
+			printf( '<link rel="token_endpoint" href="%s" />' . PHP_EOL, static::get_token_endpoint() ); //phpcs:ignore
 		}
 	}
 

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -112,13 +112,13 @@ abstract class IndieAuth_Authorize {
 	public function determine_current_user( $user_id ) {
 		$token = $this->get_provided_token();
 		// If there is not a token that means this is not an attempt to log in using IndieAuth
-		if ( ! $token ) {
+		if ( ! isset( $token ) ) {
 			return $user_id;
 		}
 		// If there is a token and it is invalid then reject all logins
 
 		$params = $this->verify_access_token( $token );
-		if ( ! $params ) {
+		if ( ! isset( $params ) ) {
 			return 0;
 		}
 		if ( is_oauth_error( $params ) ) {
@@ -202,14 +202,14 @@ abstract class IndieAuth_Authorize {
 	 */
 	public function get_provided_token() {
 		$header = $this->get_authorization_header();
-		if ( $header ) {
+		if ( isset( $header ) ) {
 			$token = $this->get_token_from_bearer_header( $header );
-			if ( $token ) {
+			if ( isset( $token ) ) {
 				return $token;
 			}
 		}
 		$token = $this->get_token_from_request();
-		if ( $token ) {
+		if ( isset( $token ) ) {
 			return $token;
 		}
 		return null;

--- a/includes/class-indieauth-client-discovery.php
+++ b/includes/class-indieauth-client-discovery.php
@@ -18,7 +18,10 @@ class IndieAuth_Client_Discovery {
 			$this->manifest = self::get_manifest( $this->html['manifest'] );
 		}
 		$this->client_icon = $this->determine_icon();
-		$this->client_name = $this->ifset( $this->manifest, 'name' ) ?: $this->ifset( $this->html, 'application-name' ) ?: $this->ifset( $this->html, 'og:title' ) ?: $this->ifset( $this->html, 'title' ) ?: '';
+		$this->client_name = $this->ifset( $this->manifest, 'name', '' );
+		if ( empty( $this->client_name ) ) {
+			$this->client_name = $this->ifset( $this->html, array( 'application-name', 'og:title', 'title' ), '' );
+		}
 	}
 
 	private function fetch( $url ) {
@@ -60,10 +63,18 @@ class IndieAuth_Client_Discovery {
 	}
 
 	private function ifset( $array, $key, $default = false ) {
-		if ( is_array( $array ) ) {
+		if ( ! is_array( $array ) ) {
+			return $defaul;
+		}
+		if ( is_array( $key ) ) {
+			foreach ( $key as $k ) {
+				if ( isset( $array[ $k ] ) ) {
+					return $array[ $k ];
+				}
+			}
+		} else {
 			return isset( $array[ $key ] ) ? $array[ $key ] : $default;
 		}
-			return $default;
 	}
 
 	public function get_name() {

--- a/includes/class-indieauth-client-discovery.php
+++ b/includes/class-indieauth-client-discovery.php
@@ -64,7 +64,7 @@ class IndieAuth_Client_Discovery {
 
 	private function ifset( $array, $key, $default = false ) {
 		if ( ! is_array( $array ) ) {
-			return $defaul;
+			return $default;
 		}
 		if ( is_array( $key ) ) {
 			foreach ( $key as $k ) {

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -13,11 +13,11 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 		$this->load();
 	}
 
-	public function get_authorization_endpoint() {
+	public static function get_authorization_endpoint() {
 		return rest_url( '/indieauth/1.0/auth' );
 	}
 
-	public function get_token_endpoint() {
+	public static function get_token_endpoint() {
 		return rest_url( '/indieauth/1.0/token' );
 	}
 

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -24,7 +24,7 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 	public function verify_access_token( $token ) {
 		$tokens = new Token_User( '_indieauth_token_' );
 		$return = $tokens->get( $token );
-		if ( empty( $return ) ) ) {
+		if ( empty( $return ) ) {
 			return new WP_OAuth_Response(
 				'invalid_token',
 				__( 'Invalid access token', 'indieauth' ),

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -7,7 +7,7 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 
 
 	public function __construct( $load = true ) {
-		if( true === $load ) {
+		if ( true === $load ) {
 			$this->load();
 		}
 	}

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -6,7 +6,10 @@
 class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 
 
-	public function __construct() {
+	public function __construct( $load = true ) {
+		if ( ! $load ) {
+			return;
+		}
 		$this->load();
 	}
 
@@ -54,4 +57,3 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 
 }
 
-new IndieAuth_Local_Authorize();

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -7,10 +7,9 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 
 
 	public function __construct( $load = true ) {
-		if ( ! $load ) {
-			return;
+		if( true === $load ) {
+			$this->load();
 		}
-		$this->load();
 	}
 
 	public static function get_authorization_endpoint() {
@@ -25,7 +24,7 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 	public function verify_access_token( $token ) {
 		$tokens = new Token_User( '_indieauth_token_' );
 		$return = $tokens->get( $token );
-		if ( ! $return ) {
+		if ( empty( $return ) ) ) {
 			return new WP_OAuth_Response(
 				'invalid_token',
 				__( 'Invalid access token', 'indieauth' ),
@@ -43,7 +42,7 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 	public static function verify_authorization_code( $code ) {
 		$tokens = new Token_User( '_indieauth_code_' );
 		$return = $tokens->get( $code );
-		if ( ! $return ) {
+		if ( empty( $return ) ) {
 			return new WP_OAuth_Response(
 				'invalid_code',
 				__( 'Invalid authorization code', 'indieauth' ),

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Micropub IndieAuth Authorization Class
+ */
+class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
+
+
+	public function __construct( $load = true ) {
+		$this->register_settings();
+		// Load the hooks for this class only if true. This allows for debugging of the functions
+		if ( ! $load ) {
+			return;
+		}
+		add_action( 'admin_init', array( get_called_class(), 'admin_init' ) );
+		$this->load();
+	}
+
+	public function register_settings() {
+		// Register Setting
+		register_setting(
+			'indieauth',
+			'indieauth_authorization_endpoint', // Setting Name
+			array(
+				'type'              => 'string',
+				'description'       => 'IndieAuth Authorization Endpoint',
+				'sanitize_callback' => 'esc_url',
+				'show_in_rest'      => true,
+			)
+		);
+		// Register Setting
+		register_setting(
+			'indieauth',
+			'indieauth_token_endpoint', // Setting Name
+			array(
+				'type'              => 'string',
+				'description'       => 'IndieAuth Token Endpoint',
+				'sanitize_callback' => 'esc_url',
+				'show_in_rest'      => true,
+			)
+		);
+
+	}
+
+	public static function admin_init() {
+		$cls  = get_called_class();
+		$page = 'indieauth';
+				add_settings_section(
+					'indieauth',
+					'Remote IndieAuth Endpoint Settings',
+					array( $cls, 'auth_settings' ),
+					$page
+				);
+				add_settings_field(
+					'indieauth_authorization_endpoint',
+					__( 'Authorization Endpoint', 'indieauth' ),
+					array( $cls, 'endpoint_field' ),
+					$page,
+					'indieauth',
+					array(
+						'label_for' => 'indieauth_authorization_endpoint',
+						'class'     => 'widefat',
+						'default'   => 'https://indieauth.com/auth',
+					)
+				);
+				add_settings_field(
+					'indieauth_token_endpoint',
+					__( 'Token Endpoint', 'indieauth' ),
+					array( $cls, 'endpoint_field' ),
+					$page,
+					'indieauth',
+					array(
+						'label_for' => 'indieauth_token_endpoint',
+						'class'     => 'widefat',
+						'default'   => 'https://tokens.indieauth.com/token',
+					)
+				);
+	}
+
+	public static function endpoint_field( $args ) {
+			printf( '<label for="%1$s"><input id="%1$s" name="%1$s" type="url" value="%2$s" placeholder="%3$s" />', esc_attr( $args['label_for'] ), esc_url( get_option( $args['label_for'], $args['default'] ) ), esc_url( $args['default'] ) );
+	}
+
+	public static function auth_settings() {
+			_e( 'Please specify a remote indieauth authorization and token endpoint.', 'indieauth' );
+	}
+
+	public function get_authorization_endpoint() {
+		return get_option( 'indieauth_authorization_endpoint', 'https://indieauth.com/auth' );
+	}
+
+	public function get_token_endpoint() {
+		return get_option( 'indieauth_token_endpoint', 'https://tokens.indieauth.com/token' );
+	}
+
+	public function verify_access_token( $token ) {
+		$resp = wp_remote_get(
+			$this->get_token_endpoint(),
+			array(
+				'headers' => array(
+					'Accept'        => 'application/json',
+					'Authorization' => 'Bearer ' . $token,
+				),
+			)
+		);
+		if ( is_wp_error( $resp ) ) {
+			return $resp;
+		}
+
+		$code   = (int) wp_remote_retrieve_response_code( $resp );
+		$body   = wp_remote_retrieve_body( $resp );
+		$params = json_decode( $body, true );
+
+		if ( ( $code / 100 ) !== 2 ) {
+			return new WP_OAuth_Response( 'invalid_request', 'invalid access token', 403 );
+		}
+
+		// look for a user with the same url as the token's `me` value.
+		$user = get_user_by_identifier( $params['me'] );
+		if ( $user instanceof WP_User ) {
+			$params['user'] = $user->ID;
+		} else {
+			return new WP_OAuth_Response( 'unauthorized', __( 'Unable to Find User', 'indieauth' ), 401 );
+		}
+		return $params;
+	}
+
+	public static function verify_authorization_code( $code ) {
+		$args  = array(
+			'headers' => array(
+				'Accept' => 'application/json',
+			),
+		);
+		$query = build_query(
+			array(
+				'code'         => rawurlencode( $code ),
+				'redirect_uri' => wp_login_url( $redirect_uri ),
+				'client_id'    => home_url(),
+			)
+		);
+		$resp  = wp_safe_remote_post( static::get_authorization_endpoint() . '?' . $query, $args );
+		if ( is_wp_error( $resp ) ) {
+			return wp_error_to_oauth_response( $resp );
+		}
+		$code   = wp_remote_retrieve_response_code( $resp );
+		$body   = wp_remote_retrieve_body( $resp );
+		$params = json_decode( $response, true );
+
+		// check if response was json or not
+		if ( ! is_array( $response ) ) {
+			return new WP_OAuth_Response( 'indieauth_response_error', __( 'IndieAuth.com seems to have some hiccups, please try it again later.', 'indieauth' ), 401 );
+		}
+
+		if ( 2 === (int) ( $code / 100 ) && isset( $body['me'] ) ) {
+			return $body;
+		}
+		if ( array_key_exists( 'error', $response ) ) {
+			return new WP_Error( 'indieauth_' . $response['error'], esc_html( $response['error_description'] ) );
+		}
+
+		return new WP_OAuth_Response(
+			'indieauth.invalid_access_token',
+			__( 'Supplied Token is Invalid', 'indieauth' ),
+			$code,
+			$response
+		);
+	}
+}

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -164,8 +164,8 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 			return new WP_OAuth_Response( 'indieauth_response_error', __( 'IndieAuth.com seems to have some hiccups, please try it again later.', 'indieauth' ), 401 );
 		}
 
-		if ( 2 === (int) ( $code / 100 ) && isset( $body['me'] ) ) {
-			return $body;
+		if ( 2 === (int) ( $code / 100 ) && isset( $params['me'] ) ) {
+			return $params;
 		}
 		if ( array_key_exists( 'error', $response ) ) {
 			return new WP_Error( 'indieauth_' . $response['error'], esc_html( $response['error_description'] ) );

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -9,11 +9,10 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 	public function __construct( $load = true ) {
 		$this->register_settings();
 		// Load the hooks for this class only if true. This allows for debugging of the functions
-		if ( ! $load ) {
-			return;
+		if ( true === $load ) {
+			add_action( 'admin_init', array( get_called_class(), 'admin_init' ) );
+			$this->load();
 		}
-		add_action( 'admin_init', array( get_called_class(), 'admin_init' ) );
-		$this->load();
 	}
 
 	public function register_settings() {

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -60,7 +60,6 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 			array(
 				'label_for' => 'indieauth_authorization_endpoint',
 				'class'     => 'widefat',
-				'default'   => 'https://indieauth.com/auth',
 			)
 		);
 		add_settings_field(
@@ -72,7 +71,6 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 			array(
 				'label_for' => 'indieauth_token_endpoint',
 				'class'     => 'widefat',
-				'default'   => 'https://tokens.indieauth.com/token',
 			)
 		);
 	}
@@ -86,23 +84,11 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 	}
 
 	public static function get_authorization_endpoint() {
-		$return = get_option( 'indieauth_authorization_endpoint', 'https://indieauth.com/auth' );
-		// Sanity Check
-		if ( empty( $return ) ) {
-			delete_option( 'indieauth_authorization_endpoint' );
-			$return = 'https://indieauth.com/auth';
-		}
-		return $return;
+		return get_option( 'indieauth_authorization_endpoint', '' );
 	}
 
 	public static function get_token_endpoint() {
-		$return = get_option( 'indieauth_token_endpoint', 'https://tokens.indieauth.com/token' );
-		// Sanity Check
-		if ( empty( $return ) ) {
-			delete_option( 'indieauth_token_endpoint' );
-			$return = 'https://tokens.indieauth.com/token';
-		}
-		return $return;
+		return get_option( 'indieauth_token_endpoint', '' );
 	}
 
 	public function verify_access_token( $token ) {

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -82,15 +82,27 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 	}
 
 	public static function auth_settings() {
-			_e( 'Please specify a remote indieauth authorization and token endpoint.', 'indieauth' );
+			esc_html_e( 'Please specify a remote indieauth authorization and token endpoint.', 'indieauth' );
 	}
 
 	public function get_authorization_endpoint() {
-		return get_option( 'indieauth_authorization_endpoint', 'https://indieauth.com/auth' );
+		$return = get_option( 'indieauth_authorization_endpoint', 'https://indieauth.com/auth' );
+		// Sanity Check
+		if ( empty( $return ) ) {
+			delete_option( 'indieauth_authorization_endpoint' );
+			$return = 'https://indieauth.com/auth';
+		}
+		return $return;
 	}
 
 	public function get_token_endpoint() {
-		return get_option( 'indieauth_token_endpoint', 'https://tokens.indieauth.com/token' );
+		$return = get_option( 'indieauth_token_endpoint', 'https://tokens.indieauth.com/token' );
+		// Sanity Check
+		if ( empty( $return ) ) {
+			delete_option( 'indieauth_token_endpoint' );
+			$return = 'https://tokens.indieauth.com/token';
+		}
+		return $return;
 	}
 
 	public function verify_access_token( $token ) {

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -86,7 +86,7 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 		esc_html_e( 'Please specify a remote indieauth authorization and token endpoint.', 'indieauth' );
 	}
 
-	public function get_authorization_endpoint() {
+	public static function get_authorization_endpoint() {
 		$return = get_option( 'indieauth_authorization_endpoint', 'https://indieauth.com/auth' );
 		// Sanity Check
 		if ( empty( $return ) ) {
@@ -96,7 +96,7 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 		return $return;
 	}
 
-	public function get_token_endpoint() {
+	public static function get_token_endpoint() {
 		$return = get_option( 'indieauth_token_endpoint', 'https://tokens.indieauth.com/token' );
 		// Sanity Check
 		if ( empty( $return ) ) {

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -60,6 +60,7 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 			array(
 				'label_for' => 'indieauth_authorization_endpoint',
 				'class'     => 'widefat',
+				'default'   => '',
 			)
 		);
 		add_settings_field(
@@ -71,6 +72,7 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 			array(
 				'label_for' => 'indieauth_token_endpoint',
 				'class'     => 'widefat',
+				'default'   => ''
 			)
 		);
 	}

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -78,11 +78,11 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 	}
 
 	public static function endpoint_field( $args ) {
-			printf( '<label for="%1$s"><input id="%1$s" name="%1$s" type="url" value="%2$s" placeholder="%3$s" />', esc_attr( $args['label_for'] ), esc_url( get_option( $args['label_for'], $args['default'] ) ), esc_url( $args['default'] ) );
+		printf( '<label for="%1$s"><input id="%1$s" name="%1$s" type="url" value="%2$s" placeholder="%3$s" />', esc_attr( $args['label_for'] ), esc_url( get_option( $args['label_for'], $args['default'] ) ), esc_url( $args['default'] ) );
 	}
 
 	public static function auth_settings() {
-			esc_html_e( 'Please specify a remote indieauth authorization and token endpoint.', 'indieauth' );
+		esc_html_e( 'Please specify a remote indieauth authorization and token endpoint.', 'indieauth' );
 	}
 
 	public function get_authorization_endpoint() {

--- a/includes/class-indieauth-remote-authorize.php
+++ b/includes/class-indieauth-remote-authorize.php
@@ -45,36 +45,37 @@ class IndieAuth_Remote_Authorize extends IndieAuth_Authorize {
 	public static function admin_init() {
 		$cls  = get_called_class();
 		$page = 'indieauth';
-				add_settings_section(
-					'indieauth',
-					'Remote IndieAuth Endpoint Settings',
-					array( $cls, 'auth_settings' ),
-					$page
-				);
-				add_settings_field(
-					'indieauth_authorization_endpoint',
-					__( 'Authorization Endpoint', 'indieauth' ),
-					array( $cls, 'endpoint_field' ),
-					$page,
-					'indieauth',
-					array(
-						'label_for' => 'indieauth_authorization_endpoint',
-						'class'     => 'widefat',
-						'default'   => 'https://indieauth.com/auth',
-					)
-				);
-				add_settings_field(
-					'indieauth_token_endpoint',
-					__( 'Token Endpoint', 'indieauth' ),
-					array( $cls, 'endpoint_field' ),
-					$page,
-					'indieauth',
-					array(
-						'label_for' => 'indieauth_token_endpoint',
-						'class'     => 'widefat',
-						'default'   => 'https://tokens.indieauth.com/token',
-					)
-				);
+
+		add_settings_section(
+			'indieauth',
+			'Remote IndieAuth Endpoint Settings',
+			array( $cls, 'auth_settings' ),
+			$page
+		);
+		add_settings_field(
+			'indieauth_authorization_endpoint',
+			__( 'Authorization Endpoint', 'indieauth' ),
+			array( $cls, 'endpoint_field' ),
+			$page,
+			'indieauth',
+			array(
+				'label_for' => 'indieauth_authorization_endpoint',
+				'class'     => 'widefat',
+				'default'   => 'https://indieauth.com/auth',
+			)
+		);
+		add_settings_field(
+			'indieauth_token_endpoint',
+			__( 'Token Endpoint', 'indieauth' ),
+			array( $cls, 'endpoint_field' ),
+			$page,
+			'indieauth',
+			array(
+				'label_for' => 'indieauth_token_endpoint',
+				'class'     => 'widefat',
+				'default'   => 'https://tokens.indieauth.com/token',
+			)
+		);
 	}
 
 	public static function endpoint_field( $args ) {

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -165,7 +165,7 @@ class IndieAuth_Token_Endpoint {
 				'client_id'   => $params['client_id'],
 				'client_name' => $info->get_name(),
 				'client_icon' => $info->get_icon(),
-				'issued_at'   => current_time( 'timestamp', 1 ),
+				'issued_at'   => time(),
 			);
 			$token = array_filter( $token );
 

--- a/includes/class-indieauth-token-ui.php
+++ b/includes/class-indieauth-token-ui.php
@@ -84,7 +84,7 @@ class IndieAuth_Token_UI {
 			'client_id'   => admin_url(),
 			'client_name' => wp_strip_all_tags( $name ),
 			'client_icon' => get_avatar_url( $user_id ),
-			'issued_at'   => current_time( 'timestamp', 1 ),
+			'issued_at'   => time(),
 		);
 		return $tokens->set( $token );
 	}

--- a/includes/class-token-generic.php
+++ b/includes/class-token-generic.php
@@ -53,7 +53,7 @@ abstract class Token_Generic {
 	 * @return int Timestamp.
 	 */
 	public function time() {
-		return current_time( 'timestamp', 1 );
+		return time();
 	}
 
 	/**

--- a/includes/class-token-transient.php
+++ b/includes/class-token-transient.php
@@ -64,7 +64,7 @@ class Token_Transient extends Token_Generic {
 
 	public function destroy_with_cookie( $key ) {
 		if ( isset( $_COOKIE[ $this->prefix ] ) ) {
-			setcookie( $this->prefix, '', current_time( 'timestamp' ) - 1000, '/', false, true );
+			setcookie( $this->prefix, '', time() - 1000, '/', false, true );
 		}
 		$this->destroy( $key );
 	}

--- a/includes/class-token-transient.php
+++ b/includes/class-token-transient.php
@@ -63,7 +63,7 @@ class Token_Transient extends Token_Generic {
 	}
 
 	public function destroy_with_cookie( $key ) {
-		if ( isset( $_COOKIE[ $this->prefix  ] ) ) {
+		if ( isset( $_COOKIE[ $this->prefix ] ) ) {
 			setcookie( $this->prefix, '', current_time( 'timestamp' ) - 1000, '/', false, true );
 		}
 		$this->destroy( $key );

--- a/includes/class-token-transient.php
+++ b/includes/class-token-transient.php
@@ -69,10 +69,6 @@ class Token_Transient extends Token_Generic {
 		$this->destroy( $key );
 	}
 
-	protected function hash( $string ) {
-		return parent::hash( $string );
-	}
-
 	/**
 	 * Destroys a token
 	 *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -151,7 +151,8 @@ if ( ! function_exists( 'parse_html_rels' ) ) {
 if ( ! function_exists( 'get_single_author' ) ) {
 	function get_single_author() {
 		global $wpdb;
-		if ( false === ( $single_author = get_transient( 'single_author' ) ) ) {
+		$single_author = get_transient( 'single_author' );
+		if ( false === $single_author ) {
 			$rows          = (array) $wpdb->get_col( "SELECT DISTINCT post_author FROM $wpdb->posts WHERE post_type = 'post' AND post_status = 'publish' LIMIT 2" );
 			$single_author = 1 === count( $rows ) ? (int) $rows[0] : false;
 			set_transient( 'single_author', $single_author );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -516,3 +516,12 @@ function indieauth_get_user( $user ) {
 	);
 	return array_filter( $return );
 }
+
+function indieauth_get_authorization_endpoint() {
+	return IndieAuth_Plugin::$indieauth->get_authorization_endpoint();
+}
+
+
+function indieauth_get_token_endpoint() {
+	return IndieAuth_Plugin::$indieauth->get_token_endpoint();
+}

--- a/indieauth.php
+++ b/indieauth.php
@@ -25,6 +25,8 @@ class IndieAuth_Plugin {
 				'class-indieauth-scope.php', // Scope Class
 				'class-indieauth-scopes.php', // Scopes Class
 				'class-indieauth-authorize.php', // IndieAuth Authorization Base Class
+				'class-token-transient.php',
+				'class-web-signin.php',
 				'class-indieauth-admin.php', // Administration Class
 			)
 		);
@@ -43,8 +45,6 @@ class IndieAuth_Plugin {
 		// Classes Require for using a Remote Endpoint
 		$remotefiles = array(
 			'class-indieauth-remote-authorize.php',
-			'class-token-transient.php',
-			'class-web-signin.php',
 		);
 		$load        = get_option( 'indieauth_config', 'local' );
 		switch ( $load ) {

--- a/indieauth.php
+++ b/indieauth.php
@@ -36,7 +36,7 @@ class IndieAuth_Plugin {
 			'class-indieauth-client-discovery.php', // Client Discovery
 			'class-token-user.php',
 			'class-indieauth-token-endpoint.php', // Token Endpoint
-			'client-indieauth-authorization-endpoint.php', // Authorization Endpoint
+			'class-indieauth-authorization-endpoint.php', // Authorization Endpoint
 			'class-token-list-table.php', // Token Management UI
 			'class-indieauth-token-ui.php',
 			'class-indieauth-local-authorize.php',

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 3.4.2
+ * Version: 3.5.0
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2019 IndieWebCamp WordPress Outreach Club
+# Copyright (C) 2020 IndieWebCamp WordPress Outreach Club
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 3.4.2\n"
+"Project-Id-Version: IndieAuth 3.5.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2019-08-08 03:49:41+00:00\n"
+"POT-Creation-Date: 2020-01-25 08:01:08+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2020-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"
@@ -34,79 +34,111 @@ msgstr ""
 msgid "IndieAuth Test"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:47
-msgid "Authorization Header Passed"
+#: includes/class-indieauth-admin.php:43
+msgid "SSL Test"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:52
+msgid "HTTPS Check Passed"
 msgstr ""
 
 #. Plugin Name of the plugin/theme
 msgid "IndieAuth"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:55
+#: includes/class-indieauth-admin.php:60
+msgid "You are using HTTPS and IndieAuth will be secure"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:68
+msgid "HTTPS Test Failed"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:71
+msgid ""
+"You are not serving your site via HTTPS. This is a security risk if running "
+"IndieAuth."
+msgstr ""
+
+#: includes/class-indieauth-admin.php:73
+msgid ""
+"We recommend you acquire an SSL Certificate. You can do this for free "
+"through Lets Encrypt"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:81
+msgid "Authorization Header Passed"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:89
 msgid ""
 "Your hosting provider allows authorization headers to pass so IndieAuth "
 "should work"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:63
+#: includes/class-indieauth-admin.php:97
 msgid "Authorization Test Failed"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:66
+#: includes/class-indieauth-admin.php:100
 msgid ""
 "Authorization Headers are being blocked by your hosting provider. This will "
 "cause IndieAuth to fail."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:68
+#: includes/class-indieauth-admin.php:102
 msgid "Visit the Settings page for guidance on how to resolve."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:78 templates/indieauth-settings.php:68
+#: includes/class-indieauth-admin.php:112 templates/indieauth-settings.php:63
 msgid "None"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:87
+#: includes/class-indieauth-admin.php:121
 msgid "Website"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:135
+#: includes/class-indieauth-admin.php:169
 msgid "Authorization Header Found. You should be able to use all clients."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:138
+#: includes/class-indieauth-admin.php:172
 msgid "Alternate Header Found. You should be able to use all clients."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:168
+#: includes/class-indieauth-admin.php:202
+msgid "Configuration option for IndieAuth Plugin"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:212
 msgid "Offer IndieAuth on Login Form"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:178
+#: includes/class-indieauth-admin.php:222
 msgid "User Who is Represented by the Site URL"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:186 templates/indieauth-settings.php:2
+#: includes/class-indieauth-admin.php:230 templates/indieauth-settings.php:2
 msgid "IndieAuth Settings"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:199
+#: includes/class-indieauth-admin.php:243
 msgid ""
 "Based on your feedback and to improve the user experience, we decided to "
 "move the settings to a separate <a href=\"%1$s\">settings-page</a>."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:272
+#: includes/class-indieauth-admin.php:316
 msgid "Overview"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:274
+#: includes/class-indieauth-admin.php:318
 msgid ""
 "IndieAuth is a way for doing Web sign-in, where you use your own homepage "
 "to sign in to other places."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:275
+#: includes/class-indieauth-admin.php:319
 msgid ""
 "IndieAuth was built on ideas and technology from existing proven "
 "technologies like OAuth and OpenID but aims at making it easier for users "
@@ -114,19 +146,19 @@ msgid ""
 "completely separate implementations and services can be used for each part."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:282
+#: includes/class-indieauth-admin.php:326
 msgid "The IndieWeb"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:284
+#: includes/class-indieauth-admin.php:328
 msgid "The IndieWeb is a people-focused alternative to the \"corporate web\"."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:286
+#: includes/class-indieauth-admin.php:330
 msgid "Your content is yours"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:287
+#: includes/class-indieauth-admin.php:331
 msgid ""
 "When you post something on the web, it should belong to you, not a "
 "corporation. Too many companies have gone out of business and lost all of "
@@ -134,142 +166,137 @@ msgid ""
 "your control."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:290
+#: includes/class-indieauth-admin.php:334
 msgid "You are better connected"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:291
+#: includes/class-indieauth-admin.php:335
 msgid ""
 "Your articles and status messages can go to all services, not just one, "
 "allowing you to engage with everyone. Even replies and likes on other "
 "services can come back to your site so they’re all in one place."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:294
+#: includes/class-indieauth-admin.php:338
 msgid "You are in control"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:295
+#: includes/class-indieauth-admin.php:339
 msgid ""
 "You can post anything you want, in any format you want, with no one "
 "monitoring you. In addition, you share simple readable links such as "
 "example.com/ideas. These links are permanent and will always work."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:301
+#: includes/class-indieauth-admin.php:345
 msgid "For more information:"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:302
+#: includes/class-indieauth-admin.php:346
 msgid "<a href=\"https://indieweb.org/IndieAuth\">IndieWeb Wiki page</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:303
+#: includes/class-indieauth-admin.php:347
 msgid "<a href=\"https://indieauth.rocks/\">Test suite</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:304
+#: includes/class-indieauth-admin.php:348
 msgid "<a href=\"https://www.w3.org/TR/indieauth/\">W3C Spec</a>"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:69
+#: includes/class-indieauth-authorization-endpoint.php:82
 msgid "Legacy Scope (Deprecated)"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:70
+#: includes/class-indieauth-authorization-endpoint.php:83
 msgid "Allows the application to create posts and upload to the Media Endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:71
+#: includes/class-indieauth-authorization-endpoint.php:84
 msgid "Allows the application to update posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:72
+#: includes/class-indieauth-authorization-endpoint.php:85
 msgid "Allows the application to delete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:73
+#: includes/class-indieauth-authorization-endpoint.php:86
 msgid "Allows the application to undelete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:74
+#: includes/class-indieauth-authorization-endpoint.php:87
 msgid "Allows the application to upload to the media endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:76
+#: includes/class-indieauth-authorization-endpoint.php:89
 msgid "Allows the application read access to channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:77
+#: includes/class-indieauth-authorization-endpoint.php:90
 msgid "Allows the application to manage a follow list"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:78
+#: includes/class-indieauth-authorization-endpoint.php:91
 msgid "Allows the application to mute and unmute users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:79
+#: includes/class-indieauth-authorization-endpoint.php:92
 msgid "Allows the application to block and unlock users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:80
+#: includes/class-indieauth-authorization-endpoint.php:93
 msgid "Allows the application to manage channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:81
+#: includes/class-indieauth-authorization-endpoint.php:94
 msgid "Allows the application to save content for later retrieval"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:83
+#: includes/class-indieauth-authorization-endpoint.php:96
 msgid ""
 "Returns a complete profile to the application. Without this only a display "
 "name, avatar, and url will be returned"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:88
+#: includes/class-indieauth-authorization-endpoint.php:101
 msgid "No Description Available"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:98
+#: includes/class-indieauth-authorization-endpoint.php:111
 msgid "Unsupported Response Type"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:104
-#: includes/class-indieauth-authorization-endpoint.php:149
+#: includes/class-indieauth-authorization-endpoint.php:117
+#: includes/class-indieauth-authorization-endpoint.php:162
 #. translators: Name of missing parameter
 msgid "Missing Parameter: %1$s"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:156
-#: includes/class-indieauth-authorize.php:145
+#: includes/class-indieauth-authorization-endpoint.php:169
+#: includes/class-indieauth-local-authorize.php:49
 #: includes/class-indieauth-token-endpoint.php:207
 msgid "Invalid authorization code"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:161
+#: includes/class-indieauth-authorization-endpoint.php:174
 msgid "The authorization code expired"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:169
-#: includes/class-indieauth-authorization-endpoint.php:173
+#: includes/class-indieauth-authorization-endpoint.php:182
+#: includes/class-indieauth-authorization-endpoint.php:186
 #: includes/class-indieauth-token-endpoint.php:212
 #: includes/class-indieauth-token-endpoint.php:216
 msgid "Failed PKCE Validation"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:189
+#: includes/class-indieauth-authorization-endpoint.php:202
 msgid ""
 "There was an error verifying the authorization code. Check that the "
 "client_id and redirect_uri match the original request."
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:111
+#: includes/class-indieauth-authorize.php:139
 msgid "User Not Found on this Site"
-msgstr ""
-
-#: includes/class-indieauth-authorize.php:127
-#: includes/class-indieauth-token-endpoint.php:100
-msgid "Invalid access token"
 msgstr ""
 
 #: includes/class-indieauth-client-discovery.php:14
@@ -292,6 +319,35 @@ msgstr ""
 msgid ""
 "You have passed a permissions test but somehow the system is still not "
 "showing you as logged in"
+msgstr ""
+
+#: includes/class-indieauth-local-authorize.php:31
+#: includes/class-indieauth-token-endpoint.php:100
+msgid "Invalid access token"
+msgstr ""
+
+#: includes/class-indieauth-remote-authorize.php:56
+msgid "Authorization Endpoint"
+msgstr ""
+
+#: includes/class-indieauth-remote-authorize.php:68
+msgid "Token Endpoint"
+msgstr ""
+
+#: includes/class-indieauth-remote-authorize.php:85
+msgid "Please specify a remote indieauth authorization and token endpoint."
+msgstr ""
+
+#: includes/class-indieauth-remote-authorize.php:135
+msgid "Unable to Find User"
+msgstr ""
+
+#: includes/class-indieauth-remote-authorize.php:163
+msgid "IndieAuth.com seems to have some hiccups, please try it again later."
+msgstr ""
+
+#: includes/class-indieauth-remote-authorize.php:175
+msgid "Supplied Token is Invalid"
 msgstr ""
 
 #: includes/class-indieauth-token-endpoint.php:90
@@ -507,6 +563,11 @@ msgstr ""
 msgid "Invalid User Profile URL"
 msgstr ""
 
+#: indieauth.php:82
+#. translators: 1. Path to file unable to load
+msgid "Unable to load: %1s"
+msgstr ""
+
 #: templates/authdiagfail.php:3
 msgid "Authorization has Failed"
 msgstr ""
@@ -589,62 +650,90 @@ msgid ""
 "application."
 msgstr ""
 
-#: templates/indieauth-settings.php:12
+#: templates/indieauth-settings.php:13
 msgid "Test your System"
 msgstr ""
 
-#: templates/indieauth-settings.php:13
+#: templates/indieauth-settings.php:14
 msgid ""
 "If you are experiencing unauthorized as an error, click below to run a test "
 "script."
 msgstr ""
 
-#: templates/indieauth-settings.php:14
+#: templates/indieauth-settings.php:15
 msgid "Diagnostic Script"
 msgstr ""
 
-#: templates/indieauth-settings.php:21
+#: templates/indieauth-settings.php:22
 msgid ""
 "With IndieAuth, you can use your blog, to log into sites like the "
 "IndieWeb-Wiki."
 msgstr ""
 
-#: templates/indieauth-settings.php:27
+#: templates/indieauth-settings.php:29
 msgid "Endpoints"
 msgstr ""
 
-#: templates/indieauth-settings.php:31
+#: templates/indieauth-settings.php:33
 msgid "Authorization Endpoint:"
 msgstr ""
 
-#: templates/indieauth-settings.php:35
+#: templates/indieauth-settings.php:37
 msgid "Token Endpoint:"
 msgstr ""
 
-#: templates/indieauth-settings.php:43 templates/websignin-link.php:3
+#: templates/indieauth-settings.php:44
+msgid "Configuration"
+msgstr ""
+
+#: templates/indieauth-settings.php:47
+msgid "Use Your Own Site as an IndieAuth Endpoint"
+msgstr ""
+
+#: templates/indieauth-settings.php:48
+msgid ""
+"The endpoint is hosted entirely inside your WordPress instance and requires "
+"no external server. When you try to log into a client with your URL you "
+"will be presented with your WordPress login screen after which you will be "
+"asked if you wish to grant the client permission to act as you. This is the "
+"recommended option."
+msgstr ""
+
+#: templates/indieauth-settings.php:50
+msgid "Use Another Site as an IndieAuth Endpoint"
+msgstr ""
+
+#: templates/indieauth-settings.php:51
+msgid ""
+"For those who do not wish to host their own IndieAuth endpoint or delegate "
+"their site authentication to another site. By default, this is "
+"indieauth.com which is free for use, but can be any endpoint."
+msgstr ""
+
+#: templates/indieauth-settings.php:57
+msgid "Set User to Represent Site URL"
+msgstr ""
+
+#: templates/indieauth-settings.php:70
+msgid "Set a User who will represent the URL of the site"
+msgstr ""
+
+#: templates/indieauth-settings.php:77 templates/websignin-link.php:3
 msgid "Web Sign-In"
 msgstr ""
 
-#: templates/indieauth-settings.php:45
+#: templates/indieauth-settings.php:79
 msgid ""
 "Enable Web Sign-In for your blog, so others can use IndieAuth or RelMeAuth "
 "to log into this site."
 msgstr ""
 
-#: templates/indieauth-settings.php:51
+#: templates/indieauth-settings.php:85
 msgid "Use IndieAuth login"
 msgstr ""
 
-#: templates/indieauth-settings.php:57
+#: templates/indieauth-settings.php:91
 msgid "Add a link to the login form to authenticate using an IndieAuth endpoint."
-msgstr ""
-
-#: templates/indieauth-settings.php:62
-msgid "Set User to Represent Site URL"
-msgstr ""
-
-#: templates/indieauth-settings.php:75
-msgid "Set a User who will represent the URL of the site"
 msgstr ""
 
 #: templates/websignin-form.php:4

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: IndieAuth 3.5.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2020-01-25 08:01:08+00:00\n"
+"POT-Creation-Date: 2020-04-21 03:19:02+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -14,31 +14,19 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"
 
-#: includes/class-indieauth-admin.php:25
-msgid ""
-"In order to ensure IndieAuth tokens will work please visit the settings "
-"page to check:"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:26
-msgid "Visit Settings Page"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:32
-msgid ""
-"Multiple user accounts have the same URL set. This is not permitted as this "
-"value is used by IndieAuth for login. Please resolve"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:39
+#: includes/class-indieauth-admin.php:22
 msgid "IndieAuth Test"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:43
+#: includes/class-indieauth-admin.php:26
 msgid "SSL Test"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:52
+#: includes/class-indieauth-admin.php:30
+msgid "Unique User URL Test"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:39
 msgid "HTTPS Check Passed"
 msgstr ""
 
@@ -46,99 +34,116 @@ msgstr ""
 msgid "IndieAuth"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:60
+#: includes/class-indieauth-admin.php:47 includes/class-indieauth-admin.php:76
 msgid "You are using HTTPS and IndieAuth will be secure"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:68
+#: includes/class-indieauth-admin.php:55
 msgid "HTTPS Test Failed"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:71
+#: includes/class-indieauth-admin.php:58
 msgid ""
 "You are not serving your site via HTTPS. This is a security risk if running "
 "IndieAuth."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:73
+#: includes/class-indieauth-admin.php:60
 msgid ""
 "We recommend you acquire an SSL Certificate. You can do this for free "
 "through Lets Encrypt"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:81
-msgid "Authorization Header Passed"
+#: includes/class-indieauth-admin.php:68
+msgid "Unique User URLs Check Passed"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:84
+msgid "Unique User URLs Test Failed"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:87
+msgid ""
+"Multiple user accounts have the same URL set. This is not permitted as this "
+"value is used by IndieAuth for login. Please resolve"
 msgstr ""
 
 #: includes/class-indieauth-admin.php:89
+msgid ""
+"Under IndieAuth, your URL is your identity. Two accounts cannot have the "
+"same website URL in their user profile as this might allow one user to gain "
+"the credentials of another"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:96
+msgid "Authorization Header Passed"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:104
 msgid ""
 "Your hosting provider allows authorization headers to pass so IndieAuth "
 "should work"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:97
+#: includes/class-indieauth-admin.php:112
 msgid "Authorization Test Failed"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:100
+#: includes/class-indieauth-admin.php:117
 msgid ""
-"Authorization Headers are being blocked by your hosting provider. This will "
-"cause IndieAuth to fail."
+"If contacting your hosting provider does not work you can open an issue on "
+"GitHub and we will try to assist"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:102
-msgid "Visit the Settings page for guidance on how to resolve."
-msgstr ""
-
-#: includes/class-indieauth-admin.php:112 templates/indieauth-settings.php:63
+#: includes/class-indieauth-admin.php:127 templates/indieauth-settings.php:52
 msgid "None"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:121
+#: includes/class-indieauth-admin.php:136
 msgid "Website"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:169
+#: includes/class-indieauth-admin.php:184
 msgid "Authorization Header Found. You should be able to use all clients."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:172
+#: includes/class-indieauth-admin.php:186
 msgid "Alternate Header Found. You should be able to use all clients."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:202
+#: includes/class-indieauth-admin.php:215
 msgid "Configuration option for IndieAuth Plugin"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:212
+#: includes/class-indieauth-admin.php:225
 msgid "Offer IndieAuth on Login Form"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:222
+#: includes/class-indieauth-admin.php:235
 msgid "User Who is Represented by the Site URL"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:230 templates/indieauth-settings.php:2
+#: includes/class-indieauth-admin.php:243 templates/indieauth-settings.php:2
 msgid "IndieAuth Settings"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:243
+#: includes/class-indieauth-admin.php:256
 msgid ""
 "Based on your feedback and to improve the user experience, we decided to "
 "move the settings to a separate <a href=\"%1$s\">settings-page</a>."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:316
+#: includes/class-indieauth-admin.php:329
 msgid "Overview"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:318
+#: includes/class-indieauth-admin.php:331
 msgid ""
 "IndieAuth is a way for doing Web sign-in, where you use your own homepage "
 "to sign in to other places."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:319
+#: includes/class-indieauth-admin.php:332
 msgid ""
 "IndieAuth was built on ideas and technology from existing proven "
 "technologies like OAuth and OpenID but aims at making it easier for users "
@@ -146,19 +151,19 @@ msgid ""
 "completely separate implementations and services can be used for each part."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:326
+#: includes/class-indieauth-admin.php:339
 msgid "The IndieWeb"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:328
+#: includes/class-indieauth-admin.php:341
 msgid "The IndieWeb is a people-focused alternative to the \"corporate web\"."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:330
+#: includes/class-indieauth-admin.php:343
 msgid "Your content is yours"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:331
+#: includes/class-indieauth-admin.php:344
 msgid ""
 "When you post something on the web, it should belong to you, not a "
 "corporation. Too many companies have gone out of business and lost all of "
@@ -166,130 +171,134 @@ msgid ""
 "your control."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:334
+#: includes/class-indieauth-admin.php:347
 msgid "You are better connected"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:335
+#: includes/class-indieauth-admin.php:348
 msgid ""
 "Your articles and status messages can go to all services, not just one, "
 "allowing you to engage with everyone. Even replies and likes on other "
 "services can come back to your site so they’re all in one place."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:338
+#: includes/class-indieauth-admin.php:351
 msgid "You are in control"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:339
+#: includes/class-indieauth-admin.php:352
 msgid ""
 "You can post anything you want, in any format you want, with no one "
 "monitoring you. In addition, you share simple readable links such as "
 "example.com/ideas. These links are permanent and will always work."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:345
+#: includes/class-indieauth-admin.php:358
 msgid "For more information:"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:346
+#: includes/class-indieauth-admin.php:359
 msgid "<a href=\"https://indieweb.org/IndieAuth\">IndieWeb Wiki page</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:347
+#: includes/class-indieauth-admin.php:360
 msgid "<a href=\"https://indieauth.rocks/\">Test suite</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:348
+#: includes/class-indieauth-admin.php:361
 msgid "<a href=\"https://www.w3.org/TR/indieauth/\">W3C Spec</a>"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:82
+#: includes/class-indieauth-authorization-endpoint.php:68
 msgid "Legacy Scope (Deprecated)"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:83
+#: includes/class-indieauth-authorization-endpoint.php:69
+#: includes/class-indieauth-scopes.php:66
 msgid "Allows the application to create posts and upload to the Media Endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:84
+#: includes/class-indieauth-authorization-endpoint.php:70
+#: includes/class-indieauth-scopes.php:94
 msgid "Allows the application to update posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:85
+#: includes/class-indieauth-authorization-endpoint.php:71
 msgid "Allows the application to delete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:86
+#: includes/class-indieauth-authorization-endpoint.php:72
 msgid "Allows the application to undelete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:87
+#: includes/class-indieauth-authorization-endpoint.php:73
+#: includes/class-indieauth-scopes.php:119
 msgid "Allows the application to upload to the media endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:89
+#: includes/class-indieauth-authorization-endpoint.php:75
 msgid "Allows the application read access to channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:90
+#: includes/class-indieauth-authorization-endpoint.php:76
 msgid "Allows the application to manage a follow list"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:91
+#: includes/class-indieauth-authorization-endpoint.php:77
 msgid "Allows the application to mute and unmute users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:92
+#: includes/class-indieauth-authorization-endpoint.php:78
 msgid "Allows the application to block and unlock users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:93
+#: includes/class-indieauth-authorization-endpoint.php:79
 msgid "Allows the application to manage channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:94
+#: includes/class-indieauth-authorization-endpoint.php:80
+#: includes/class-indieauth-scopes.php:178
 msgid "Allows the application to save content for later retrieval"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:96
+#: includes/class-indieauth-authorization-endpoint.php:82
 msgid ""
 "Returns a complete profile to the application. Without this only a display "
 "name, avatar, and url will be returned"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:101
+#: includes/class-indieauth-authorization-endpoint.php:87
 msgid "No Description Available"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:111
+#: includes/class-indieauth-authorization-endpoint.php:97
 msgid "Unsupported Response Type"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:117
-#: includes/class-indieauth-authorization-endpoint.php:162
+#: includes/class-indieauth-authorization-endpoint.php:103
+#: includes/class-indieauth-authorization-endpoint.php:148
 #. translators: Name of missing parameter
 msgid "Missing Parameter: %1$s"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:169
-#: includes/class-indieauth-local-authorize.php:49
+#: includes/class-indieauth-authorization-endpoint.php:155
+#: includes/class-indieauth-local-authorize.php:48
 #: includes/class-indieauth-token-endpoint.php:207
 msgid "Invalid authorization code"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:174
+#: includes/class-indieauth-authorization-endpoint.php:160
 msgid "The authorization code expired"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:182
-#: includes/class-indieauth-authorization-endpoint.php:186
+#: includes/class-indieauth-authorization-endpoint.php:168
+#: includes/class-indieauth-authorization-endpoint.php:172
 #: includes/class-indieauth-token-endpoint.php:212
 #: includes/class-indieauth-token-endpoint.php:216
 msgid "Failed PKCE Validation"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:202
+#: includes/class-indieauth-authorization-endpoint.php:188
 msgid ""
 "There was an error verifying the authorization code. Check that the "
 "client_id and redirect_uri match the original request."
@@ -321,7 +330,7 @@ msgid ""
 "showing you as logged in"
 msgstr ""
 
-#: includes/class-indieauth-local-authorize.php:31
+#: includes/class-indieauth-local-authorize.php:30
 #: includes/class-indieauth-token-endpoint.php:100
 msgid "Invalid access token"
 msgstr ""
@@ -348,6 +357,44 @@ msgstr ""
 
 #: includes/class-indieauth-remote-authorize.php:175
 msgid "Supplied Token is Invalid"
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:44
+msgid "Unknown cap: %1s"
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:82
+msgid "Allows the application to create draft posts only."
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:107
+msgid "Allows the application to delete or undelete posts"
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:130
+msgid "Allows the application read access to Microsub channels"
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:140
+msgid "Allows the application to manage a Microsub following list"
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:150
+msgid "Allows the application to mute and unmute users in a Microsub channel"
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:160
+msgid "Allows the application to block users in a Microsub channel"
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:169
+msgid "Allows the application to manage Microsub channels"
+msgstr ""
+
+#: includes/class-indieauth-scopes.php:188
+msgid ""
+"Returns a complete profile to the application as part of the IndieAuth "
+"response. Without this only a display name, avatar, and url will be returned"
 msgstr ""
 
 #: includes/class-indieauth-token-endpoint.php:90
@@ -563,7 +610,7 @@ msgstr ""
 msgid "Invalid User Profile URL"
 msgstr ""
 
-#: indieauth.php:82
+#: indieauth.php:83
 #. translators: 1. Path to file unable to load
 msgid "Unable to load: %1s"
 msgstr ""
@@ -650,47 +697,34 @@ msgid ""
 "application."
 msgstr ""
 
-#: templates/indieauth-settings.php:13
-msgid "Test your System"
-msgstr ""
-
-#: templates/indieauth-settings.php:14
-msgid ""
-"If you are experiencing unauthorized as an error, click below to run a test "
-"script."
-msgstr ""
-
-#: templates/indieauth-settings.php:15
-msgid "Diagnostic Script"
-msgstr ""
-
-#: templates/indieauth-settings.php:22
+#: templates/indieauth-settings.php:11
 msgid ""
 "With IndieAuth, you can use your blog, to log into sites like the "
-"IndieWeb-Wiki."
+"IndieWeb-Wiki. Please run a Site Health check to ensure this will work with "
+"your site"
 msgstr ""
 
-#: templates/indieauth-settings.php:29
+#: templates/indieauth-settings.php:18
 msgid "Endpoints"
 msgstr ""
 
-#: templates/indieauth-settings.php:33
+#: templates/indieauth-settings.php:22
 msgid "Authorization Endpoint:"
 msgstr ""
 
-#: templates/indieauth-settings.php:37
+#: templates/indieauth-settings.php:26
 msgid "Token Endpoint:"
 msgstr ""
 
-#: templates/indieauth-settings.php:44
+#: templates/indieauth-settings.php:33
 msgid "Configuration"
 msgstr ""
 
-#: templates/indieauth-settings.php:47
+#: templates/indieauth-settings.php:36
 msgid "Use Your Own Site as an IndieAuth Endpoint"
 msgstr ""
 
-#: templates/indieauth-settings.php:48
+#: templates/indieauth-settings.php:37
 msgid ""
 "The endpoint is hosted entirely inside your WordPress instance and requires "
 "no external server. When you try to log into a client with your URL you "
@@ -699,40 +733,40 @@ msgid ""
 "recommended option."
 msgstr ""
 
-#: templates/indieauth-settings.php:50
+#: templates/indieauth-settings.php:39
 msgid "Use Another Site as an IndieAuth Endpoint"
 msgstr ""
 
-#: templates/indieauth-settings.php:51
+#: templates/indieauth-settings.php:40
 msgid ""
 "For those who do not wish to host their own IndieAuth endpoint or delegate "
 "their site authentication to another site. By default, this is "
 "indieauth.com which is free for use, but can be any endpoint."
 msgstr ""
 
-#: templates/indieauth-settings.php:57
+#: templates/indieauth-settings.php:46
 msgid "Set User to Represent Site URL"
 msgstr ""
 
-#: templates/indieauth-settings.php:70
+#: templates/indieauth-settings.php:59
 msgid "Set a User who will represent the URL of the site"
 msgstr ""
 
-#: templates/indieauth-settings.php:77 templates/websignin-link.php:3
+#: templates/indieauth-settings.php:66 templates/websignin-link.php:3
 msgid "Web Sign-In"
 msgstr ""
 
-#: templates/indieauth-settings.php:79
+#: templates/indieauth-settings.php:68
 msgid ""
 "Enable Web Sign-In for your blog, so others can use IndieAuth or RelMeAuth "
 "to log into this site."
 msgstr ""
 
-#: templates/indieauth-settings.php:85
+#: templates/indieauth-settings.php:74
 msgid "Use IndieAuth login"
 msgstr ""
 
-#: templates/indieauth-settings.php:91
+#: templates/indieauth-settings.php:80
 msgid "Add a link to the login form to authenticate using an IndieAuth endpoint."
 msgstr ""
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
+		<testsuite name="IndieAuth">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>

--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,8 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.4  
-**Tested up to:** 5.2.2  
-**Stable tag:** 3.4.2  
+**Tested up to:** 5.3.2  
+**Stable tag:** 3.5.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -47,7 +47,7 @@ This plugin only supports searching an external site for an authorization endpoi
 
 ### What is IndieAuth.com? ###
 
-[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol and available for public use. If you activate this plugin you do not need to use this site. IndieAuth.com uses rel-me links on your website to determine your identity for authentication, but this is not required to use this plugin.
+[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol and available for public use. If you activate this plugin you do not need to use this site. IndieAuth.com uses rel-me links on your website to determine your identity for authentication, but this is not required to use this plugin. If you wish to use Indieauth.com or any remote endpoint, you can disable the local endpoint in the configuration settings.
 
 ### How does the application know my name and avatar? ###
 
@@ -66,13 +66,13 @@ By adding Indieauth support, you can log into sites simply by providing your URL
 
 ### How secure is this? ###
 
-We recommend your site uses SSL to ensure your credentials are not sent in cleartext. As of Version 3.3, this plugin supports Proof Key for Code Exchange(PKCE), if the client supports it.
+We recommend your site uses HTTPS to ensure your credentials are not sent in cleartext. As of Version 3.3, this plugin supports Proof Key for Code Exchange(PKCE), if the client supports it.
 
 ### What is a token endpoint? ###
 
 Once you have proven your identity, the token endpoint issues a token, which applications can use to authenticate as you to your site. The plugin supports you using an external token endpoint if you want, but by having it built into your WordPress site, it is under your control.
 
-You can manage and revoke tokens under User->Manage Tokens. You will only see tokens for the currently logged in user.
+You can manage and revoke tokens under User->Manage Tokens if you are using the local configuration only. You will only see tokens for the currently logged in user.
 
 ### How do I incorporate this into my plugin? ###
 
@@ -126,6 +126,10 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 ## Upgrade Notice ##
 
+### 3.5.0 ###
+
+The option to use a remote endpoint has been restored
+
 ### 3.4.0 ###
 
 Due to the possibility of someone setting the url in their user profile to the same as another account, you will no longer be able to save the exact same url into two accounts. If you already set two accounts to the 
@@ -142,6 +146,13 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 3.5.0 ###
+* Restore ability to use a remote endpoint
+* Add load function and config setting in order to load the files appropriate for your configuration
+* Create Authorization plugin base class that can be used to create different IndieAuth configurations
+* Add Site Health Check for SSL
+* Create local and remote classes that can be instantiated depending on configuration
 
 ### 3.4.2 ###
 * Repair issue with other flow caused by function name issue

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.4  
-**Tested up to:** 5.3.2  
+**Tested up to:** 5.4  
 **Stable tag:** 3.5.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
@@ -151,7 +151,7 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 * Restore ability to use a remote endpoint
 * Add load function and config setting in order to load the files appropriate for your configuration
 * Create Authorization plugin base class that can be used to create different IndieAuth configurations
-* Add Site Health Check for SSL
+* Add Site Health Check for SSL and Unique Users
 * Create local and remote classes that can be instantiated depending on configuration
 
 ### 3.4.2 ###

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.4  
-**Tested up to:** 5.4  
+**Tested up to:** 5.4.2  
 **Stable tag:** 3.5.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
@@ -126,10 +126,6 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 ## Upgrade Notice ##
 
-### 3.5.0 ###
-
-The option to use a remote endpoint has been restored
-
 ### 3.4.0 ###
 
 Due to the possibility of someone setting the url in their user profile to the same as another account, you will no longer be able to save the exact same url into two accounts. If you already set two accounts to the 
@@ -148,7 +144,7 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
 
 ### 3.5.0 ###
-* Restore ability to use a remote endpoint
+* Restore ability to use a remote endpoint but keep this feature hidden for now.
 * Add load function and config setting in order to load the files appropriate for your configuration
 * Create Authorization plugin base class that can be used to create different IndieAuth configurations
 * Add Site Health Check for SSL and Unique Users

--- a/readme.md
+++ b/readme.md
@@ -47,7 +47,7 @@ This plugin only supports searching an external site for an authorization endpoi
 
 ### What is IndieAuth.com? ###
 
-[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol and available for public use. If you activate this plugin you do not need to use this site. IndieAuth.com uses rel-me links on your website to determine your identity for authentication, but this is not required to use this plugin. If you wish to use Indieauth.com or any remote endpoint, you can disable the local endpoint in the configuration settings.
+[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol. If you activate this plugin you do not need to use this site. IndieAuth.com uses rel-me links on your website to determine your identity for authentication, but this is not required to use this plugin which uses your WordPress login to verify your identity.
 
 ### How does the application know my name and avatar? ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.4
-Tested up to: 5.3.2
+Tested up to: 5.4
 Stable tag: 3.5.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -151,7 +151,7 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 * Restore ability to use a remote endpoint
 * Add load function and config setting in order to load the files appropriate for your configuration
 * Create Authorization plugin base class that can be used to create different IndieAuth configurations
-* Add Site Health Check for SSL
+* Add Site Health Check for SSL and Unique Users
 * Create local and remote classes that can be instantiated depending on configuration
 
 = 3.4.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.4
-Tested up to: 5.4
+Tested up to: 5.4.2
 Stable tag: 3.5.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -126,10 +126,6 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 == Upgrade Notice ==
 
-= 3.5.0 =
-
-The option to use a remote endpoint has been restored
-
 = 3.4.0 =
 
 Due to the possibility of someone setting the url in their user profile to the same as another account, you will no longer be able to save the exact same url into two accounts. If you already set two accounts to the 
@@ -148,7 +144,7 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
 
 = 3.5.0 =
-* Restore ability to use a remote endpoint
+* Restore ability to use a remote endpoint but keep this feature hidden for now.
 * Add load function and config setting in order to load the files appropriate for your configuration
 * Create Authorization plugin base class that can be used to create different IndieAuth configurations
 * Add Site Health Check for SSL and Unique Users

--- a/readme.txt
+++ b/readme.txt
@@ -47,7 +47,7 @@ This plugin only supports searching an external site for an authorization endpoi
 
 = What is IndieAuth.com? =
 
-[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol and available for public use. If you activate this plugin you do not need to use this site. IndieAuth.com uses rel-me links on your website to determine your identity for authentication, but this is not required to use this plugin. If you wish to use Indieauth.com or any remote endpoint, you can disable the local endpoint in the configuration settings.
+[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol. If you activate this plugin you do not need to use this site. IndieAuth.com uses rel-me links on your website to determine your identity for authentication, but this is not required to use this plugin which uses your WordPress login to verify your identity.
 
 = How does the application know my name and avatar? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.4
-Tested up to: 5.2.2
-Stable tag: 3.4.2
+Tested up to: 5.3.2
+Stable tag: 3.5.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -47,7 +47,7 @@ This plugin only supports searching an external site for an authorization endpoi
 
 = What is IndieAuth.com? =
 
-[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol and available for public use. If you activate this plugin you do not need to use this site. IndieAuth.com uses rel-me links on your website to determine your identity for authentication, but this is not required to use this plugin.
+[Indieauth.com](https://indieauth.com) is the reference implementation of the IndieAuth Protocol and available for public use. If you activate this plugin you do not need to use this site. IndieAuth.com uses rel-me links on your website to determine your identity for authentication, but this is not required to use this plugin. If you wish to use Indieauth.com or any remote endpoint, you can disable the local endpoint in the configuration settings.
 
 = How does the application know my name and avatar? =
 
@@ -66,13 +66,13 @@ By adding Indieauth support, you can log into sites simply by providing your URL
 
 = How secure is this? =
 
-We recommend your site uses SSL to ensure your credentials are not sent in cleartext. As of Version 3.3, this plugin supports Proof Key for Code Exchange(PKCE), if the client supports it.
+We recommend your site uses HTTPS to ensure your credentials are not sent in cleartext. As of Version 3.3, this plugin supports Proof Key for Code Exchange(PKCE), if the client supports it.
 
 = What is a token endpoint? =
 
 Once you have proven your identity, the token endpoint issues a token, which applications can use to authenticate as you to your site. The plugin supports you using an external token endpoint if you want, but by having it built into your WordPress site, it is under your control.
 
-You can manage and revoke tokens under User->Manage Tokens. You will only see tokens for the currently logged in user.
+You can manage and revoke tokens under User->Manage Tokens if you are using the local configuration only. You will only see tokens for the currently logged in user.
 
 = How do I incorporate this into my plugin? =
 
@@ -126,6 +126,10 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 == Upgrade Notice ==
 
+= 3.5.0 =
+
+The option to use a remote endpoint has been restored
+
 = 3.4.0 =
 
 Due to the possibility of someone setting the url in their user profile to the same as another account, you will no longer be able to save the exact same url into two accounts. If you already set two accounts to the 
@@ -142,6 +146,13 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 3.5.0 =
+* Restore ability to use a remote endpoint
+* Add load function and config setting in order to load the files appropriate for your configuration
+* Create Authorization plugin base class that can be used to create different IndieAuth configurations
+* Add Site Health Check for SSL
+* Create local and remote classes that can be instantiated depending on configuration
 
 = 3.4.2 =
 * Repair issue with other flow caused by function name issue

--- a/templates/authdiagfail.php
+++ b/templates/authdiagfail.php
@@ -1,5 +1,5 @@
  
-<div class="notice notice-error">
+<div>
 <h3><?php _e( 'Authorization has Failed', 'indieauth' ); ?></h3>
 
 <p> <?php _e( 'The authorization header was not returned on this test, which means that your server may be stripping the Authorization header. This is needed for IndieAuth to work correctly.', 'indieauth' ); ?>

--- a/templates/indieauth-settings.php
+++ b/templates/indieauth-settings.php
@@ -1,7 +1,8 @@
 <div class="wrap">
 	<h1><?php esc_html_e( 'IndieAuth Settings', 'indieauth' ); ?></h1>
 
-<?php 
+<?php
+$checked = get_option( 'indieauth_config', 'local' );
 $message = get_query_var( 'authdiag_message' );
 if ( $message ) {
 ?>
@@ -22,6 +23,7 @@ if ( $message ) {
 
 		<table class="form-table">
 			<tbody>
+
 				<tr>
 					<th>
 						<?php _e( 'Endpoints', 'indieauth' ); ?>
@@ -29,12 +31,44 @@ if ( $message ) {
 					<td>
 						<p>
 							<?php _e( 'Authorization Endpoint:', 'indieauth' ); ?><br />
-							<code><?php echo rest_url( '/indieauth/1.0/auth' ); ?></code>
+							<code><?php echo indieauth_get_authorization_endpoint(); ?></code>
 						</p>
 						<p>
 							<?php _e( 'Token Endpoint:', 'indieauth' ); ?><br />
-							<code><?php echo rest_url( '/indieauth/1.0/token' ); ?></code>
+							<code><?php echo indieauth_get_token_endpoint(); ?></code>
 						</p>
+					</td>
+				</tr>
+				<tr>
+					<th>
+						<?php _e( 'Configuration', 'indieauth' ); ?>
+					</th>
+					<td>
+						<p><input type="radio" name="indieauth_config" value="local" <?php checked( $checked, 'local' ); ?>><strong><?php _e( 'Use Your Own Site as an IndieAuth Endpoint', 'indieauth' ); ?></strong> <br />
+						<?php _e( 'The endpoint is hosted entirely inside your WordPress instance and requires no external server. When you try to log into a client with your URL you will be presented with your WordPress login screen after which you will be asked if you wish to grant the client permission to act as you. This is the recommended option.', 'indieauth' ); ?>
+						</p>
+						<p><input type="radio" name="indieauth_config" value="remote" <?php checked( $checked, 'remote' ); ?>> <strong><?php _e( 'Use Another Site as an IndieAuth Endpoint', 'indieauth' ); ?></strong> <br />
+						<?php _e( 'For those who do not wish to host their own IndieAuth endpoint or delegate their site authentication to another site. By default, this is indieauth.com which is free for use, but can be any endpoint.', 'indieauth' ); ?>
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th>
+						<?php _e( 'Set User to Represent Site URL', 'indieauth' ); ?>
+					</th>
+					<td>
+						<label for="indieauth_root_user">
+							<?php wp_dropdown_users(
+								array(
+									'show_option_all' => __( 'None', 'indieauth' ),
+									'name' => 'indieauth_root_user',
+									'id' => 'indieauth_root_user',
+									'show' => 'display_name_with_login',
+									'selected' => get_option( 'indieauth_root_user' )
+								)
+							); ?>
+							<?php _e( 'Set a User who will represent the URL of the site', 'indieauth' ); ?>
+						</label>
 					</td>
 				</tr>
 			</tbody>
@@ -57,25 +91,6 @@ if ( $message ) {
 							<?php _e( 'Add a link to the login form to authenticate using an IndieAuth endpoint.', 'indieauth' ); ?>
 						</label>
 					</td>
-				<tr>
-					<th>
-						<?php _e( 'Set User to Represent Site URL', 'indieauth' ); ?>
-					</th>
-					<td>
-						<label for="indieauth_root_user">
-							<?php wp_dropdown_users(
-								array(
-									'show_option_all' => __( 'None', 'indieauth' ),
-									'name' => 'indieauth_root_user',
-									'id' => 'indieauth_root_user',
-									'show' => 'display_name_with_login',
-									'selected' => get_option( 'indieauth_root_user' )
-								)
-							); ?>
-							<?php _e( 'Set a User who will represent the URL of the site', 'indieauth' ); ?>
-						</label>
-					</td>
-				</tr>
 				</tr>
 			</tbody>
 		</table>

--- a/templates/indieauth-settings.php
+++ b/templates/indieauth-settings.php
@@ -36,9 +36,6 @@
 						<p><input type="radio" name="indieauth_config" value="local" <?php checked( $checked, 'local' ); ?>><strong><?php _e( 'Use Your Own Site as an IndieAuth Endpoint', 'indieauth' ); ?></strong> <br />
 						<?php _e( 'The endpoint is hosted entirely inside your WordPress instance and requires no external server. When you try to log into a client with your URL you will be presented with your WordPress login screen after which you will be asked if you wish to grant the client permission to act as you. This is the recommended option.', 'indieauth' ); ?>
 						</p>
-						<p><input type="radio" name="indieauth_config" value="remote" <?php checked( $checked, 'remote' ); ?>> <strong><?php _e( 'Use Another Site as an IndieAuth Endpoint', 'indieauth' ); ?></strong> <br />
-						<?php _e( 'For those who do not wish to host their own IndieAuth endpoint or delegate their site authentication to another site. By default, this is indieauth.com which is free for use, but can be any endpoint.', 'indieauth' ); ?>
-						</p>
 					</td>
 				</tr>
 				<tr>

--- a/templates/indieauth-settings.php
+++ b/templates/indieauth-settings.php
@@ -30,16 +30,6 @@
 				</tr>
 				<tr>
 					<th>
-						<?php _e( 'Configuration', 'indieauth' ); ?>
-					</th>
-					<td>
-						<p><input type="radio" name="indieauth_config" value="local" <?php checked( $checked, 'local' ); ?>><strong><?php _e( 'Use Your Own Site as an IndieAuth Endpoint', 'indieauth' ); ?></strong> <br />
-						<?php _e( 'The endpoint is hosted entirely inside your WordPress instance and requires no external server. When you try to log into a client with your URL you will be presented with your WordPress login screen after which you will be asked if you wish to grant the client permission to act as you. This is the recommended option.', 'indieauth' ); ?>
-						</p>
-					</td>
-				</tr>
-				<tr>
-					<th>
 						<?php _e( 'Set User to Represent Site URL', 'indieauth' ); ?>
 					</th>
 					<td>

--- a/templates/indieauth-settings.php
+++ b/templates/indieauth-settings.php
@@ -1,25 +1,14 @@
 <div class="wrap">
 	<h1><?php esc_html_e( 'IndieAuth Settings', 'indieauth' ); ?></h1>
 
-<?php
-$checked = get_option( 'indieauth_config', 'local' );
-$message = get_query_var( 'authdiag_message' );
-if ( $message ) {
-?>
-<div>
-<?php echo $message; ?>
-</div>
-<?php } else {  ?>
-	<h2 class="title"><?php _e( 'Test your System', 'indieauth' ); ?></h2>
-	<p><?php _e( 'If you are experiencing unauthorized as an error, click below to run a test script.', 'indieauth' ); ?></p>
-	<p><a href="<?php echo add_query_arg( 'action', 'authdiag', wp_login_url() ); ?>"><?php _e( 'Diagnostic Script', 'indieauth' ); ?></a></p>
-<?php } ?>
+<?php $checked = get_option( 'indieauth_config', 'local' ); ?>
+
 	<form method="post" action="options.php">
 		<?php settings_fields( 'indieauth' ); ?>
 
 		<h2 class="title"><?php _e( 'IndieAuth', 'indieauth' ); ?></h2>
 
-		<p><?php _e( 'With IndieAuth, you can use your blog, to log into sites like the IndieWeb-Wiki.', 'indieauth' ); ?></p>
+		<p><?php _e( 'With IndieAuth, you can use your blog, to log into sites like the IndieWeb-Wiki. Please run a Site Health check to ensure this will work with your site', 'indieauth' ); ?></p>
 
 		<table class="form-table">
 			<tbody>


### PR DESCRIPTION
This adds an HTTP/SSL check to the Site Health system, restores the remote endpoint functionality, and introduces loading logic to either allow the site to run using an external service like IndieAuth or using the built-in service without loading both simultaneously. It also turns IndieAuth_Plugin into a static class. We can't remove the class as Micropub and Microsub at this time check for its presence. The purpose of the class is to handle the load and store the object reflecting the remote/local configuration.

I tried to get the language in the settings clear about what each does.