### PR TITLE
Clean Up Token Job

### DIFF
--- a/includes/class-indieauth-token-ui.php
+++ b/includes/class-indieauth-token-ui.php
@@ -100,6 +100,9 @@ class IndieAuth_Token_UI {
 		// As a precaution every time the Token UI page is lost it will check for any expired auth codes and purge them
 		$codes = new Token_User( '_indieauth_code_', get_current_user_id() );
 		$codes->check_expires();
+		// Check to see if the cleanup function is scheduled.
+		IndieAuth_Plugin::schedule();
+
 		$token_table = new Token_List_Table();
 		echo '<div class="wrap"><h2>' . esc_html__( 'Manage IndieAuth Tokens', 'indieauth' ) . '</h2>';
 		echo '<form method="get">';

--- a/includes/class-token-list-table.php
+++ b/includes/class-token-list-table.php
@@ -39,8 +39,17 @@ class Token_List_Table extends WP_List_Table {
 		$this->process_action();
 		$this->_column_headers = array( $columns, $hidden, $this->get_sortable_columns() );
 		$t                     = new Token_User( '_indieauth_token_', get_current_user_id() );
+		// Always refresh the list of token users while loading this page.
+		$t->find_token_users( true );
 		$tokens                = $t->get_all();
 		$this->items           = array();
+		$this->set_pagination_args( 
+			array(
+				'total_items' => count( $tokens ),
+				'total_pages' => 1,
+				'per_page' => count( $tokens )
+			)
+		);
 		foreach ( $tokens as $key => $value ) {
 			$value['token'] = $key;
 			$this->items[]  = $value;

--- a/includes/class-token-list-table.php
+++ b/includes/class-token-list-table.php
@@ -26,7 +26,6 @@ class Token_List_Table extends WP_List_Table {
 				  'revoke_week'  => __( 'Revoke Tokens Last Accessed 1 Week Ago or Never', 'indieauth' ),
 				  'revoke_day'   => __( 'Revoke Tokens Last Accessed 1 Day Ago or Never', 'indieauth' ),
 				  'revoke_hour'  => __( 'Revoke Tokens Last Accessed 1 Hour Ago or Never', 'indieauth' ),
-				  'cleanup'      => __( 'Clean Up Expired Tokens and Authorization Codes', 'indieauth' ),
 			  );
 	}
 
@@ -69,11 +68,6 @@ class Token_List_Table extends WP_List_Table {
 						$t->destroy( $token );
 					}
 				}
-				break;
-			case 'cleanup':
-				$t->check_expires();
-				$users = new Token_User( '_indieauth_code_', get_current_user_id() );
-				$users->destroy_all();
 				break;
 			case 'revoke_year':
 				$this->destroy_older_than( $t, 'year' );

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -101,8 +101,13 @@ class Token_User extends Token_Generic {
 		foreach ( $meta as $key => $value ) {
 			if ( 0 === strncmp( $key, $this->prefix, strlen( $this->prefix ) ) ) {
 				$value         = maybe_unserialize( array_pop( $value ) );
+				$key = str_replace( $this->prefix, '', $key );
 				$value['user'] = $this->user_id;
-				$tokens[ str_replace( $this->prefix, '', $key ) ] = $value;
+				if ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) {
+					$this->destroy( $key );
+				} else {
+					$tokens[ $key ] = $value;
+				}
 			}
 		}
 		return $tokens;

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -203,4 +203,22 @@ class Token_User extends Token_Generic {
 		}
 		return update_user_meta( $this->user_id, $key, $info );
 	}
+
+	/**
+	 *
+	 */
+	public function find_token_users() {
+		$args     = array(
+			'count_total' => false,
+			'fields'      => 'ID',
+			'meta_query'  => array(
+				array(
+					'key'         => $this->prefix,
+					'compare_key' => 'LIKE',
+				),
+			),
+		);
+		$user_ids = get_users( $args );
+		return $user_ids;
+	}
 }

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -101,7 +101,7 @@ class Token_User extends Token_Generic {
 		foreach ( $meta as $key => $value ) {
 			if ( 0 === strncmp( $key, $this->prefix, strlen( $this->prefix ) ) ) {
 				$value         = maybe_unserialize( array_pop( $value ) );
-				$key = str_replace( $this->prefix, '', $key );
+				$key           = str_replace( $this->prefix, '', $key );
 				$value['user'] = $this->user_id;
 				if ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) {
 					$this->destroy( $key );
@@ -150,6 +150,7 @@ class Token_User extends Token_Generic {
 		$args    = array(
 			'number'      => 1,
 			'count_total' => false,
+			'fields'      => 'ID',
 			'meta_query'  => array(
 				array(
 					'key'     => $key,
@@ -157,25 +158,24 @@ class Token_User extends Token_Generic {
 				),
 			),
 		);
-		$query   = new WP_User_Query( $args );
-		$results = $query->get_results();
+		$results = get_users( $args );
 		if ( empty( $results ) ) {
 			return false;
 		}
-		$user  = $results[0];
-		$value = get_user_meta( $user->ID, $key, true );
+		$user_id = $results[0];
+		$value   = get_user_meta( $user_id, $key, true );
 		if ( empty( $value ) ) {
 			return false;
 		}
 
 		// If this token has expired destroy the token and return false;
 		if ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) {
-			$this->destroy( $key, $user->ID );
+			$this->destroy( $key, $user_ID );
 			return false;
 		}
 
-		$this->user_id = $user->ID;
-		$value['user'] = $user->ID;
+		$this->user_id = $user_id;
+		$value['user'] = $user_id;
 		return $value;
 
 	}

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -177,6 +177,7 @@ class Token_User extends Token_Generic {
 			return false;
 		}
 		$user_id = $results[0];
+
 		$value   = get_user_meta( $user_id, $key, true );
 		if ( empty( $value ) ) {
 			return false;
@@ -184,11 +185,10 @@ class Token_User extends Token_Generic {
 
 		// If this token has expired destroy the token and return false;
 		if ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) {
-			$this->destroy( $key, $user_ID );
+			$this->destroy( $key );
 			return false;
 		}
 
-		$this->user_id = $user_id;
 		$value['user'] = $user_id;
 		return $value;
 

--- a/indieauth.php
+++ b/indieauth.php
@@ -18,7 +18,7 @@ if ( ! defined( 'INDIEAUTH_REMOTE_MODE' ) ) {
 	define( 'INDIEAUTH_REMOTE_MODE', 0 );
 }
 
-register_activation_hook( __FILE__, array( 'IndieAuth_Plugin', 'schedule' ) );
+register_activation_hook( __FILE__, array( 'IndieAuth_Plugin', 'activation' ) );
 register_deactivation_hook( __FILE__, array( 'IndieAuth_Plugin', 'deactivation' ) );
 
 
@@ -43,10 +43,18 @@ class IndieAuth_Plugin {
 	}
 
 	public static function deactivation() {
+		self::cancel_schedule();
+	}
+
+	public static function cancel_schedule() {
 		$timestamp = wp_next_scheduled( 'indieauth_cleanup', array( false ) );
 		if ( $timestamp ) {
 			wp_unschedule_event( $timestamp, 'indieauth_cleanup', array( false ) );
 		}
+	}
+
+	public static function activation() {
+		self::schedule();
 	}
 
 	public static function schedule() {

--- a/indieauth.php
+++ b/indieauth.php
@@ -23,6 +23,7 @@ register_deactivation_hook( __FILE__, array( 'IndieAuth_Plugin', 'deactivate' ) 
 
 
 add_action( 'upgrader_process_complete', array( 'IndieAuth_Plugin', 'upgrader_process_complete' ), 10, 2 );
+add_action( 'indieauth_cleanup', array( 'IndieAuth_Plugin', 'expires' ) );
 
 class IndieAuth_Plugin {
 	public static $indieauth = null; // Loaded instance of authorize class
@@ -53,6 +54,17 @@ class IndieAuth_Plugin {
 			return wp_schedule_event( time() + HOUR_IN_SECONDS, 'twicedaily', 'indieauth_cleanup', array( false ) );
 		}
 		return true;
+	}
+
+	/*
+	 * Expires authorization codes in the event any are left in the system.
+	 *
+	 */
+	public static function expires() {
+		// The get_all function retrieves all tokens and destroys any expired token.
+		$t = new Token_User( '_indieauth_token_', $user_id );
+		$t->get_all();
+		$t = new Token_User( '_indieauth_code_', $user_id );
 	}
 
 	public static function plugins_loaded() {

--- a/indieauth.php
+++ b/indieauth.php
@@ -19,7 +19,7 @@ if ( ! defined( 'INDIEAUTH_REMOTE_MODE' ) ) {
 }
 
 register_activation_hook( __FILE__, array( 'IndieAuth_Plugin', 'schedule' ) );
-register_deactivation_hook( __FILE__, array( 'IndieAuth_Plugin', 'deactivate' ) );
+register_deactivation_hook( __FILE__, array( 'IndieAuth_Plugin', 'deactivation' ) );
 
 
 add_action( 'upgrader_process_complete', array( 'IndieAuth_Plugin', 'upgrader_process_complete' ), 10, 2 );
@@ -42,7 +42,7 @@ class IndieAuth_Plugin {
 		}
 	}
 
-	public static function deactivate() {
+	public static function deactivation() {
 		$timestamp = wp_next_scheduled( 'indieauth_cleanup', array( false ) );
 		if ( $timestamp ) {
 			wp_unschedule_event( $timestamp, 'indieauth_cleanup', array( false ) );

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -11,6 +11,19 @@ class TokensTest extends WP_UnitTestCase {
 		$this->assertEquals( $token, $get );
 	}
 
+	public function test_find_token_users() {
+		$user_id_1 = self::factory()->user->create();
+		$user_id_2 = self::factory()->user->create();
+		$tokens = new Token_User( '_indieauth_code_', $user_id_1 );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$tokens->set( $token );
+		$tokens->set_user( $user_id_2 );
+		$key = $tokens->set( $token );
+		$users = $tokens->find_token_users();
+		$this->assertEquals( $users, array( $user_id_1, $user_id_2 ) );
+	}
+
+
 
 	public function test_expired_token() {
 		$user_id = self::factory()->user->create();
@@ -35,6 +48,8 @@ class TokensTest extends WP_UnitTestCase {
 		$get = $tokens->get( $key );
 		$this->assertFalse( $get );
 	}
+
+
 
 
 }

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -21,4 +21,20 @@ class TokensTest extends WP_UnitTestCase {
 		$this->assertFalse( $get );
 	}
 
+	public function test_destroy_token() {
+		$user_id = self::factory()->user->create();
+		$tokens = new Token_User( '_indieauth_code_', $user_id );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$key = $tokens->set( $token, 300 );
+		$get = $tokens->get( $key );
+		unset( $get['user'] );
+		unset( $get['expiration' ] );
+		$this->assertEquals( $get, $token );
+		$destroy = $tokens->destroy( $key );
+		$this->assertTrue( $destroy );
+		$get = $tokens->get( $key );
+		$this->assertFalse( $get );
+	}
+
+
 }


### PR DESCRIPTION
This introduces the indieauth_cleanup schedule, which is run twice daily and cleans up any expired authorization codes or tokens. The cron job is activated on plugin update or activation or if not scheduled when visiting the token page, and removed on deactivation.

To accommodate this, as the token class wasn't designed for multiple users, added a function to find all users who have tokens, and, as a LIKE query can use up resources, the results are saved in the options table, and invalidated any time the user setting a token is not on the list. The list is also refreshed when you visit the token table. 

The function to retrieve all tokens for a user now checks expiry when it does, and will delete any expired tokens at that point as well. As this is now scheduled, the manual cleanup option was removed.

This is a precursor to adding an option for expiring tokens. Technically, the code already supported expiring tokens, but not actually setting a token to expire. The token retrieval code checks the expiry date and destroys the token if it is expired. This runs that check on a schedule, which means tokens that are expired will not wait until someone tries to use them to be deleted.

