### PR TITLE
Fix notice: Don't run JSON through wp_kses

### DIFF
--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -101,7 +101,8 @@ class IndieAuth_Admin {
 			}
 			if ( 'application/json' === $_SERVER['HTTP_ACCEPT'] ) {
 				header( 'Content-Type: application/json' );
-				$return = wp_json_encode( array( 'message' => $return ) );
+				echo wp_json_encode( array( 'message' => $return ) );
+				exit;
 			}
 			echo wp_kses( 
 				$return,


### PR DESCRIPTION
After #198 was applied, I get this message in wp-admin:
```
 Notice: Trying to get property 'message' of non-object in wp-content/plugins/indieauth/includes/class-indieauth-admin.php on line 220
```

This is because JSON is run through wp_kses. This brings back direct output of the JSON.