### PR TITLE
Additional fixes

### DIFF
--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -363,4 +363,3 @@ class IndieAuth_Admin {
 	}
 }
 
-new IndieAuth_Admin();

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -117,8 +117,12 @@ class IndieAuth_Authorization_Endpoint {
 				'code_challenge_method' => isset( $params['code_challenge_method'] ) ? $params['code_challenge_method'] : null,
 			)
 		);
+
 		if ( 'code' === $params['response_type'] ) {
 			$args['scope'] = isset( $params['scope'] ) ? $params['scope'] : 'create update';
+			if ( ! preg_match( '@^([\x21\x23-\x5B\x5D-\x7E]+( [\x21\x23-\x5B\x5D-\x7E]+)*)?$@', $args['scope'] ) ) {
+				return new WP_OAuth_Response( 'invalid_grant', __( 'Invalid scope request', 'indieauth' ), 400 );
+			}
 		}
 		$url = add_query_params_to_url( $args, $url );
 

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -66,6 +66,7 @@ class IndieAuth_Authorization_Endpoint {
 		$scopes = array(
 			// Micropub Scopes
 			'post'     => __( 'Legacy Scope (Deprecated)', 'indieauth' ),
+			'draft'    => __( 'Allows the applicate to create posts in draft status only', 'indieauth' ),
 			'create'   => __( 'Allows the application to create posts and upload to the Media Endpoint', 'indieauth' ),
 			'update'   => __( 'Allows the application to update posts', 'indieauth' ),
 			'delete'   => __( 'Allows the application to delete posts', 'indieauth' ),

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -277,4 +277,3 @@ class IndieAuth_Authorization_Endpoint {
 	}
 }
 
-new IndieAuth_Authorization_Endpoint();

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -249,10 +249,11 @@ abstract class IndieAuth_Authorize {
 	 * @return string|null Token on success, null on failure.
 	 */
 	public function get_token_from_request() {
-		if ( empty( $_REQUEST['access_token'] ) ) {
+		if ( empty( $_POST['access_token'] ) ) {
 			return null;
 		}
-		$token = $_REQUEST['access_token'];
+		$token = $_POST['access_token'];
+
 		if ( is_string( $token ) ) {
 			return $token;
 		}

--- a/includes/class-indieauth-debug.php
+++ b/includes/class-indieauth-debug.php
@@ -116,4 +116,3 @@ class IndieAuth_Debug {
 	}
 }
 
-new IndieAuth_Debug();

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -231,4 +231,3 @@ class IndieAuth_Token_Endpoint {
 
 }
 
-new IndieAuth_Token_Endpoint();

--- a/indieauth.php
+++ b/indieauth.php
@@ -31,6 +31,8 @@ class IndieAuth_Plugin {
 			)
 		);
 
+		new IndieAuth_Admin();
+
 		// Classes Required for the Local Endpoint
 		$localfiles = array(
 			'class-indieauth-client-discovery.php', // Client Discovery
@@ -54,12 +56,15 @@ class IndieAuth_Plugin {
 				break;
 			default:
 				self::load( $localfiles );
+				new IndieAuth_Authorization_Endpoint();
+				new IndieAuth_Token_Endpoint();
 				static::$indieauth = new IndieAuth_Local_Authorize();
 				break;
 		}
 
 		if ( WP_DEBUG ) {
 			self::load( 'class-indieauth-debug.php' );
+			new IndieAuth_Debug();
 		}
 
 	}

--- a/indieauth.php
+++ b/indieauth.php
@@ -12,6 +12,12 @@
  * Domain Path: /languages
  */
 
+
+/* If this is set then it will activate the remote mode for delegating your login to a remote endpoint */
+if ( ! defined( 'INDIEAUTH_REMOTE_MODE' ) ) {
+	define( 'INDIEAUTH_REMOTE_MODE', 0 );
+}
+
 class IndieAuth_Plugin {
 	public static $indieauth = null; // Loaded instance of authorize class
 
@@ -48,7 +54,10 @@ class IndieAuth_Plugin {
 		$remotefiles = array(
 			'class-indieauth-remote-authorize.php',
 		);
-		$load        = get_option( 'indieauth_config', 'local' );
+		
+		// $load        = get_option( 'indieauth_config', 'local' );
+		$load = INDIEAUTH_REMOTE_MODE ? 'remote' : 'local';
+		
 		switch ( $load ) {
 			case 'remote':
 				self::load( $remotefiles );

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: IndieAuth 3.5.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2020-04-21 03:19:02+00:00\n"
+"POT-Creation-Date: 2020-07-19 23:26:47+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -95,7 +95,7 @@ msgid ""
 "GitHub and we will try to assist"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:127 templates/indieauth-settings.php:52
+#: includes/class-indieauth-admin.php:127 templates/indieauth-settings.php:39
 msgid "None"
 msgstr ""
 
@@ -214,97 +214,105 @@ msgid "Legacy Scope (Deprecated)"
 msgstr ""
 
 #: includes/class-indieauth-authorization-endpoint.php:69
+msgid "Allows the applicate to create posts in draft status only"
+msgstr ""
+
+#: includes/class-indieauth-authorization-endpoint.php:70
 #: includes/class-indieauth-scopes.php:66
 msgid "Allows the application to create posts and upload to the Media Endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:70
+#: includes/class-indieauth-authorization-endpoint.php:71
 #: includes/class-indieauth-scopes.php:94
 msgid "Allows the application to update posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:71
+#: includes/class-indieauth-authorization-endpoint.php:72
 msgid "Allows the application to delete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:72
+#: includes/class-indieauth-authorization-endpoint.php:73
 msgid "Allows the application to undelete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:73
+#: includes/class-indieauth-authorization-endpoint.php:74
 #: includes/class-indieauth-scopes.php:119
 msgid "Allows the application to upload to the media endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:75
+#: includes/class-indieauth-authorization-endpoint.php:76
 msgid "Allows the application read access to channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:76
+#: includes/class-indieauth-authorization-endpoint.php:77
 msgid "Allows the application to manage a follow list"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:77
+#: includes/class-indieauth-authorization-endpoint.php:78
 msgid "Allows the application to mute and unmute users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:78
+#: includes/class-indieauth-authorization-endpoint.php:79
 msgid "Allows the application to block and unlock users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:79
+#: includes/class-indieauth-authorization-endpoint.php:80
 msgid "Allows the application to manage channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:80
+#: includes/class-indieauth-authorization-endpoint.php:81
 #: includes/class-indieauth-scopes.php:178
 msgid "Allows the application to save content for later retrieval"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:82
+#: includes/class-indieauth-authorization-endpoint.php:83
 msgid ""
 "Returns a complete profile to the application. Without this only a display "
 "name, avatar, and url will be returned"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:87
+#: includes/class-indieauth-authorization-endpoint.php:88
 msgid "No Description Available"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:97
+#: includes/class-indieauth-authorization-endpoint.php:98
 msgid "Unsupported Response Type"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:103
-#: includes/class-indieauth-authorization-endpoint.php:148
+#: includes/class-indieauth-authorization-endpoint.php:104
+#: includes/class-indieauth-authorization-endpoint.php:153
 #. translators: Name of missing parameter
 msgid "Missing Parameter: %1$s"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:155
+#: includes/class-indieauth-authorization-endpoint.php:124
+msgid "Invalid scope request"
+msgstr ""
+
+#: includes/class-indieauth-authorization-endpoint.php:160
 #: includes/class-indieauth-local-authorize.php:48
 #: includes/class-indieauth-token-endpoint.php:207
 msgid "Invalid authorization code"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:160
+#: includes/class-indieauth-authorization-endpoint.php:165
 msgid "The authorization code expired"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:168
-#: includes/class-indieauth-authorization-endpoint.php:172
+#: includes/class-indieauth-authorization-endpoint.php:173
+#: includes/class-indieauth-authorization-endpoint.php:177
 #: includes/class-indieauth-token-endpoint.php:212
 #: includes/class-indieauth-token-endpoint.php:216
 msgid "Failed PKCE Validation"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:188
+#: includes/class-indieauth-authorization-endpoint.php:193
 msgid ""
 "There was an error verifying the authorization code. Check that the "
 "client_id and redirect_uri match the original request."
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:139
+#: includes/class-indieauth-authorize.php:153
 msgid "User Not Found on this Site"
 msgstr ""
 
@@ -347,15 +355,15 @@ msgstr ""
 msgid "Please specify a remote indieauth authorization and token endpoint."
 msgstr ""
 
-#: includes/class-indieauth-remote-authorize.php:135
+#: includes/class-indieauth-remote-authorize.php:123
 msgid "Unable to Find User"
 msgstr ""
 
-#: includes/class-indieauth-remote-authorize.php:163
+#: includes/class-indieauth-remote-authorize.php:151
 msgid "IndieAuth.com seems to have some hiccups, please try it again later."
 msgstr ""
 
-#: includes/class-indieauth-remote-authorize.php:175
+#: includes/class-indieauth-remote-authorize.php:163
 msgid "Supplied Token is Invalid"
 msgstr ""
 
@@ -610,7 +618,7 @@ msgstr ""
 msgid "Invalid User Profile URL"
 msgstr ""
 
-#: indieauth.php:83
+#: indieauth.php:97
 #. translators: 1. Path to file unable to load
 msgid "Unable to load: %1s"
 msgstr ""
@@ -717,56 +725,28 @@ msgid "Token Endpoint:"
 msgstr ""
 
 #: templates/indieauth-settings.php:33
-msgid "Configuration"
-msgstr ""
-
-#: templates/indieauth-settings.php:36
-msgid "Use Your Own Site as an IndieAuth Endpoint"
-msgstr ""
-
-#: templates/indieauth-settings.php:37
-msgid ""
-"The endpoint is hosted entirely inside your WordPress instance and requires "
-"no external server. When you try to log into a client with your URL you "
-"will be presented with your WordPress login screen after which you will be "
-"asked if you wish to grant the client permission to act as you. This is the "
-"recommended option."
-msgstr ""
-
-#: templates/indieauth-settings.php:39
-msgid "Use Another Site as an IndieAuth Endpoint"
-msgstr ""
-
-#: templates/indieauth-settings.php:40
-msgid ""
-"For those who do not wish to host their own IndieAuth endpoint or delegate "
-"their site authentication to another site. By default, this is "
-"indieauth.com which is free for use, but can be any endpoint."
-msgstr ""
-
-#: templates/indieauth-settings.php:46
 msgid "Set User to Represent Site URL"
 msgstr ""
 
-#: templates/indieauth-settings.php:59
+#: templates/indieauth-settings.php:46
 msgid "Set a User who will represent the URL of the site"
 msgstr ""
 
-#: templates/indieauth-settings.php:66 templates/websignin-link.php:3
+#: templates/indieauth-settings.php:53 templates/websignin-link.php:3
 msgid "Web Sign-In"
 msgstr ""
 
-#: templates/indieauth-settings.php:68
+#: templates/indieauth-settings.php:55
 msgid ""
 "Enable Web Sign-In for your blog, so others can use IndieAuth or RelMeAuth "
 "to log into this site."
 msgstr ""
 
-#: templates/indieauth-settings.php:74
+#: templates/indieauth-settings.php:61
 msgid "Use IndieAuth login"
 msgstr ""
 
-#: templates/indieauth-settings.php:80
+#: templates/indieauth-settings.php:67
 msgid "Add a link to the login form to authenticate using an IndieAuth endpoint."
 msgstr ""
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,7 @@
 	<exclude-pattern>*/includes/*\.(inc|css|js|svg)</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="5.4-"/>
+	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibilityWP"/>
 	<config name="minimum_supported_wp_version" value="4.7"/>
 	<rule ref="WordPress.WP.DeprecatedFunctions" />

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 **Contributors:** [indieweb](https://profiles.wordpress.org/indieweb), [pfefferle](https://profiles.wordpress.org/pfefferle), [dshanske](https://profiles.wordpress.org/dshanske)  
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.9.9  
-**Requires PHP:** 5.4  
+**Requires PHP:** 5.6  
 **Tested up to:** 5.4.2  
 **Stable tag:** 3.5.0  
 **License:** MIT  

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ IndieAuth is a way to allow users to use their own domain to sign into other web
 
 ## Description ##
 
-The plugin turns WordPress into an IndieAuth endpoint. This can be used to act as an authentication mechanism for WordPress and its REST API, as well as an identity mechanism for other sites. It uses the URL from the profile page to identify the blog user or your author url.
+The plugin turns WordPress into an IndieAuth endpoint. This can be used to act as an authentication mechanism for WordPress and its REST API, as well as an identity mechanism for other sites. It uses the URL from the profile page to identify the blog user or your author url. We recommend your site be served over https to use this.
 
 You can also install this plugin to enable web sign-in for your site using your domain.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
-Requires PHP: 5.4
+Requires PHP: 5.6
 Tested up to: 5.4.2
 Stable tag: 3.5.0
 License: MIT

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ IndieAuth is a way to allow users to use their own domain to sign into other web
 
 == Description ==
 
-The plugin turns WordPress into an IndieAuth endpoint. This can be used to act as an authentication mechanism for WordPress and its REST API, as well as an identity mechanism for other sites. It uses the URL from the profile page to identify the blog user or your author url.
+The plugin turns WordPress into an IndieAuth endpoint. This can be used to act as an authentication mechanism for WordPress and its REST API, as well as an identity mechanism for other sites. It uses the URL from the profile page to identify the blog user or your author url. We recommend your site be served over https to use this.
 
 You can also install this plugin to enable web sign-in for your site using your domain.
 


### PR DESCRIPTION
This hides the remote option behind a constant that is only documented in the code for now, if anyone wants to use it. It also validates the scope is a proper string, switches the token to only work as a POST request, not a GET request. bumps the minimum version to 5.6, moves instantiation of classes out of their own files, etc