### PR TITLE
Tries to Adopt some of the New IndieAuth Changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "installer-name": "indieauth"
   },
   "require": {
-    "php": ">=5.4.0",
+    "php": ">=5.6.0",
     "composer/installers": "~1.0"
   },
   "require-dev": {

--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -23,10 +23,6 @@ class IndieAuth_Admin {
 			'label' => __( 'SSL Test', 'indieauth' ),
 			'test'  => array( $this, 'site_health_https_test' ),
 		);
-		$tests['direct']['indieauth_users']  = array(
-			'label' => __( 'Unique User URL Test', 'indieauth' ),
-			'test'  => array( $this, 'site_health_users_test' ),
-		);
 		return $tests;
 	}
 
@@ -57,34 +53,6 @@ class IndieAuth_Admin {
 			$result['actions']     = __( 'We recommend you acquire an SSL Certificate. You can do this for free through Lets Encrypt', 'indieauth' );
 		}
 
-		return $result;
-	}
-
-	public function site_health_users_test() {
-		$result = array(
-			'label'       => __( 'Unique User URLs Check Passed', 'indieauth' ),
-			'status'      => 'good',
-			'badge'       => array(
-				'label' => __( 'IndieAuth', 'indieauth' ),
-				'color' => 'green',
-			),
-			'description' => sprintf(
-				'<p>%s</p>',
-				__( 'You are using HTTPS and IndieAuth will be secure', 'indieauth' )
-			),
-			'actions'     => '',
-			'test'        => 'indieauth_headers',
-		);
-
-		if ( $this->check_dupe_user_urls() ) {
-			$result['status']      = 'critical';
-			$result['label']       = __( 'Unique User URLs Test Failed', 'indieauth' );
-			$result['description'] = sprintf(
-				'<p>%s</p>',
-				__( 'Multiple user accounts have the same URL set. This is not permitted as this value is used by IndieAuth for login. Please resolve', 'indieauth' )
-			);
-			$result['actions']     = __( 'Under IndieAuth, your URL is your identity. Two accounts cannot have the same website URL in their user profile as this might allow one user to gain the credentials of another', 'indieauth' );
-		}
 		return $result;
 	}
 

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -80,7 +80,9 @@ class IndieAuth_Authorization_Endpoint {
 						/* grant_type=authorization_code is the only one supported right now. This remains optional as not required in
 						 * the original IndieAuth spec, but will eventually be mandatory.
 						 */
-						'grant_type'    => array(),
+						'grant_type'    => array(
+							'default' => 'authorization_code',
+						),
 						/* The authorization code received from the authorization endpoint in the redirect.
 						 */
 						'code'          => array(),
@@ -197,12 +199,15 @@ class IndieAuth_Authorization_Endpoint {
 	public function verify( $request ) {
 		$params = $request->get_params();
 
-		$required = array( 'redirect_uri', 'client_id', 'code' );
+		$required = array( 'redirect_uri', 'client_id', 'code', 'grant_type' );
 		foreach ( $required as $require ) {
 			if ( ! isset( $params[ $require ] ) ) {
 				// translators: Name of missing parameter
 				return new WP_OAuth_Response( 'parameter_absent', sprintf( __( 'Missing Parameter: %1$s', 'indieauth' ), $require ), 400 );
 			}
+		}
+		if ( 'authorization_code' !== $params['grant_type'] ) {
+			return new WP_OAuth_Response( 'invalid_grant', __( 'Endpoint only accepts authorization_code grant_type', 'indieauth' ), 400 );
 		}
 		$params = wp_array_slice_assoc( $params, array( 'client_id', 'redirect_uri' ) );
 		$code   = $request->get_param( 'code' );

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -137,6 +137,19 @@ class IndieAuth_Authorization_Endpoint {
 		return apply_filters( 'indieauth_scope_description', $description, $scope );
 	}
 
+	/*
+	 * Output a list of checkboxes to select scopes.
+	 *
+	 * @param array $scopes Scopes to Output.
+	 */
+	public static function scope_list( $scopes ) {
+		if ( ! empty( $scopes ) ) {
+			foreach ( $scopes as $s ) {
+				printf( '<li><input type="checkbox" name="scope[]" value="%1$s" %2$s /><strong>%1$s</strong> - %3$s</li>', $s, checked( true, true, false ), self::scopes( $s ) );
+			}
+		}
+	}
+
 	public function request( $request ) {
 		$params = $request->get_params();
 		if ( ! isset( $params['response_type'] ) || 'id' === $params['response_type'] ) {

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -169,7 +169,7 @@ class IndieAuth_Authorization_Endpoint {
 			if ( ! preg_match( '@^([\x21\x23-\x5B\x5D-\x7E]+( [\x21\x23-\x5B\x5D-\x7E]+)*)?$@', $args['scope'] ) ) {
 				return new WP_OAuth_Response( 'invalid_grant', __( 'Invalid scope request', 'indieauth' ), 400 );
 			}
-			$scopes = explode( ' ', $scopes );
+			$scopes = explode( ' ', $args['scope'] );
 			if ( in_array( 'email', $scopes, true ) && ! in_array( 'profile', $scopes, true ) ) {
 				return new WP_OAuth_Response( 'invalid_grant', __( 'Cannot request email scope without profile scope', 'indieauth' ), 400 );
 			}

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -143,7 +143,7 @@ class IndieAuth_Authorization_Endpoint {
 		if ( 'code' !== $params['response_type'] ) {
 			return new WP_OAuth_Response( 'unsupported_response_type', __( 'Unsupported Response Type', 'indieauth' ), 400 );
 		}
-		$required = array( 'redirect_uri', 'client_id', 'state', 'me' );
+		$required = array( 'redirect_uri', 'client_id', 'state' );
 		foreach ( $required as $require ) {
 			if ( ! isset( $params[ $require ] ) ) {
 				// translators: Name of missing parameter
@@ -157,7 +157,7 @@ class IndieAuth_Authorization_Endpoint {
 				'_wpnonce'              => wp_create_nonce( 'wp_rest' ),
 				'response_type'         => $params['response_type'],
 				'client_id'             => $params['client_id'],
-				'me'                    => $params['me'],
+				'me'                    => isset( $params['me'] ) ? $params['me'] : null,
 				'state'                 => $params['state'],
 				'code_challenge'        => isset( $params['code_challenge'] ) ? $params['code_challenge'] : null,
 				'code_challenge_method' => isset( $params['code_challenge_method'] ) ? $params['code_challenge_method'] : null,
@@ -195,7 +195,7 @@ class IndieAuth_Authorization_Endpoint {
 	}
 
 	public function verify( $request ) {
-		$params   = $request->get_params();
+		$params = $request->get_params();
 
 		$required = array( 'redirect_uri', 'client_id', 'code' );
 		foreach ( $required as $require ) {
@@ -287,7 +287,7 @@ class IndieAuth_Authorization_Endpoint {
 			)
 		);
 		$url    = add_query_params_to_url( $args, wp_login_url() );
-		if ( empty( $scopes ) || empty( array_diff( $scopes, array( 'profile', 'email' ) ) ) || array( 'profile' ) === $scopes ) {
+		if ( empty( $scopes ) || empty( array_diff( $scopes, array( 'profile', 'email' ) ) ) ) {
 			include plugin_dir_path( __DIR__ ) . 'templates/indieauth-authenticate-form.php';
 		} else {
 			include plugin_dir_path( __DIR__ ) . 'templates/indieauth-authorize-form.php';
@@ -320,7 +320,6 @@ class IndieAuth_Authorization_Endpoint {
 		// In IndieAuth 1.1, me parameter is optional. Me should actually be derived only from the logged in user not from this parameter.
 		// In other implementations, there may be multiple identities permitted for a single user, but this is not currently practical on a 
 		// WordPress site, so we will just ignore the optional me parameter and always return our own.
-		// $me            = isset( $_POST['me'] ) ? wp_unslash( $_POST['me'] ) : null;
 		$me = get_url_from_user( $user );
 
 

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -26,20 +26,48 @@ class IndieAuth_Authorization_Endpoint {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'request' ),
 					'args'                => array(
-						'response_type' => array(),
+						/* Code is currently the only type as of IndieAuth 1.1 and a response_type is now required, but not requiring it here yet.
+						 * Indicates to the authorization server that an authorization code should be returned as the response.
+						 */
+						'response_type' => array(
+							'default'           => 'code',
+							),
+						// The Client URL.
 						'client_id'     => array(
 							'validate_callback' => 'rest_is_valid_url',
 							'sanitize_callback' => 'esc_url_raw',
 						),
+						// The redirect URL indicating where the user should be redirected to after approving the request.
 						'redirect_uri'  => array(
 							'validate_callback' => 'rest_is_valid_url',
 							'sanitize_callback' => 'esc_url_raw',
 						),
+						/* A parameter set by the client which will be included when the user is redirected back to the client. 
+						 * This is used to prevent CSRF attacks. The authorization server MUST return the unmodified state value back to the client.
+						 */
+						'state'         => array(
+							'required'          => true
+						),
+						/* Code Challenge.
+						 * IndieAuth 1.1 requires PKCE, but for now these parameters will remain optional to give time for other implementers.
+						 */
+						'code_challenge' => array(),
+						/* The hashing method used to calculate the code challenge, e.g. "S256"
+						 */
+						'code_challenge_method' => array(),
+
+						/* A space-separated list of scopes the client is requesting, e.g. "profile", or "profile create". 
+						 * If the client omits this value, the authorization server MUST NOT issue an access token for this authorization code. 
+						 * Only the user's profile URL may be returned without any scope requested. See Profile Information for details about 
+						 * which scopes to request to return user profile information. Optional.
+						 */
+						'scope' => array(),
+						/* The Profile URL the user entered. Optional.
+						 */
 						'me'            => array(
 							'validate_callback' => 'rest_is_valid_url',
 							'sanitize_callback' => 'esc_url_raw',
 						),
-						'state'         => array(),
 					),
 					'permission_callback' => '__return_true',
 				),
@@ -47,15 +75,28 @@ class IndieAuth_Authorization_Endpoint {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'verify' ),
 					'args'                => array(
+						/* grant_type=authorization_code is the only one supported right now. This remains optional as not required in
+						 * the original IndieAuth spec, but will eventually be mandatory.
+						 */
+						'grant_type'   => array(),
+						/* The authorization code received from the authorization endpoint in the redirect.
+						 */
 						'code'         => array(),
+						/* The client's URL, which MUST match the client_id used in the authentication request.
+						*/
 						'client_id'    => array(
 							'validate_callback' => 'rest_is_valid_url',
 							'sanitize_callback' => 'esc_url_raw',
 						),
+						/* The client's redirect URL, which MUST match the initial authentication request.
+						 */
 						'redirect_uri' => array(
 							'validate_callback' => 'rest_is_valid_url',
 							'sanitize_callback' => 'esc_url_raw',
 						),
+						/* The original plaintext random string generated before starting the authorization request.
+						 */
+						'code_verifier' => array(),
 					),
 					'permission_callback' => '__return_true',
 				),
@@ -82,7 +123,8 @@ class IndieAuth_Authorization_Endpoint {
 			'channels' => __( 'Allows the application to manage channels', 'indieauth' ),
 			'save'     => __( 'Allows the application to save content for later retrieval', 'indieauth' ),
 			// Profile
-			'profile'  => __( 'Returns a complete profile to the application. Without this only a display name, avatar, and url will be returned', 'indieauth' ),
+			'profile'  => __( 'Allows access to the users default profile information which includes name, photo, and url', 'indieauth' ),
+			'email'    => __( 'Allows access to the users email address', 'indieauth' )
 		);
 		if ( 'all' === $scope ) {
 			return $scopes;
@@ -93,10 +135,10 @@ class IndieAuth_Authorization_Endpoint {
 
 	public function request( $request ) {
 		$params = $request->get_params();
-		if ( ! isset( $params['response_type'] ) ) {
-			$params['response_type'] = 'id';
+		if ( ! isset( $params['response_type'] ) || 'id' === $params['response_type'] ) {
+			$params['response_type'] = 'code';
 		}
-		if ( 'code' !== $params['response_type'] && 'id' !== $params['response_type'] ) {
+		if ( 'code' !== $params['response_type'] ) {
 			return new WP_OAuth_Response( 'unsupported_response_type', __( 'Unsupported Response Type', 'indieauth' ), 400 );
 		}
 		$required = array( 'redirect_uri', 'client_id', 'state', 'me' );
@@ -121,7 +163,7 @@ class IndieAuth_Authorization_Endpoint {
 		);
 
 		if ( 'code' === $params['response_type'] ) {
-			$args['scope'] = isset( $params['scope'] ) ? $params['scope'] : 'create update';
+			$args['scope'] = isset( $params['scope'] ) ? $params['scope'] : '';
 			if ( ! preg_match( '@^([\x21\x23-\x5B\x5D-\x7E]+( [\x21\x23-\x5B\x5D-\x7E]+)*)?$@', $args['scope'] ) ) {
 				return new WP_OAuth_Response( 'invalid_grant', __( 'Invalid scope request', 'indieauth' ), 400 );
 			}
@@ -218,7 +260,7 @@ class IndieAuth_Authorization_Endpoint {
 		$client_icon = $info->get_icon();
 		$redirect_uri  = isset( $_GET['redirect_to'] ) ? wp_unslash( $_GET['redirect_to'] ) : null;
 		$scope         = isset( $_GET['scope'] ) ? wp_unslash( $_GET['scope'] ) : null;
-		$scopes        = explode( ' ', $scope );
+		$scopes        = array_filter( explode( ' ', $scope ) );
 		$state         = isset( $_GET['state'] ) ? $_GET['state'] : null;
 		$me            = isset( $_GET['me'] ) ? wp_unslash( $_GET['me'] ) : null;
 		$response_type = isset( $_GET['response_type'] ) ? wp_unslash( $_GET['response_type'] ) : null;
@@ -238,11 +280,12 @@ class IndieAuth_Authorization_Endpoint {
 			)
 		);
 		$url    = add_query_params_to_url( $args, wp_login_url() );
-		if ( 'code' === $_GET['response_type'] ) {
-			include plugin_dir_path( __DIR__ ) . 'templates/indieauth-authorize-form.php';
-		} elseif ( 'id' === $_GET['response_type'] ) {
+		if ( empty( $scopes ) || empty( array_diff( $scopes, array( 'profile', 'email' ) ) ) || array( 'profile' ) === $scopes || array( 'email' ) === $scopes ) {
 			include plugin_dir_path( __DIR__ ) . 'templates/indieauth-authenticate-form.php';
+		} else {
+			include plugin_dir_path( __DIR__ ) . 'templates/indieauth-authorize-form.php';
 		}
+		
 		include plugin_dir_path( __DIR__ ) . 'templates/indieauth-auth-footer.php';
 	}
 
@@ -254,11 +297,14 @@ class IndieAuth_Authorization_Endpoint {
 		$scope         = isset( $_POST['scope'] ) ? $_POST['scope'] : array();
 		$code_challenge  = isset( $_POST['code_challenge'] ) ? wp_unslash( $_POST['code_challenge'] ) : null;
 		$code_challenge_method  = isset( $_POST['code_challenge_method'] ) ? wp_unslash( $_POST['code_challenge_method'] ) : null;
+
+		// Do not allow the post scope as deprecated. For compatibility, instead update the offering to the more limited but functionally identical create/update.
 		$search = array_search( 'post', $scope, true );
 		if ( is_numeric( $search ) ) {
 			unset( $scope[ $search ] );
 			$scope = array_unique( array_merge( $scope, array( 'create', 'update' ) ) );
 		}
+
 		$scope = implode( ' ', $scope );
 
 		$state         = isset( $_POST['state'] ) ? $_POST['state'] : null;

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -273,10 +273,10 @@ abstract class IndieAuth_Authorize {
 	 * @return string|null Token on success, null on failure.
 	 */
 	public function get_token_from_request() {
-		if ( empty( $_POST['access_token'] ) ) {
+		if ( empty( $_POST['access_token'] ) ) { // phpcs:ignore
 			return null;
 		}
-		$token = $_POST['access_token'];
+		$token = $_POST['access_token']; // phpcs:ignore
 
 		if ( is_string( $token ) ) {
 			return $token;

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -35,6 +35,7 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 			return $return;
 		}
 		$return['last_accessed'] = time();
+		$return['last_ip']       = $_SERVER['REMOTE_ADDR'];
 		$tokens->update( $token, $return );
 		return $return;
 	}

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -183,7 +183,7 @@ class IndieAuth_Token_Endpoint {
 			}
 
 			// Issue a token
-			if ( ! empty( array_diff( $scopes, array( 'profile', 'email' ) ) ) && array( 'profile' ) !== $scopes ) {
+			if ( ! empty( array_diff( $scopes, array( 'profile', 'email' ) ) ) ) {
 				$info                  = new IndieAuth_Client_Discovery( $params['client_id'] );
 				$return['token_type']  = 'Bearer';
 				$return['scope']       = $response['scope'];

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -179,7 +179,7 @@ class IndieAuth_Token_Endpoint {
 				$user = $user->ID;
 			}
 			if ( in_array( 'profile', $scopes, true ) ) {
-				$token['profile'] = indieauth_get_user( $user, in_array( 'email', $scopes, true ) );
+				$return['profile'] = indieauth_get_user( $user, in_array( 'email', $scopes, true ) );
 			}
 
 			// Issue a token

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -149,7 +149,7 @@ class IndieAuth_Token_Endpoint {
 
 	// Request a Token
 	public function request( $params ) {
-		$diff = array_diff( array( 'code', 'client_id', 'redirect_uri', 'me' ), array_keys( $params ) );
+		$diff = array_diff( array( 'code', 'client_id', 'redirect_uri' ), array_keys( $params ) );
 		if ( ! empty( $diff ) ) {
 			return new WP_OAuth_Response( 'invalid_request', __( 'The request is missing one or more required parameters', 'indieauth' ), 400 );
 		}
@@ -184,13 +184,13 @@ class IndieAuth_Token_Endpoint {
 
 			// Issue a token
 			if ( ! empty( array_diff( $scopes, array( 'profile', 'email' ) ) ) ) {
-				$info                  = new IndieAuth_Client_Discovery( $params['client_id'] );
-				$return['token_type']  = 'Bearer';
+				$info                 = new IndieAuth_Client_Discovery( $params['client_id'] );
+				$return['token_type'] = 'Bearer';
 
 				/* Add UUID for reference. In case you’d like to build infrastructure for additional properties and store them in an alternate location.
-				 * This idea came from the core application password implementation. 
+				 * This idea came from the core application password implementation.
 				 */
-				$return['uuid']        =  wp_generate_uuid4(); 
+				$return['uuid'] = wp_generate_uuid4();
 
 				$return['scope']       = $response['scope'];
 				$return['issued_by']   = rest_url( 'indieauth/1.0/token' );

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -186,6 +186,12 @@ class IndieAuth_Token_Endpoint {
 			if ( ! empty( array_diff( $scopes, array( 'profile', 'email' ) ) ) ) {
 				$info                  = new IndieAuth_Client_Discovery( $params['client_id'] );
 				$return['token_type']  = 'Bearer';
+
+				/* Add UUID for reference. In case you’d like to build infrastructure for additional properties and store them in an alternate location.
+				 * This idea came from the core application password implementation. 
+				 */
+				$return['uuid']        =  wp_generate_uuid4(); 
+
 				$return['scope']       = $response['scope'];
 				$return['issued_by']   = rest_url( 'indieauth/1.0/token' );
 				$return['client_id']   = $params['client_id'];

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -41,7 +41,9 @@ class IndieAuth_Token_Endpoint {
 					'args'                => array(
 						/* grant_type=authorization_code is the only one currently supported.
 						 */
-						'grant_type'    => array(),
+						'grant_type'    => array(
+							'default' => 'authorization_code',
+						),
 						/* The authorization code received from the authorization endpoint in the redirect.
 						 */
 						'code'          => array(),
@@ -140,8 +142,10 @@ class IndieAuth_Token_Endpoint {
 			return __( 'The Token Provided is No Longer Valid', 'indieauth' );
 		}
 		// Request Token
-		if ( isset( $params['grant_type'] ) && 'authorization_code' === $params['grant_type'] ) {
+		if ( 'authorization_code' === $params['grant_type'] ) {
 			return $this->request( $params );
+		} else {
+			return new WP_OAuth_Response( 'invalid_grant', __( 'Endpoint only accepts authorization_code grant_type', 'indieauth' ), 400 );
 		}
 		// Everything Failed
 		return new WP_OAuth_Response( 'invalid_request', __( 'Invalid Request', 'indieauth' ), 400 );

--- a/includes/class-web-signin.php
+++ b/includes/class-web-signin.php
@@ -241,7 +241,7 @@ class Web_Signin {
 			$redirect_to = rawurldecode( $redirect_to );
 
 			if ( array_key_exists( 'websignin_identifier', $_POST ) ) { // phpcs:ignore
-				$me = esc_url_raw( $_POST['websignin_identifier'] );
+				$me = esc_url_raw( $_POST['websignin_identifier'] ); //phpcs:ignore
 				// Check for valid URLs
 				if ( ! wp_http_validate_url( $me ) ) {
 					return new WP_Error( 'websignin_invalid_url', __( 'Invalid User Profile URL', 'indieauth' ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -225,7 +225,9 @@ if ( ! function_exists( 'get_url_from_user' ) ) {
 		if ( (int) get_option( 'indieauth_root_user' ) === $user_id ) {
 			return home_url( '/' );
 		}
-		$user = get_user_by( 'ID', $user_id );
+		if ( ! $user_id ) {
+			return null;
+		}
 		return get_author_posts_url( $user_id );
 	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -492,10 +492,13 @@ function base64_urlencode( $string ) {
 }
 
 
-/* Returns jf2 formatted user data
+/* Returns IndieAuth profile user data
  *
+ * @param int|WP_User User.
+ * @param boolean $email Whether to return email or not.
+ * @return array User information or empty if none.
  */
-function indieauth_get_user( $user ) {
+function indieauth_get_user( $user, $email = false ) {
 	if ( is_numeric( $user ) ) {
 		$user = get_user_by( 'ID', $user );
 	}
@@ -503,10 +506,8 @@ function indieauth_get_user( $user ) {
 		return array();
 	}
 	$return = array(
-		'type'  => 'card',
 		'name'  => $user->display_name,
 		'url'   => empty( $user->user_url ) ? get_author_posts_url( $user->ID ) : $user->user_url,
-		'note'  => get_user_meta( $user->ID, 'description', true ),
 		'photo' => get_avatar_url(
 			$user->ID,
 			array(
@@ -514,8 +515,32 @@ function indieauth_get_user( $user ) {
 				'default' => '404',
 			)
 		),
+		'email' => $email ? $user->user_email : false,
 	);
 	return array_filter( $return );
+}
+
+function indieauth_verify_local_authorization_code( $args ) {
+	$tokens = new Token_User( '_indieauth_code_' );
+	$return = $tokens->get( $args['code'] );
+	if ( ! $return ) {
+		return new WP_OAuth_Response( 'invalid_code', __( 'Invalid authorization code', 'indieauth' ), 401 );
+	}
+	if ( isset( $return['code_challenge'] ) ) {
+		if ( ! isset( $args['code_verifier'] ) ) {
+			$tokens->destroy( $post_args['code'] );
+			return new WP_OAuth_Response( 'invalid_grant', __( 'Failed PKCE Validation', 'indieauth' ), 400 );
+		}
+		if ( ! pkce_verifier( $return['code_challenge'], $args['code_verifier'], $return['code_challenge_method'] ) ) {
+			$tokens->destroy( $args['code'] );
+			return new WP_OAuth_Response( 'invalid_grant', __( 'Failed PKCE Validation', 'indieauth' ), 400 );
+		}
+		unset( $return['code_challenge'] );
+		unset( $return['code_challenge_method'] );
+	}
+
+	$tokens->destroy( $args['code'] );
+	return $return;
 }
 
 function indieauth_get_authorization_endpoint() {

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 3.5.1
+ * Version: 3.6.0
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 3.5.1\n"
+"Project-Id-Version: IndieAuth 3.6.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2020-08-15 14:46:44+00:00\n"
+"POT-Creation-Date: 2020-12-13 20:38:40+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -14,19 +14,15 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"
 
-#: includes/class-indieauth-admin.php:22
+#: includes/class-indieauth-admin.php:19
 msgid "IndieAuth Test"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:26
+#: includes/class-indieauth-admin.php:23
 msgid "SSL Test"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:30
-msgid "Unique User URL Test"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:39
+#: includes/class-indieauth-admin.php:32
 msgid "HTTPS Check Passed"
 msgstr ""
 
@@ -34,116 +30,87 @@ msgstr ""
 msgid "IndieAuth"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:47 includes/class-indieauth-admin.php:76
+#: includes/class-indieauth-admin.php:40
 msgid "You are using HTTPS and IndieAuth will be secure"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:55
+#: includes/class-indieauth-admin.php:48
 msgid "HTTPS Test Failed"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:58
+#: includes/class-indieauth-admin.php:51
 msgid ""
 "You are not serving your site via HTTPS. This is a security risk if running "
 "IndieAuth."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:60
+#: includes/class-indieauth-admin.php:53
 msgid ""
 "We recommend you acquire an SSL Certificate. You can do this for free "
 "through Lets Encrypt"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:68
-msgid "Unique User URLs Check Passed"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:84
-msgid "Unique User URLs Test Failed"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:87
-msgid ""
-"Multiple user accounts have the same URL set. This is not permitted as this "
-"value is used by IndieAuth for login. Please resolve"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:89
-msgid ""
-"Under IndieAuth, your URL is your identity. Two accounts cannot have the "
-"same website URL in their user profile as this might allow one user to gain "
-"the credentials of another"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:96
+#: includes/class-indieauth-admin.php:61
 msgid "Authorization Header Passed"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:104
+#: includes/class-indieauth-admin.php:69
 msgid ""
 "Your hosting provider allows authorization headers to pass so IndieAuth "
 "should work"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:112
+#: includes/class-indieauth-admin.php:77
 msgid "Authorization Test Failed"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:117
+#: includes/class-indieauth-admin.php:82
 msgid ""
 "If contacting your hosting provider does not work you can open an issue on "
 "GitHub and we will try to assist"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:127 templates/indieauth-settings.php:41
-msgid "None"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:136
-msgid "Website"
-msgstr ""
-
-#: includes/class-indieauth-admin.php:184
+#: includes/class-indieauth-admin.php:92
 msgid "Authorization Header Found. You should be able to use all clients."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:186
+#: includes/class-indieauth-admin.php:94
 msgid "Alternate Header Found. You should be able to use all clients."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:215
+#: includes/class-indieauth-admin.php:123
 msgid "Configuration option for IndieAuth Plugin"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:225
+#: includes/class-indieauth-admin.php:133
 msgid "Offer IndieAuth on Login Form"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:235
+#: includes/class-indieauth-admin.php:143
 msgid "User Who is Represented by the Site URL"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:243 templates/indieauth-settings.php:2
+#: includes/class-indieauth-admin.php:151 templates/indieauth-settings.php:2
 msgid "IndieAuth Settings"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:256
+#: includes/class-indieauth-admin.php:164
 msgid ""
 "Based on your feedback and to improve the user experience, we decided to "
 "move the settings to a separate <a href=\"%1$s\">settings-page</a>."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:329
+#: includes/class-indieauth-admin.php:237
 msgid "Overview"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:331
+#: includes/class-indieauth-admin.php:239
 msgid ""
 "IndieAuth is a way for doing Web sign-in, where you use your own homepage "
 "to sign in to other places."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:332
+#: includes/class-indieauth-admin.php:240
 msgid ""
 "IndieAuth was built on ideas and technology from existing proven "
 "technologies like OAuth and OpenID but aims at making it easier for users "
@@ -151,19 +118,19 @@ msgid ""
 "completely separate implementations and services can be used for each part."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:339
+#: includes/class-indieauth-admin.php:247
 msgid "The IndieWeb"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:341
+#: includes/class-indieauth-admin.php:249
 msgid "The IndieWeb is a people-focused alternative to the \"corporate web\"."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:343
+#: includes/class-indieauth-admin.php:251
 msgid "Your content is yours"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:344
+#: includes/class-indieauth-admin.php:252
 msgid ""
 "When you post something on the web, it should belong to you, not a "
 "corporation. Too many companies have gone out of business and lost all of "
@@ -171,147 +138,158 @@ msgid ""
 "your control."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:347
+#: includes/class-indieauth-admin.php:255
 msgid "You are better connected"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:348
+#: includes/class-indieauth-admin.php:256
 msgid ""
 "Your articles and status messages can go to all services, not just one, "
 "allowing you to engage with everyone. Even replies and likes on other "
 "services can come back to your site so they’re all in one place."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:351
+#: includes/class-indieauth-admin.php:259
 msgid "You are in control"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:352
+#: includes/class-indieauth-admin.php:260
 msgid ""
 "You can post anything you want, in any format you want, with no one "
 "monitoring you. In addition, you share simple readable links such as "
 "example.com/ideas. These links are permanent and will always work."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:358
+#: includes/class-indieauth-admin.php:266
 msgid "For more information:"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:359
+#: includes/class-indieauth-admin.php:267
 msgid "<a href=\"https://indieweb.org/IndieAuth\">IndieWeb Wiki page</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:360
+#: includes/class-indieauth-admin.php:268
 msgid "<a href=\"https://indieauth.rocks/\">Test suite</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:361
+#: includes/class-indieauth-admin.php:269
 msgid "<a href=\"https://www.w3.org/TR/indieauth/\">W3C Spec</a>"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:68
+#: includes/class-indieauth-authorization-endpoint.php:115
 msgid "Legacy Scope (Deprecated)"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:69
+#: includes/class-indieauth-authorization-endpoint.php:116
 msgid "Allows the applicate to create posts in draft status only"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:70
+#: includes/class-indieauth-authorization-endpoint.php:117
 msgid "Allows the application to create posts and upload to the Media Endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:71
+#: includes/class-indieauth-authorization-endpoint.php:118
 #: includes/class-indieauth-scopes.php:93
 msgid "Allows the application to update posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:72
+#: includes/class-indieauth-authorization-endpoint.php:119
 msgid "Allows the application to delete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:73
+#: includes/class-indieauth-authorization-endpoint.php:120
 msgid "Allows the application to undelete posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:74
+#: includes/class-indieauth-authorization-endpoint.php:121
 #: includes/class-indieauth-scopes.php:118
 msgid "Allows the application to upload to the media endpoint"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:76
+#: includes/class-indieauth-authorization-endpoint.php:123
 msgid "Allows the application read access to channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:77
+#: includes/class-indieauth-authorization-endpoint.php:124
 msgid "Allows the application to manage a follow list"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:78
+#: includes/class-indieauth-authorization-endpoint.php:125
 msgid "Allows the application to mute and unmute users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:79
+#: includes/class-indieauth-authorization-endpoint.php:126
 msgid "Allows the application to block and unlock users"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:80
+#: includes/class-indieauth-authorization-endpoint.php:127
 msgid "Allows the application to manage channels"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:81
+#: includes/class-indieauth-authorization-endpoint.php:128
 #: includes/class-indieauth-scopes.php:177
 msgid "Allows the application to save content for later retrieval"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:83
+#: includes/class-indieauth-authorization-endpoint.php:130
 msgid ""
-"Returns a complete profile to the application. Without this only a display "
-"name, avatar, and url will be returned"
+"Allows access to the users default profile information which includes name, "
+"photo, and url"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:88
+#: includes/class-indieauth-authorization-endpoint.php:131
+msgid "Allows access to the users email address"
+msgstr ""
+
+#: includes/class-indieauth-authorization-endpoint.php:136
 msgid "No Description Available"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:98
+#: includes/class-indieauth-authorization-endpoint.php:146
 msgid "Unsupported Response Type"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:104
-#: includes/class-indieauth-authorization-endpoint.php:153
+#: includes/class-indieauth-authorization-endpoint.php:152
+#: includes/class-indieauth-authorization-endpoint.php:206
 #. translators: Name of missing parameter
 msgid "Missing Parameter: %1$s"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:124
+#: includes/class-indieauth-authorization-endpoint.php:172
 msgid "Invalid scope request"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:160
-#: includes/class-indieauth-local-authorize.php:48
-#: includes/class-indieauth-token-endpoint.php:207
+#: includes/class-indieauth-authorization-endpoint.php:176
+msgid "Cannot request email scope without profile scope"
+msgstr ""
+
+#: includes/class-indieauth-authorization-endpoint.php:210
+#: includes/class-indieauth-token-endpoint.php:148
+msgid "Endpoint only accepts authorization_code grant_type"
+msgstr ""
+
+#: includes/class-indieauth-authorization-endpoint.php:216
+#: includes/class-indieauth-local-authorize.php:49 includes/functions.php:527
 msgid "Invalid authorization code"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:165
+#: includes/class-indieauth-authorization-endpoint.php:221
 msgid "The authorization code expired"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:173
-#: includes/class-indieauth-authorization-endpoint.php:177
-#: includes/class-indieauth-token-endpoint.php:212
-#: includes/class-indieauth-token-endpoint.php:216
+#: includes/class-indieauth-authorization-endpoint.php:229
+#: includes/class-indieauth-authorization-endpoint.php:233
+#: includes/functions.php:532 includes/functions.php:536
 msgid "Failed PKCE Validation"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:193
+#: includes/class-indieauth-authorization-endpoint.php:249
 msgid ""
 "There was an error verifying the authorization code. Check that the "
 "client_id and redirect_uri match the original request."
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:153
+#: includes/class-indieauth-authorize.php:177
 msgid "User Not Found on this Site"
 msgstr ""
 
@@ -338,7 +316,7 @@ msgid ""
 msgstr ""
 
 #: includes/class-indieauth-local-authorize.php:30
-#: includes/class-indieauth-token-endpoint.php:100
+#: includes/class-indieauth-token-endpoint.php:114
 msgid "Invalid access token"
 msgstr ""
 
@@ -408,33 +386,27 @@ msgid ""
 "response. Without this only a display name, avatar, and url will be returned"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:90
+#: includes/class-indieauth-token-endpoint.php:104
 msgid ""
 "Bearer Token Not Supplied or Server Misconfigured to Not Pass Token. Run "
-"diagnostic script in WordPress Admin \n"
+"diagnostic script in WordPress Admin\n"
 "\t\t\t\tIndieAuth Settings Page"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:128
+#: includes/class-indieauth-token-endpoint.php:142
 msgid "The Token Provided is No Longer Valid"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:135
+#: includes/class-indieauth-token-endpoint.php:151
 msgid "Invalid Request"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:142
+#: includes/class-indieauth-token-endpoint.php:158
 msgid "The request is missing one or more required parameters"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:198
-msgid ""
-"This authorization code was issued with no scope, so it cannot be used to "
-"obtain an access token"
-msgstr ""
-
-#: includes/class-indieauth-token-endpoint.php:200
-msgid "There was an error issuing the access token"
+#: includes/class-indieauth-token-endpoint.php:231
+msgid "There was an error in response."
 msgstr ""
 
 #: includes/class-indieauth-token-ui.php:33
@@ -659,7 +631,7 @@ msgid "Authorization Header Test"
 msgstr ""
 
 #: templates/indieauth-authenticate-form.php:4
-#: templates/indieauth-authenticate-form.php:36
+#: templates/indieauth-authenticate-form.php:48
 msgid "Authenticate"
 msgstr ""
 
@@ -676,17 +648,23 @@ msgid ""
 "the domain of the client ID."
 msgstr ""
 
-#: templates/indieauth-authenticate-form.php:37
-#: templates/indieauth-authorize-form.php:58
+#: templates/indieauth-authenticate-form.php:27
+msgid ""
+"In addition, the app is requesting access to additional user profile "
+"information"
+msgstr ""
+
+#: templates/indieauth-authenticate-form.php:49
+#: templates/indieauth-authorize-form.php:60
 msgid "Cancel"
 msgstr ""
 
-#: templates/indieauth-authenticate-form.php:40
+#: templates/indieauth-authenticate-form.php:52
 msgid "You will be redirected to <code>%1$s</code> after authenticating."
 msgstr ""
 
 #: templates/indieauth-authorize-form.php:4
-#: templates/indieauth-authorize-form.php:57
+#: templates/indieauth-authorize-form.php:59
 msgid "Authorize"
 msgstr ""
 
@@ -702,7 +680,7 @@ msgid ""
 "href=\"https://indieweb.org/scope\">scopes</a>"
 msgstr ""
 
-#: templates/indieauth-authorize-form.php:61
+#: templates/indieauth-authorize-form.php:63
 msgid ""
 "You will be redirected to <code>%1$s</code> after authorizing this "
 "application."
@@ -735,6 +713,10 @@ msgstr ""
 
 #: templates/indieauth-settings.php:35
 msgid "Set User to Represent Site URL"
+msgstr ""
+
+#: templates/indieauth-settings.php:41
+msgid "None"
 msgstr ""
 
 #: templates/indieauth-settings.php:48

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.6  
 **Tested up to:** 5.5  
-**Stable tag:** 3.5.1  
+**Stable tag:** 3.6.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -130,6 +130,11 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 ## Upgrade Notice ##
 
+### 3.6.0 ###
+
+Due to the fact that this upgrades the spec adherence to address the changes in the IndieAuth Living Standard as of September 26, 2020, there may be unanticipated issues with clients not meeting the changes.
+Until such a time as more IndieAuth clients adopt the changes, some elements of the changes will not be mandatory, such as PKCE compliance.
+
 ### 3.4.0 ###
 
 Due to the possibility of someone setting the url in their user profile to the same as another account, you will no longer be able to save the exact same url into two accounts. If you already set two accounts to the 
@@ -146,6 +151,14 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 3.6.0 ###
+* Adopt changes to the living spec as of the September 26, 2020 version.
+* Drop explicit support for response_type=id. Endpoint will convert to type code for backcompat until further notice.
+* Change experimental profile return behavior to match newly documented behavior in spec.
+* Support profile and email scopes, to be handled within this plugin. 
+* Add additional code comments
+* Remove unique URL code as looking for user URLs is no longer supported
 
 ### 3.5.1 ###
 * Make Site Health More Explicit

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.6  
-**Tested up to:** 5.5  
+**Tested up to:** 5.6  
 **Stable tag:** 3.6.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
@@ -114,7 +114,7 @@ If your Micropub client includes an `Authorization` HTTP request header but you 
 
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 
-If that doesn't work, [try this line](https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing):
+If you are not running the latest version of WordPress, [try this line](https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing). It is added automatically as of 5.6:
 
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
@@ -132,7 +132,7 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 ### 3.6.0 ###
 
-Due to the fact that this upgrades the spec adherence to address the changes in the IndieAuth Living Standard as of September 26, 2020, there may be unanticipated issues with clients not meeting the changes.
+Due to the fact that this upgrades the spec adherence to address the changes in the IndieAuth Living Standard as of November 26, 2020, there may be unanticipated issues with clients not meeting the changes.
 Until such a time as more IndieAuth clients adopt the changes, some elements of the changes will not be mandatory, such as PKCE compliance.
 
 ### 3.4.0 ###
@@ -153,12 +153,14 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
 
 ### 3.6.0 ###
-* Adopt changes to the living spec as of the September 26, 2020 version.
+* Adopt changes to the living spec as of the November 26, 2020 version.
 * Drop explicit support for response_type=id. Endpoint will convert to type code for backcompat until further notice.
 * Change experimental profile return behavior to match newly documented behavior in spec.
 * Support profile and email scopes, to be handled within this plugin. 
 * Add additional code comments
 * Remove unique URL code as looking for user URLs is no longer supported
+* Add UUID to tokens as used in the WP5.6 Application Password feature.
+* Add Last IP Accessed to storage as used in the WP5.6 Application Password feature.
 
 ### 3.5.1 ###
 * Make Site Health More Explicit

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.6
-Tested up to: 5.5
+Tested up to: 5.6
 Stable tag: 3.6.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
@@ -114,7 +114,7 @@ If your Micropub client includes an `Authorization` HTTP request header but you 
 
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
 
-If that doesn't work, [try this line](https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing):
+If you are not running the latest version of WordPress, [try this line](https://github.com/georgestephanis/application-passwords/wiki/Basic-Authorization-Header----Missing). It is added automatically as of 5.6:
 
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
@@ -132,7 +132,7 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 = 3.6.0 =
 
-Due to the fact that this upgrades the spec adherence to address the changes in the IndieAuth Living Standard as of September 26, 2020, there may be unanticipated issues with clients not meeting the changes.
+Due to the fact that this upgrades the spec adherence to address the changes in the IndieAuth Living Standard as of November 26, 2020, there may be unanticipated issues with clients not meeting the changes.
 Until such a time as more IndieAuth clients adopt the changes, some elements of the changes will not be mandatory, such as PKCE compliance.
 
 = 3.4.0 =
@@ -153,12 +153,14 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
 
 = 3.6.0 = 
-* Adopt changes to the living spec as of the September 26, 2020 version.
+* Adopt changes to the living spec as of the November 26, 2020 version.
 * Drop explicit support for response_type=id. Endpoint will convert to type code for backcompat until further notice.
 * Change experimental profile return behavior to match newly documented behavior in spec.
 * Support profile and email scopes, to be handled within this plugin. 
 * Add additional code comments
 * Remove unique URL code as looking for user URLs is no longer supported
+* Add UUID to tokens as used in the WP5.6 Application Password feature.
+* Add Last IP Accessed to storage as used in the WP5.6 Application Password feature.
 
 = 3.5.1 =
 * Make Site Health More Explicit

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.6
 Tested up to: 5.5
-Stable tag: 3.5.1
+Stable tag: 3.6.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -130,6 +130,11 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 == Upgrade Notice ==
 
+= 3.6.0 =
+
+Due to the fact that this upgrades the spec adherence to address the changes in the IndieAuth Living Standard as of September 26, 2020, there may be unanticipated issues with clients not meeting the changes.
+Until such a time as more IndieAuth clients adopt the changes, some elements of the changes will not be mandatory, such as PKCE compliance.
+
 = 3.4.0 =
 
 Due to the possibility of someone setting the url in their user profile to the same as another account, you will no longer be able to save the exact same url into two accounts. If you already set two accounts to the 
@@ -146,6 +151,14 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 3.6.0 = 
+* Adopt changes to the living spec as of the September 26, 2020 version.
+* Drop explicit support for response_type=id. Endpoint will convert to type code for backcompat until further notice.
+* Change experimental profile return behavior to match newly documented behavior in spec.
+* Support profile and email scopes, to be handled within this plugin. 
+* Add additional code comments
+* Remove unique URL code as looking for user URLs is no longer supported
 
 = 3.5.1 =
 * Make Site Health More Explicit

--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -23,6 +23,18 @@ login_header(
 		</p>
 		<?php } ?>
 	</div>
+	<div class="scope-info">
+		<?php _e( 'In addition, the app is requesting access to additional user profile information', 'indieauth' ); ?>
+		<ul>
+		<?php
+		if ( ! empty( $scopes ) ) {
+			foreach ( $scopes as $s ) {
+				printf( '<li><input type="checkbox" name="scope[]" value="%1$s" %2$s /><strong>%1$s</strong> - %3$s</li>', $s, checked( true, true, false ), self::scopes( $s ) );
+			}
+		}
+		?>
+		</ul>
+	</div>
 	<p class="submit">
 	<?php
 		// Hook to allow adding to form

--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -27,13 +27,7 @@ login_header(
 	<div class="scope-info">
 		<?php _e( 'In addition, the app is requesting access to additional user profile information', 'indieauth' ); ?>
 		<ul>
-		<?php
-		if ( ! empty( $scopes ) ) {
-			foreach ( $scopes as $s ) {
-				printf( '<li><input type="checkbox" name="scope[]" value="%1$s" %2$s /><strong>%1$s</strong> - %3$s</li>', $s, checked( true, true, false ), self::scopes( $s ) );
-			}
-		}
-		?>
+		<?php self::scope_list( $scopes ); ?>
 		</ul>
 	</div>
 	<p class="submit">

--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -5,6 +5,12 @@ login_header(
 	'',
 	$errors
 );
+$user_id = get_url_from_user( $current_user->ID );
+if ( ! $user_id ) {
+	__e( 'The application cannot sign you in as WordPress cannot determine the current user', 'indieauth' );
+	exit;
+}
+	
 ?>
 <form method="post" action="<?php echo $url; ?>">
 	<div class="login-info">
@@ -13,7 +19,7 @@ login_header(
 			printf(
 				'<p>' . __( 'The app <strong>%1$s</strong> would like to sign you in as <strong>%2$s</strong>.', 'indieauth' ) . '</p>',
 				$client_id,
-				get_url_from_user( $current_user->ID )
+				$user_id
 				
 			);
 

--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -13,7 +13,8 @@ login_header(
 			printf(
 				'<p>' . __( 'The app <strong>%1$s</strong> would like to sign you in as <strong>%2$s</strong>.', 'indieauth' ) . '</p>',
 				$client_id,
-				$me
+				get_url_from_user( $current_user->ID )
+				
 			);
 
 		if ( wp_parse_url( $client_id, PHP_URL_HOST ) !== wp_parse_url( $redirect_uri, PHP_URL_HOST ) ) {
@@ -38,7 +39,7 @@ login_header(
 	<p class="submit">
 	<?php
 		// Hook to allow adding to form
-		do_action( 'indieauth_authentication_form', $current_user->user_id, $client_id );
+		do_action( 'indieauth_authentication_form', $current_user->ID, $client_id );
 	?>
 		<input type="hidden" name="client_id" value="<?php echo $client_id; ?>" />
 		<input type="hidden" name="redirect_uri" value="<?php echo $redirect_uri; ?>" />

--- a/templates/indieauth-authorize-form.php
+++ b/templates/indieauth-authorize-form.php
@@ -32,13 +32,7 @@ login_header(
 	<div class="scope-info">
 		<?php _e( 'The app is requesting the following <a href="https://indieweb.org/scope">scopes</a>', 'indieauth' ); ?>
 		<ul>
-		<?php
-		if ( ! empty( $scopes ) ) {
-			foreach ( $scopes as $s ) {
-				printf( '<li><input type="checkbox" name="scope[]" value="%1$s" %2$s /><strong>%1$s</strong> - %3$s</li>', $s, checked( true, true, false ), self::scopes( $s ) );
-			}
-		}
-		?>
+		<?php self::scope_list( $scopes ); ?>
 		</ul>
 	</div>
 	<p class="submit">

--- a/templates/indieauth-authorize-form.php
+++ b/templates/indieauth-authorize-form.php
@@ -33,8 +33,10 @@ login_header(
 		<?php _e( 'The app is requesting the following <a href="https://indieweb.org/scope">scopes</a>', 'indieauth' ); ?>
 		<ul>
 		<?php
-		foreach ( $scopes as $s ) {
-			printf( '<li><input type="checkbox" name="scope[]" value="%1$s" %2$s /><strong>%1$s</strong> - %3$s</li>', $s, checked( true, true, false ), self::scopes( $s ) );
+		if ( ! empty( $scopes ) ) {
+			foreach ( $scopes as $s ) {
+				printf( '<li><input type="checkbox" name="scope[]" value="%1$s" %2$s /><strong>%1$s</strong> - %3$s</li>', $s, checked( true, true, false ), self::scopes( $s ) );
+			}
 		}
 		?>
 		</ul>

--- a/tests/test-auth-endpoint.php
+++ b/tests/test-auth-endpoint.php
@@ -1,0 +1,15 @@
+<?php
+class AuthEndpointTest extends WP_UnitTestCase {
+	 
+	public function test_pkce_verifier_true() {
+	 	$code_challenge = "OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo";   
+	 	$code_verifier  = "a6128783714cfda1d388e2e98b6ae8221ac31aca31959e59512c59f5";
+		$this->assertTrue( pkce_verifier( $code_challenge, $code_verifier, 'S256' ) );
+	}
+
+	public function test_pkce_verifier_false() {
+	 	$code_challenge = "OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo";   
+	 	$code_verifier  = "a612878371009ghja1d388e2e98b6ae8221ac31aca31959e59512c59f5";
+		$this->assertFalse( pkce_verifier( $code_challenge, $code_verifier, 'S256' ) );
+	}
+}

--- a/tests/test-getuserbyurl.php
+++ b/tests/test-getuserbyurl.php
@@ -26,12 +26,4 @@ class UsersTest extends WP_UnitTestCase {
 		$result = url_to_author( get_author_posts_url( static::$author_id ) );
 		$this->assertSame( $result->ID, static::$author_id );
 	}
-
-	// Test Retrieving ID using the user_url
-	public function test_userurl() {
-		$this->factory->user->create_many( 4 );
-		wp_update_user( array( 'ID' => 4, 'user_url' => 'http://example.uk' ) );
-		$result = get_user_by_identifier( 'http://example.uk' );
-		$this->assertSame( $result->ID, 4 );
-	}
 }

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -11,4 +11,14 @@ class TokensTest extends WP_UnitTestCase {
 		$this->assertEquals( $token, $get );
 	}
 
+
+	public function test_expired_token() {
+		$user_id = self::factory()->user->create();
+		$tokens = new Token_User( '_indieauth_code_', $user_id );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$key = $tokens->set( $token, -30 );
+		$get = $tokens->get( $key );
+		$this->assertFalse( $get );
+	}
+
 }


### PR DESCRIPTION
The most notable changes here are cuts. The unique URL code is gone, as per the changes to the spec, only URLs on the same domain as the initially entered URL should be accepted by the client. 

The me url is now optional, so changes were added to ensure less reliance on it. The URL returned is either the root domain when set in the plugin, or the author URL. This ensures, as per the concerns in https://indieauth.spec.indieweb.org/#differing-user-profile-urls.

This also changes the profile response, which was experimental, to the final version, which only appears with a profile scope being requested, and adds support for the email scope.

Since the exchange has been simplified, the 'id' response_type is now gone, and the new parameters for issuing a token vs just a profile return have been added. Because not all clients may have caught up, until further notice, requesting 'id' will behave like a 'code' request with no scope. 