### PR TITLE
Turn create into a create/draft/none option selection

### DIFF
--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -144,6 +144,20 @@ class IndieAuth_Authorization_Endpoint {
 	 */
 	public static function scope_list( $scopes ) {
 		if ( ! empty( $scopes ) ) {
+			$create = array_search( 'create', $scopes );
+			if ( false !== $create ) {
+				unset( $scopes[ $create ] );
+				$draft = array_search( 'draft', $scopes );
+				if ( false !== $draft ) {
+					unset( $scopes[ $draft ] );
+				}
+				$scopes = array_values( $scopes );
+				echo '<div class="create_scope">';
+				echo sprintf( '<li><input type="radio" name="scope[]" value="create"><strong>create</strong> - %1$s</li>', esc_html( self::scopes( 'create' ) ) );
+				echo sprintf( '<li><input type="radio" name="scope[]" value="draft"><strong>draft</strong> - %1$s</li>', esc_html( self::scopes( 'draft' ) ) );
+				echo sprintf( '<li><input type="radio" name="scope[]" value=""><strong>none</strong> - %1$s</li>', __( 'Token will have no privileges to create posts', 'indieauth' ) );
+				echo '</div>';
+			}
 			foreach ( $scopes as $s ) {
 				echo wp_kses(
 					sprintf( '<li><input type="checkbox" name="scope[]" value="%1$s" %2$s /><strong>%1$s</strong> - %3$s</li>', $s, checked( true, true, false ), esc_html( self::scopes( $s ) ) ),

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -144,18 +144,51 @@ class IndieAuth_Authorization_Endpoint {
 	 */
 	public static function scope_list( $scopes ) {
 		if ( ! empty( $scopes ) ) {
-			$create = array_search( 'create', $scopes );
+			$create = array_search( 'create', $scopes, true );
 			if ( false !== $create ) {
 				unset( $scopes[ $create ] );
-				$draft = array_search( 'draft', $scopes );
+				$draft = array_search( 'draft', $scopes, true );
 				if ( false !== $draft ) {
 					unset( $scopes[ $draft ] );
 				}
 				$scopes = array_values( $scopes );
 				echo '<div class="create_scope">';
-				echo sprintf( '<li><input type="radio" name="scope[]" value="create"><strong>create</strong> - %1$s</li>', esc_html( self::scopes( 'create' ) ) );
-				echo sprintf( '<li><input type="radio" name="scope[]" value="draft"><strong>draft</strong> - %1$s</li>', esc_html( self::scopes( 'draft' ) ) );
-				echo sprintf( '<li><input type="radio" name="scope[]" value=""><strong>none</strong> - %1$s</li>', __( 'Token will have no privileges to create posts', 'indieauth' ) );
+				echo wp_kses(
+					sprintf( '<li><input type="radio" name="scope[]" value="create"><strong>create</strong> - %1$s</li>', esc_html( self::scopes( 'create' ) ) ),
+					array(
+						'li'     => array(),
+						'strong' => array(),
+						'input'  => array(
+							'type'  => array(),
+							'name'  => array(),
+							'value' => array(),
+						),
+					)
+				);
+				echo wp_kses(
+					sprintf( '<li><input type="radio" name="scope[]" value="draft"><strong>draft</strong> - %1$s</li>', esc_html( self::scopes( 'draft' ) ) ),
+					array(
+						'li'     => array(),
+						'strong' => array(),
+						'input'  => array(
+							'type'  => array(),
+							'name'  => array(),
+							'value' => array(),
+						),
+					)
+				);
+				echo wp_kses(
+					sprintf( '<li><input type="radio" name="scope[]" value=""><strong>none</strong> - %1$s</li>', __( 'Token will have no privileges to create posts', 'indieauth' ) ),
+					array(
+						'li'     => array(),
+						'strong' => array(),
+						'input'  => array(
+							'type'  => array(),
+							'name'  => array(),
+							'value' => array(),
+						),
+					)
+				);
 				echo '</div>';
 			}
 			foreach ( $scopes as $s ) {

--- a/templates/indieauth-auth-footer.php
+++ b/templates/indieauth-auth-footer.php
@@ -38,6 +38,10 @@
 	list-style: none;
 }
 
+.create_scope {
+	margin-bottom: 3em;
+}
+
 .expiration {
 	margin-top: 1em;
 }


### PR DESCRIPTION
This changes the authorize screen to allow you to dynamically change a create scope request into a draft scope. This means even clients that don't support draft can be given a token that will only create draft posts. This is a visual only change.