### PR TITLE
Update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,19 @@
 # Directories
 /.wordpress-org export-ignore
 /.github export-ignore
+/vendor export-ignore
+/tests export-ignore
+/bin export-ignore
+/node-modules export-ignore
 
 # Files
 /.gitattributes export-ignore
 /.gitignore export-ignore
+/composer.json export-ignore
+/composer.lock export-ignore
+/package.json export-ignore
+/package-lock.json export-ignore
+/readme.md export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml export-ignore
+/Gruntfile.js export-ignore


### PR DESCRIPTION
This came up during the review for my new plugin. Excluding things in gitattributes excludes them from archive files and releases. So, only people who use git to clone a repo get the development files. Every other download just gets the distribution files. 

If this works, I think it would be worth adding to every plugin we both work on.