### PR TITLE
Add expiration functionality

### DIFF
--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -149,7 +149,7 @@ class IndieAuth_Admin {
 			'indieauth_expires_in',
 			array(
 				'type'         => 'numer',
-				'description'  => __( '', 'indieauth' ),
+				'description'  => __( 'IndieAuth Default Expiry Time', 'indieauth' ),
 				'show_in_rest' => true,
 				'default'      => 1209600, // Two Weeks.
 			)

--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -146,6 +146,16 @@ class IndieAuth_Admin {
 		);
 		register_setting(
 			'indieauth',
+			'indieauth_expires_in',
+			array(
+				'type'         => 'numer',
+				'description'  => __( '', 'indieauth' ),
+				'show_in_rest' => true,
+				'default'      => 1209600, // Two Weeks.
+			)
+		);
+		register_setting(
+			'indieauth',
 			'indieauth_root_user',
 			array(
 				'type'         => 'int',

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -35,7 +35,10 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 			return $return;
 		}
 		$return['last_accessed'] = time();
-		$return['last_ip']       = $_SERVER['REMOTE_ADDR'];
+		if ( array_key_exists( 'expiration', $return ) ) {
+			$return['expires_in'] = $return['expiration'] - time();
+		}
+		$return['last_ip'] = $_SERVER['REMOTE_ADDR'];
 		$tokens->update( $token, $return );
 		return $return;
 	}

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -116,14 +116,14 @@ class IndieAuth_Token_Endpoint {
 		return rest_ensure_response( $token );
 	}
 
-	public function set_token( $token ) {
+	public function set_token( $token, $expiration = null ) {
 		if ( ! isset( $token['me'] ) ) {
 			return false;
 		}
 		$user = get_user_by_identifier( $token['me'] );
 		if ( $user instanceof WP_User ) {
 			$this->tokens->set_user( $user->ID );
-			return $this->tokens->set( $token );
+			return $this->tokens->set( $token, $expiration );
 		}
 		return false;
 	}
@@ -202,9 +202,10 @@ class IndieAuth_Token_Endpoint {
 				$return['client_name'] = $info->get_name();
 				$return['client_icon'] = $info->get_icon();
 				$return['issued_at']   = time();
+				$return['expires_in']  = get_option( 'indieauth_expires_in' );
 				$return                = array_filter( $return );
 
-				$return['access_token'] = $this->set_token( $return );
+				$return['access_token'] = $this->set_token( $return, get_option( 'indieauth_expires_in' ) );
 			}
 		}
 

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -202,10 +202,12 @@ class IndieAuth_Token_Endpoint {
 				$return['client_name'] = $info->get_name();
 				$return['client_icon'] = $info->get_icon();
 				$return['issued_at']   = time();
-				$return['expires_in']  = get_option( 'indieauth_expires_in' );
-				$return                = array_filter( $return );
 
-				$return['access_token'] = $this->set_token( $return, get_option( 'indieauth_expires_in' ) );
+				$expires              = (int) get_option( 'indieauth_expires_in' );
+				$return['expires_in'] = $expires;
+				$return               = array_filter( $return );
+
+				$return['access_token'] = $this->set_token( $return, $expires );
 			}
 		}
 

--- a/includes/class-indieauth-token-ui.php
+++ b/includes/class-indieauth-token-ui.php
@@ -59,8 +59,9 @@ class IndieAuth_Token_UI {
 		if ( empty( $scopes ) ) {
 			$scopes = 'create update';
 		}
-		$scopes = sanitize_text_field( $scopes );
-		$token  = self::generate_local_token( $client_name, $scopes );
+		$scopes  = sanitize_text_field( $scopes );
+		$expires = sanitize_text_field( $_REQUEST['expires_in'] );
+		$token   = self::generate_local_token( $client_name, $scopes, $expires );
 		?>
 	<p><?php esc_html_e( 'A token has been generated and appears below. This token will not be stored anywhere. Please copy and store it.', 'indieauth' ); ?></p>
 	<h3><?php echo $token; // phpcs:ignore 
@@ -71,7 +72,7 @@ class IndieAuth_Token_UI {
 		exit;
 	}
 
-	private function generate_local_token( $name, $scopes ) {
+	private function generate_local_token( $name, $scopes, $expires_in = 0 ) {
 		$user_id = get_current_user_id();
 		$tokens  = new Token_User( '_indieauth_token_' );
 		$tokens->set_user( $user_id );
@@ -86,6 +87,10 @@ class IndieAuth_Token_UI {
 			'client_icon' => get_avatar_url( $user_id ),
 			'issued_at'   => time(),
 		);
+		if ( $expires_in > 0 ) {
+			$token['expires_in'] = $expires_in;
+			$token['expiration'] = time() + $expires_in;
+		}
 		return $tokens->set( $token );
 	}
 
@@ -120,6 +125,9 @@ class IndieAuth_Token_UI {
 			<input type="hidden" name="action" id="action" value="indieauth_newtoken" />
 			<h4><?php esc_html_e( 'Scopes', 'indieauth' ); ?></h4>
 			<?php echo esc_html( $this->scopes() ); ?>
+			<p><label><?php esc_html_e( 'Set Expiry Time in Seconds(0 to disable)', 'indieauth' ); ?></label>
+			<input type="number" name="expires_in" id="expires_in" min="0" value="3600" />
+			</p>
 			<p><button class="button-primary"><?php esc_html_e( 'Add New Token', 'indieauth' ); ?></button></p>
 		</form>
 		</div>

--- a/includes/class-token-generic.php
+++ b/includes/class-token-generic.php
@@ -21,6 +21,45 @@ abstract class Token_Generic {
 	abstract public function destroy( $key );
 
 	/**
+	 * Renews a token.
+	 *
+	 * @param string $key token to renew
+	 * @return boolean Return if successfully renewed
+	 */
+	public function renew( $key ) {
+		$token = $this->get( $key, false );
+		if ( ! $token ) {
+			return;
+		}
+		if ( array_key_exists( 'expiration', $token ) ) {
+			$token['expiration'] = $token['expiration'] + get_option( 'indieauth_expires_in' );
+		} else {
+			$token['expiration'] = time() + get_option( 'indieauth_expires_in' );
+		}
+		$token['expires_in'] = $token['expiration'] - time();
+		error_log( 'Token!!' );
+		$this->update( $key, $token, true );
+	}
+
+	/**
+	 * Disable Expiry
+	 *
+	 * @param string $key token to disable
+	 * @return boolean Return if successful
+	 */
+	public function noexpire( $key ) {
+		$token = $this->get( $key, false );
+		if ( ! $token ) {
+			return;
+		}
+		if ( array_key_exists( 'expiration', $token ) ) {
+			unset( $token['expiration'] );
+			unset( $token['expires_in'] );
+		}
+		$this->update( $key, $token, true );
+	}
+
+	/**
 	 * Retrieves a token
 	 *
 	 * @param string  $key token to retrieve.

--- a/includes/class-token-generic.php
+++ b/includes/class-token-generic.php
@@ -39,7 +39,7 @@ abstract class Token_Generic {
 		if ( array_key_exists( 'expiration', $token ) ) {
 			$token['expiration'] = $token['expiration'] + $expires;
 		} else {
-			$token['expiration'] = time() + $xpires;
+			$token['expiration'] = time() + $expires;
 		}
 		$token['expires_in'] = $token['expiration'] - time();
 		$this->update( $key, $token, true );

--- a/includes/class-token-generic.php
+++ b/includes/class-token-generic.php
@@ -31,13 +31,17 @@ abstract class Token_Generic {
 		if ( ! $token ) {
 			return;
 		}
+		$expires = (int) get_option( 'indieauth_expires_in' );
+		// Ignore if the renewal time is 0.
+		if ( 0 === $expires ) {
+			return;
+		}
 		if ( array_key_exists( 'expiration', $token ) ) {
-			$token['expiration'] = $token['expiration'] + get_option( 'indieauth_expires_in' );
+			$token['expiration'] = $token['expiration'] + $expires;
 		} else {
-			$token['expiration'] = time() + get_option( 'indieauth_expires_in' );
+			$token['expiration'] = time() + $xpires;
 		}
 		$token['expires_in'] = $token['expiration'] - time();
-		error_log( 'Token!!' );
 		$this->update( $key, $token, true );
 	}
 

--- a/includes/class-token-list-table.php
+++ b/includes/class-token-list-table.php
@@ -19,11 +19,11 @@ class Token_List_Table extends WP_List_Table {
 	}
 
 	public function get_bulk_actions() {
-			  return array(
-				  'revoke'   => __( 'Revoke', 'indieauth' ),
-				  'renew'    => __( 'Renew', 'indieauth' ),
-				  'noexpire' => __( 'Disable Expiry', 'indieauth' ),
-			  );
+		return array(
+			'revoke'   => __( 'Revoke', 'indieauth' ),
+			'renew'    => __( 'Renew', 'indieauth' ),
+			'noexpire' => __( 'Disable Expiry', 'indieauth' ),
+		);
 	}
 
 	public function get_sortable_columns() {

--- a/includes/class-token-list-table.php
+++ b/includes/class-token-list-table.php
@@ -20,12 +20,9 @@ class Token_List_Table extends WP_List_Table {
 
 	public function get_bulk_actions() {
 			  return array(
-				  'revoke'       => __( 'Revoke', 'indieauth' ),
-				  'revoke_year'  => __( 'Revoke Tokens Last Accessed 1 Year Ago or Never', 'indieauth' ),
-				  'revoke_month' => __( 'Revoke Tokens Last Accessed 1 Month Ago or Never', 'indieauth' ),
-				  'revoke_week'  => __( 'Revoke Tokens Last Accessed 1 Week Ago or Never', 'indieauth' ),
-				  'revoke_day'   => __( 'Revoke Tokens Last Accessed 1 Day Ago or Never', 'indieauth' ),
-				  'revoke_hour'  => __( 'Revoke Tokens Last Accessed 1 Hour Ago or Never', 'indieauth' ),
+				  'revoke'   => __( 'Revoke', 'indieauth' ),
+				  'renew'    => __( 'Renew', 'indieauth' ),
+				  'noexpire' => __( 'Disable Expiry', 'indieauth' ),
 			  );
 	}
 
@@ -78,20 +75,23 @@ class Token_List_Table extends WP_List_Table {
 					}
 				}
 				break;
-			case 'revoke_year':
-				$this->destroy_older_than( $t, 'year' );
+			case 'renew':
+				if ( is_string( $tokens ) ) {
+					$t->renew( $tokens );
+				} elseif ( is_array( $tokens ) ) {
+					foreach ( $tokens as $token ) {
+						$t->renew( $token );
+					}
+				}
 				break;
-			case 'revoke_month':
-				$this->destroy_older_than( $t, 'month' );
-				break;
-			case 'revoke_week':
-				$this->destroy_older_than( $t, 'week' );
-				break;
-			case 'revoke_day':
-				$this->destroy_older_than( $t, 'day' );
-				break;
-			case 'revoke_hour':
-				$this->destroy_older_than( $t, 'hour' );
+			case 'noexpire':
+				if ( is_string( $tokens ) ) {
+					$t->noexpire( $tokens );
+				} elseif ( is_array( $tokens ) ) {
+					foreach ( $tokens as $token ) {
+						$t->noexpire( $token );
+					}
+				}
 				break;
 			case 'retrieve':
 				if ( is_string( $tokens ) ) {
@@ -143,9 +143,10 @@ class Token_List_Table extends WP_List_Table {
 	}
 
 	public function column_client_name( $item ) {
+		$uri     = wp_doing_ajax() ? wp_get_referer() : $_SERVER['REQUEST_URI'];
+		$uri     = urlencode( wp_unslash( $uri ) );
 		$actions = array(
-			'revoke'   => sprintf( '<a href="?page=%1$s&action=%2$s&tokens=%3$s">%4$s</a>', 'indieauth_user_token', 'revoke', $item['token'], __( 'Revoke', 'indieauth' ) ),
-			'retrieve' => sprintf( '<a href="?page=%1$s&action=%2$s&tokens=%3$s">%4$s</a>', 'indieauth_user_token', 'retrieve', $item['token'], __( 'Retrieve Information', 'indieauth' ) ),
+			'retrieve' => sprintf( '<a href="?page=indieauth_user_token&action=retrieve&tokens=%1$s&wp_http_referer=%2$s">%3$s</a>', $item['token'], $uri, __( 'Retrieve Information', 'indieauth' ) ),
 		);
 		if ( ! isset( $item['client_name'] ) ) {
 			$item['client_name'] = __( 'Not Provided', 'indieauth' );
@@ -185,12 +186,12 @@ class Token_List_Table extends WP_List_Table {
 			// translators: Human time difference ago
 			return sprintf( __( '%s ago', 'indieauth' ), human_time_diff( $time ) );
 		}
-		return date_i18n( get_option( 'date_format' ), $time );
+		return wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $time );
 	}
 
 
 	public function column_issued_at( $item ) {
-		return date_i18n( get_option( 'date_format' ), $item['issued_at'] );
+		return wp_date( get_option( 'date_format' ), $item['issued_at'] );
 	}
 
 	public function column_client_id( $item ) {

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 3.7.0
+ * Version: 4.0.0
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 3.6.2
+ * Version: 3.7.0
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 3.6.2\n"
+"Project-Id-Version: IndieAuth 3.7.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2021-05-25 03:26:53+00:00\n"
+"POT-Creation-Date: 2021-06-13 17:40:52+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -86,31 +86,31 @@ msgstr ""
 msgid "Offer IndieAuth on Login Form"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:152
+#: includes/class-indieauth-admin.php:162
 msgid "User Who is Represented by the Site URL"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:160 templates/indieauth-settings.php:2
+#: includes/class-indieauth-admin.php:170 templates/indieauth-settings.php:2
 msgid "IndieAuth Settings"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:173
+#: includes/class-indieauth-admin.php:183
 msgid ""
 "Based on your feedback and to improve the user experience, we decided to "
 "move the settings to a separate <a href=\"%1$s\">settings-page</a>."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:246
+#: includes/class-indieauth-admin.php:256
 msgid "Overview"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:248
+#: includes/class-indieauth-admin.php:258
 msgid ""
 "IndieAuth is a way for doing Web sign-in, where you use your own homepage "
 "to sign in to other places."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:249
+#: includes/class-indieauth-admin.php:259
 msgid ""
 "IndieAuth was built on ideas and technology from existing proven "
 "technologies like OAuth and OpenID but aims at making it easier for users "
@@ -118,19 +118,19 @@ msgid ""
 "completely separate implementations and services can be used for each part."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:256
+#: includes/class-indieauth-admin.php:266
 msgid "The IndieWeb"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:258
+#: includes/class-indieauth-admin.php:268
 msgid "The IndieWeb is a people-focused alternative to the \"corporate web\"."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:260
+#: includes/class-indieauth-admin.php:270
 msgid "Your content is yours"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:261
+#: includes/class-indieauth-admin.php:271
 msgid ""
 "When you post something on the web, it should belong to you, not a "
 "corporation. Too many companies have gone out of business and lost all of "
@@ -138,41 +138,41 @@ msgid ""
 "your control."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:264
+#: includes/class-indieauth-admin.php:274
 msgid "You are better connected"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:265
+#: includes/class-indieauth-admin.php:275
 msgid ""
 "Your articles and status messages can go to all services, not just one, "
 "allowing you to engage with everyone. Even replies and likes on other "
 "services can come back to your site so they’re all in one place."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:268
+#: includes/class-indieauth-admin.php:278
 msgid "You are in control"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:269
+#: includes/class-indieauth-admin.php:279
 msgid ""
 "You can post anything you want, in any format you want, with no one "
 "monitoring you. In addition, you share simple readable links such as "
 "example.com/ideas. These links are permanent and will always work."
 msgstr ""
 
-#: includes/class-indieauth-admin.php:275
+#: includes/class-indieauth-admin.php:285
 msgid "For more information:"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:276
+#: includes/class-indieauth-admin.php:286
 msgid "<a href=\"https://indieweb.org/IndieAuth\">IndieWeb Wiki page</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:277
+#: includes/class-indieauth-admin.php:287
 msgid "<a href=\"https://indieauth.rocks/\">Test suite</a>"
 msgstr ""
 
-#: includes/class-indieauth-admin.php:278
+#: includes/class-indieauth-admin.php:288
 msgid "<a href=\"https://www.w3.org/TR/indieauth/\">W3C Spec</a>"
 msgstr ""
 
@@ -269,7 +269,7 @@ msgid "Endpoint only accepts authorization_code grant_type"
 msgstr ""
 
 #: includes/class-indieauth-authorization-endpoint.php:241
-#: includes/class-indieauth-local-authorize.php:49 includes/functions.php:529
+#: includes/class-indieauth-local-authorize.php:52 includes/functions.php:529
 msgid "Invalid authorization code"
 msgstr ""
 
@@ -406,12 +406,12 @@ msgstr ""
 msgid "The request is missing one or more required parameters"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:231
+#: includes/class-indieauth-token-endpoint.php:232
 msgid "There was an error in response."
 msgstr ""
 
 #: includes/class-indieauth-token-ui.php:33
-#: includes/class-indieauth-token-ui.php:107
+#: includes/class-indieauth-token-ui.php:112
 msgid "Manage IndieAuth Tokens"
 msgstr ""
 
@@ -431,25 +431,29 @@ msgstr ""
 msgid "A Name Must be Set for Your Token"
 msgstr ""
 
-#: includes/class-indieauth-token-ui.php:65
+#: includes/class-indieauth-token-ui.php:66
 msgid ""
 "A token has been generated and appears below. This token will not be stored "
 "anywhere. Please copy and store it."
 msgstr ""
 
-#: includes/class-indieauth-token-ui.php:116
+#: includes/class-indieauth-token-ui.php:121
 msgid "Add Token"
 msgstr ""
 
-#: includes/class-indieauth-token-ui.php:118
+#: includes/class-indieauth-token-ui.php:123
 msgid "Name for Token"
 msgstr ""
 
-#: includes/class-indieauth-token-ui.php:121
+#: includes/class-indieauth-token-ui.php:126
 msgid "Scopes"
 msgstr ""
 
-#: includes/class-indieauth-token-ui.php:123
+#: includes/class-indieauth-token-ui.php:128
+msgid "Set Expiry Time in Seconds(0 to disable)"
+msgstr ""
+
+#: includes/class-indieauth-token-ui.php:131
 msgid "Add New Token"
 msgstr ""
 
@@ -482,45 +486,32 @@ msgid "Expires"
 msgstr ""
 
 #: includes/class-token-list-table.php:23
-#: includes/class-token-list-table.php:147
 msgid "Revoke"
 msgstr ""
 
 #: includes/class-token-list-table.php:24
-msgid "Revoke Tokens Last Accessed 1 Year Ago or Never"
+msgid "Renew"
 msgstr ""
 
 #: includes/class-token-list-table.php:25
-msgid "Revoke Tokens Last Accessed 1 Month Ago or Never"
+msgid "Disable Expiry"
 msgstr ""
 
-#: includes/class-token-list-table.php:26
-msgid "Revoke Tokens Last Accessed 1 Week Ago or Never"
-msgstr ""
-
-#: includes/class-token-list-table.php:27
-msgid "Revoke Tokens Last Accessed 1 Day Ago or Never"
-msgstr ""
-
-#: includes/class-token-list-table.php:28
-msgid "Revoke Tokens Last Accessed 1 Hour Ago or Never"
-msgstr ""
-
-#: includes/class-token-list-table.php:148
+#: includes/class-token-list-table.php:149
 msgid "Retrieve Information"
 msgstr ""
 
-#: includes/class-token-list-table.php:151
+#: includes/class-token-list-table.php:152
 msgid "Not Provided"
 msgstr ""
 
-#: includes/class-token-list-table.php:166
-#: includes/class-token-list-table.php:180
+#: includes/class-token-list-table.php:167
+#: includes/class-token-list-table.php:181
 msgid "Never"
 msgstr ""
 
-#: includes/class-token-list-table.php:172
-#: includes/class-token-list-table.php:186
+#: includes/class-token-list-table.php:173
+#: includes/class-token-list-table.php:187
 #. translators: Human time difference ago
 msgid "%s ago"
 msgstr ""
@@ -649,7 +640,7 @@ msgid "Allow"
 msgstr ""
 
 #: templates/indieauth-authenticate-form.php:59
-#: templates/indieauth-authorize-form.php:66
+#: templates/indieauth-authorize-form.php:75
 msgid "Cancel"
 msgstr ""
 
@@ -679,11 +670,16 @@ msgstr ""
 msgid "Below select the privileges you would like to grant the application."
 msgstr ""
 
-#: templates/indieauth-authorize-form.php:65
+#: templates/indieauth-authorize-form.php:54
+#. translators: 1. human time difference
+msgid "The client will have access for %1$s."
+msgstr ""
+
+#: templates/indieauth-authorize-form.php:74
 msgid "Approve"
 msgstr ""
 
-#: templates/indieauth-authorize-form.php:70
+#: templates/indieauth-authorize-form.php:79
 #. translators: 1. Redirect URI
 msgid "You will be redirected to %1$s after approving this application."
 msgstr ""
@@ -756,6 +752,16 @@ msgstr ""
 
 #: templates/indieauth-settings.php:77
 msgid "Add a link to the login form to authenticate using an IndieAuth endpoint."
+msgstr ""
+
+#: templates/indieauth-settings.php:83
+msgid "Set Default Expiration"
+msgstr ""
+
+#: templates/indieauth-settings.php:88
+msgid ""
+"Set the Number of Seconds An IndieAuth Tokens Will Expire In (Default is "
+"Two Weeks)"
 msgstr ""
 
 #: templates/websignin-form.php:4

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 3.7.0\n"
+"Project-Id-Version: IndieAuth 4.0.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2021-06-13 17:40:52+00:00\n"
+"POT-Creation-Date: 2021-06-16 04:09:00+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -84,6 +84,10 @@ msgstr ""
 
 #: includes/class-indieauth-admin.php:142
 msgid "Offer IndieAuth on Login Form"
+msgstr ""
+
+#: includes/class-indieauth-admin.php:152
+msgid "IndieAuth Default Expiry Time"
 msgstr ""
 
 #: includes/class-indieauth-admin.php:162
@@ -406,7 +410,7 @@ msgstr ""
 msgid "The request is missing one or more required parameters"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:232
+#: includes/class-indieauth-token-endpoint.php:234
 msgid "There was an error in response."
 msgstr ""
 
@@ -640,7 +644,7 @@ msgid "Allow"
 msgstr ""
 
 #: templates/indieauth-authenticate-form.php:59
-#: templates/indieauth-authorize-form.php:75
+#: templates/indieauth-authorize-form.php:78
 msgid "Cancel"
 msgstr ""
 
@@ -670,16 +674,16 @@ msgstr ""
 msgid "Below select the privileges you would like to grant the application."
 msgstr ""
 
-#: templates/indieauth-authorize-form.php:54
+#: templates/indieauth-authorize-form.php:56
 #. translators: 1. human time difference
 msgid "The client will have access for %1$s."
 msgstr ""
 
-#: templates/indieauth-authorize-form.php:74
+#: templates/indieauth-authorize-form.php:77
 msgid "Approve"
 msgstr ""
 
-#: templates/indieauth-authorize-form.php:79
+#: templates/indieauth-authorize-form.php:82
 #. translators: 1. Redirect URI
 msgid "You will be redirected to %1$s after approving this application."
 msgstr ""
@@ -761,7 +765,7 @@ msgstr ""
 #: templates/indieauth-settings.php:88
 msgid ""
 "Set the Number of Seconds An IndieAuth Tokens Will Expire In (Default is "
-"Two Weeks)"
+"Two Weeks). 0 to Disable"
 msgstr ""
 
 #: templates/websignin-form.php:4

--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,8 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.6  
-**Tested up to:** 5.7  
-**Stable tag:** 3.7.0  
+**Tested up to:** 5.7.2  
+**Stable tag:** 4.0.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -130,7 +130,7 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 ## Upgrade Notice ##
 
-### 3.7.0 ###
+### 4.0.0 ###
 
 This version enables expiring tokens. All existing tokens will remain as they were. New tokens will expire in 14 days by default. You can change this in settings.
 
@@ -156,7 +156,7 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
 
-### 3.7.0 ###
+### 4.0.0 ###
 
 * Add default expiry time.
 * Ensure tokens expire at their proper time.

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.6  
 **Tested up to:** 5.7  
-**Stable tag:** 3.6.2  
+**Stable tag:** 3.7.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -130,6 +130,10 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 ## Upgrade Notice ##
 
+### 3.7.0 ###
+
+This version enables expiring tokens. All existing tokens will remain as they were. New tokens will expire in 14 days by default. You can change this in settings.
+
 ### 3.6.0 ###
 
 Due to the fact that this upgrades the spec adherence to address the changes in the IndieAuth Living Standard as of November 26, 2020, there may be unanticipated issues with clients not meeting the changes.
@@ -151,6 +155,12 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 3.7.0 ###
+
+* Add default expiry time.
+* Ensure tokens expire at their proper time.
+* Cleanup related to expiry
 
 ### 3.6.2 ###
 * Fix missing argument, props @chee

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.6
 Tested up to: 5.7
-Stable tag: 3.6.2
+Stable tag: 3.7.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -130,6 +130,10 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 == Upgrade Notice ==
 
+= 3.7.0 =
+
+This version enables expiring tokens. All existing tokens will remain as they were. New tokens will expire in 14 days by default. You can change this in settings.
+
 = 3.6.0 =
 
 Due to the fact that this upgrades the spec adherence to address the changes in the IndieAuth Living Standard as of November 26, 2020, there may be unanticipated issues with clients not meeting the changes.
@@ -151,6 +155,12 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 3.7.0 = 
+
+* Add default expiry time.
+* Ensure tokens expire at their proper time.
+* Cleanup related to expiry
 
 = 3.6.2 =
 * Fix missing argument, props @chee

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.6
-Tested up to: 5.7
-Stable tag: 3.7.0
+Tested up to: 5.7.2
+Stable tag: 4.0.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -130,7 +130,7 @@ Some hosting providers filter this out using mod_security. For one user, they ne
 
 == Upgrade Notice ==
 
-= 3.7.0 =
+= 4.0.0 =
 
 This version enables expiring tokens. All existing tokens will remain as they were. New tokens will expire in 14 days by default. You can change this in settings.
 
@@ -156,7 +156,7 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
 
-= 3.7.0 = 
+= 4.0.0 = 
 
 * Add default expiry time.
 * Ensure tokens expire at their proper time.

--- a/templates/indieauth-auth-footer.php
+++ b/templates/indieauth-auth-footer.php
@@ -37,6 +37,11 @@
 	margin-left: 2em;
 	list-style: none;
 }
+
+.expiration {
+	margin-top: 1em;
+}
+
 .redirect-info {
 	margin-top: 1em;
 }

--- a/templates/indieauth-authorize-form.php
+++ b/templates/indieauth-authorize-form.php
@@ -47,6 +47,15 @@ login_header(
 		<?php self::scope_list( $scopes ); ?>
 		</ul>
 	</div>
+	<div class="expiration">
+		<?php
+			printf(
+				/* translators: 1. human time difference */
+				esc_html__( 'The client will have access for %1$s.', 'indieauth' ),
+				esc_html( human_time_diff( time(), time() + get_option( 'indieauth_expires_in' ) ) )
+			);
+			?>
+	</div>
 	<p class="submit">
 	<?php
 		// Hook to allow adding to form

--- a/templates/indieauth-authorize-form.php
+++ b/templates/indieauth-authorize-form.php
@@ -49,7 +49,7 @@ login_header(
 	</div>
 	<div class="expiration">
 		<?php
-			$expiration = (int) get_option( 'indieauth_expires_in' );
+		$expiration = (int) get_option( 'indieauth_expires_in' );
 		if ( 0 !== $expiration ) {
 			printf(
 				/* translators: 1. human time difference */

--- a/templates/indieauth-authorize-form.php
+++ b/templates/indieauth-authorize-form.php
@@ -49,12 +49,15 @@ login_header(
 	</div>
 	<div class="expiration">
 		<?php
+			$expiration = (int) get_option( 'indieauth_expires_in' );
+		if ( 0 !== $expiration ) {
 			printf(
 				/* translators: 1. human time difference */
-				esc_html__( 'The client will have access for %1$s.', 'indieauth' ),
-				esc_html( human_time_diff( time(), time() + get_option( 'indieauth_expires_in' ) ) )
+				'⌛ ' . esc_html__( 'The client will have access for %1$s.', 'indieauth' ),
+				esc_html( human_time_diff( time(), time() + $expiration ) )
 			);
-			?>
+		}
+		?>
 	</div>
 	<p class="submit">
 	<?php

--- a/templates/indieauth-settings.php
+++ b/templates/indieauth-settings.php
@@ -84,8 +84,8 @@
 					</th>
 					<td>
 						<label for="indieauth_expires_in">
-							<input type="number" min="300" name="indieauth_expires_in" id="indieauth_expires_in" value="<?php echo intval( get_option( 'indieauth_expires_in' ) ); ?>" />
-							<?php esc_html_e( 'Set the Number of Seconds An IndieAuth Tokens Will Expire In (Default is Two Weeks)', 'indieauth' ); ?>
+							<input type="number" min="0" name="indieauth_expires_in" id="indieauth_expires_in" value="<?php echo intval( get_option( 'indieauth_expires_in' ) ); ?>" />
+							<?php esc_html_e( 'Set the Number of Seconds An IndieAuth Tokens Will Expire In (Default is Two Weeks). 0 to Disable', 'indieauth' ); ?>
 						</label>
 					</td>
 				</tr>

--- a/templates/indieauth-settings.php
+++ b/templates/indieauth-settings.php
@@ -78,6 +78,17 @@
 						</label>
 					</td>
 				</tr>
+				<tr>
+					<th>
+						<?php esc_html_e( 'Set Default Expiration', 'indieauth' ); ?>
+					</th>
+					<td>
+						<label for="indieauth_expires_in">
+							<input type="number" min="300" name="indieauth_expires_in" id="indieauth_expires_in" value="<?php echo intval( get_option( 'indieauth_expires_in' ) ); ?>" />
+							<?php esc_html_e( 'Set the Number of Seconds An IndieAuth Tokens Will Expire In (Default is Two Weeks)', 'indieauth' ); ?>
+						</label>
+					</td>
+				</tr>
 			</tbody>
 		</table>
 


### PR DESCRIPTION
This adds expiration functionality. By default, all tokens will expire within two weeks. It can be changed in the settings screen.

The bulk action functionality in the token admin can renew or disable expiry. The manual add token can set a custom expiring token. The existing cron job will clean up expired tokens.

The option to expire all tokens older than Y is now removed as unnecessary. 

