### PR TITLE
fix C&P issue

### DIFF
--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -40,7 +40,7 @@ class IndieAuth_Admin {
 				__( 'You are using HTTPS and IndieAuth will be secure', 'indieauth' )
 			),
 			'actions'     => '',
-			'test'        => 'indieauth_headers',
+			'test'        => 'indieauth_https',
 		);
 
 		if ( ! is_ssl() ) {


### PR DESCRIPTION
both tests use the same identifier, so you always get the header informations, even if you click on the `https` test results