### PR TITLE
Introspection

### DIFF
--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -241,11 +241,11 @@ class IndieAuth_Authorization_Endpoint {
 			return new WP_OAuth_Response( 'invalid_grant', __( 'Invalid authorization code', 'indieauth' ), 400 );
 		}
 		$user = get_user_by( 'id', $token['user'] );
-		if ( $token['expiration'] <= time() ) {
+		if ( $token['exp'] <= time() ) {
 			$this->delete_code( $code, $token['user'] );
 			return new WP_OAuth_Response( 'invalid_grant', __( 'The authorization code expired', 'indieauth' ), 400 );
 		}
-		unset( $token['expiration'] );
+		unset( $token['exp'] );
 		// If there is a code challenge
 		if ( isset( $token['code_challenge'] ) ) {
 			$code_verifier = $request->get_param( 'code_verifier' );

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -35,11 +35,11 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 			return $return;
 		}
 		$return['last_accessed'] = time();
-		if ( array_key_exists( 'expiration', $return ) ) {
-			$return['expires_in'] = $return['expiration'] - time();
-		}
 		$return['last_ip'] = $_SERVER['REMOTE_ADDR'];
 		$tokens->update( $token, $return );
+		if ( array_key_exists( 'exp', $return ) ) {
+			$return['expires_in'] = $return['exp'] - time();
+		}
 		return $return;
 	}
 

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -35,7 +35,7 @@ class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 			return $return;
 		}
 		$return['last_accessed'] = time();
-		$return['last_ip'] = $_SERVER['REMOTE_ADDR'];
+		$return['last_ip']       = $_SERVER['REMOTE_ADDR'];
 		$tokens->update( $token, $return );
 		if ( array_key_exists( 'exp', $return ) ) {
 			$return['expires_in'] = $return['exp'] - time();

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -201,13 +201,18 @@ class IndieAuth_Token_Endpoint {
 				$return['client_id']   = $params['client_id'];
 				$return['client_name'] = $info->get_name();
 				$return['client_icon'] = $info->get_icon();
-				$return['issued_at']   = time();
+				$return['iat']         = time();
 
-				$expires              = (int) get_option( 'indieauth_expires_in' );
-				$return['expires_in'] = $expires;
-				$return               = array_filter( $return );
+				$expires = (int) get_option( 'indieauth_expires_in' );
+
+				$return = array_filter( $return );
 
 				$return['access_token'] = $this->set_token( $return, $expires );
+
+				// Do Not Add Expires In for the Return Until After It is Saved to the Database
+				if ( 0 !== $expires ) {
+					$return['expires_in'] = $expires;
+				}
 			}
 		}
 
@@ -222,6 +227,7 @@ class IndieAuth_Token_Endpoint {
 						'scope',
 						'me',
 						'profile',
+						'expires_in',
 					)
 				),
 				200, // Status Code

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -140,26 +140,26 @@ class IndieAuth_Token_Endpoint {
 
 		// Action Handler
 		if ( isset( $params['action'] ) ) {
-			switch( $params['action'] ) {
+			switch ( $params['action'] ) {
 				// Revoke Token
 				case 'revoke':
 					if ( isset( $params['token'] ) ) {
 						$this->delete_token( $params['token'] );
 						return __( 'The Token Provided is No Longer Valid', 'indieauth' );
 					}
-				default: 
+					// In the event the token parameter is not set, fall through to the default.
+				default:
 					return new WP_OAuth_Response( 'invalid_request', __( 'Invalid Request', 'indieauth' ), 400 );
 			}
-					
 		}
 
 		// Grant Type Handler.
 		if ( isset( $params['grant_type'] ) ) {
-			switch( $params['grant_type'] ) {
+			switch ( $params['grant_type'] ) {
 				// Request Token
 				case 'authorization_code':
 					return $this->authorization_code( $params );
-				default: 
+				default:
 					return new WP_OAuth_Response( 'invalid_grant', __( 'Endpoint only accepts authorization_code grant_type', 'indieauth' ), 400 );
 			}
 		}

--- a/includes/class-token-generic.php
+++ b/includes/class-token-generic.php
@@ -37,11 +37,15 @@ abstract class Token_Generic {
 			return;
 		}
 		if ( array_key_exists( 'expiration', $token ) ) {
-			$token['expiration'] = $token['expiration'] + $expires;
-		} else {
-			$token['expiration'] = time() + $expires;
+			$token['exp'] = $token['expiration'];
+			unset( $token['expiration'] );
 		}
-		$token['expires_in'] = $token['expiration'] - time();
+
+		if ( array_key_exists( 'exp', $token ) ) {
+			$token['exp'] = $token['exp'] + $expires;
+		} else {
+			$token['exp'] = time() + $expires;
+		}
 		$this->update( $key, $token, true );
 	}
 
@@ -56,10 +60,10 @@ abstract class Token_Generic {
 		if ( ! $token ) {
 			return;
 		}
-		if ( array_key_exists( 'expiration', $token ) ) {
-			unset( $token['expiration'] );
-			unset( $token['expires_in'] );
-		}
+
+		unset( $token['exp'] );
+		unset( $token['expiration'] );
+		unset( $token['expires_in'] );
 		$this->update( $key, $token, true );
 	}
 

--- a/includes/class-token-list-table.php
+++ b/includes/class-token-list-table.php
@@ -12,9 +12,9 @@ class Token_List_Table extends WP_List_Table {
 			'client_icon'   => __( 'Client Icon', 'indieauth' ),
 			'client_id'     => __( 'Client ID', 'indieauth' ),
 			'scope'         => __( 'Scope', 'indieauth' ),
-			'issued_at'     => __( 'Issue Date', 'indieauth' ),
+			'iat'           => __( 'Issue Date', 'indieauth' ),
 			'last_accessed' => __( 'Last Accessed', 'indieauth' ),
-			'expiration'    => __( 'Expires', 'indieauth' ),
+			'exp'           => __( 'Expires', 'indieauth' ),
 		);
 	}
 
@@ -176,11 +176,16 @@ class Token_List_Table extends WP_List_Table {
 	}
 
 
-	public function column_expiration( $item ) {
-		if ( ! isset( $item['expiration'] ) ) {
+	public function column_exp( $item ) {
+		// Check for old property.
+		if ( isset( $item['expiration'] ) ) {
+			$item['exp'] = $item['expiration'];
+		}
+
+		if ( ! isset( $item['exp'] ) ) {
 			return __( 'Never', 'indieauth' );
 		}
-		$time      = (int) $item['expiration'];
+		$time      = (int) $item['exp'];
 		$time_diff = time() - $time;
 		if ( $time_diff > 0 && $time_diff < DAY_IN_SECONDS ) {
 			// translators: Human time difference ago
@@ -190,8 +195,12 @@ class Token_List_Table extends WP_List_Table {
 	}
 
 
-	public function column_issued_at( $item ) {
-		return wp_date( get_option( 'date_format' ), $item['issued_at'] );
+	public function column_iat( $item ) {
+		// Check for old property.
+		if ( isset( $item['issued_at'] ) ) {
+			$item['iat'] = $item['issued_at'];
+		}
+		return wp_date( get_option( 'date_format' ), $item['iat'] );
 	}
 
 	public function column_client_id( $item ) {

--- a/includes/class-token-transient.php
+++ b/includes/class-token-transient.php
@@ -25,7 +25,7 @@ class Token_Transient extends Token_Generic {
 			return false;
 		}
 		if ( $expiration ) {
-			$info['expiration'] = $this->expires( $expiration );
+			$info['exp'] = $this->expires( $expiration );
 		}
 		$key = $this->generate_token();
 
@@ -97,7 +97,7 @@ class Token_Transient extends Token_Generic {
 		}
 
 		// Even though WordPress should do it for us, if this token has expired destroy the token and return false;
-		if ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) {
+		if ( ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) || ( isset( $value['exp'] ) && $this->is_expired( $value['exp'] ) ) ) {
 			$this->destroy( $key );
 			return false;
 		}
@@ -121,7 +121,7 @@ class Token_Transient extends Token_Generic {
 		if ( ! $old ) {
 			return false;
 		}
-		$expires = $old['expiration'] - $this->time();
+		$expires = $old['exp'] - $this->time();
 		return set_transient( $key, $info, $expires );
 	}
 }

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -48,7 +48,7 @@ class Token_User extends Token_Generic {
 			return false;
 		}
 		if ( $expiration ) {
-			$info['expiration'] = $this->expires( $expiration );
+			$info['exp'] = $this->expires( $expiration );
 		}
 		$key = $this->generate_token();
 		// Will only add if value is not set
@@ -116,7 +116,8 @@ class Token_User extends Token_Generic {
 					$value         = maybe_unserialize( array_pop( $value ) );
 					$key           = str_replace( $this->prefix, '', $key );
 					$value['user'] = $user_id;
-					if ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) {
+					// Check for old and new property.
+					if ( ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) || ( isset( $value['exp'] ) && $this->is_expired( $value['exp'] ) ) ) {
 						$this->destroy( $key );
 					} else {
 						$tokens[ $key ] = $value;
@@ -142,7 +143,7 @@ class Token_User extends Token_Generic {
 		}
 		$return = false;
 		foreach ( $tokens as $key => $value ) {
-			if ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) {
+			if ( ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) || ( isset( $value['exp'] ) && $this->is_expired( $value['exp'] ) ) ) {
 				$this->destroy( $key );
 				$return = true;
 			}
@@ -184,7 +185,7 @@ class Token_User extends Token_Generic {
 		}
 
 		// If this token has expired destroy the token and return false;
-		if ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) {
+		if ( ( isset( $value['expiration'] ) && $this->is_expired( $value['expiration'] ) ) || ( isset( $value['exp'] ) && $this->is_expired( $value['exp'] ) ) ) {
 			$this->destroy( $key );
 			return false;
 		}

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -41,7 +41,7 @@ class TokensTest extends WP_UnitTestCase {
 		$key = $tokens->set( $token, 300 );
 		$get = $tokens->get( $key );
 		unset( $get['user'] );
-		unset( $get['expiration' ] );
+		unset( $get['exp' ] );
 		$this->assertEquals( $get, $token );
 		$destroy = $tokens->destroy( $key );
 		$this->assertTrue( $destroy );


### PR DESCRIPTION
As per https://github.com/indieweb/indieauth/issues/33, we're adopting the response used by the Token Introspection specification. This means the properties I used, which were internal only, 'expiration' and 'issued_at' should be changed to 'iat' and 'exp' to match. While I could just change them on the response, there was no reason to retain the old structure. 

I also changed expires_in to no longer be stored. It is generated only on return, as there is no need to store it.

While the return parameters of the GET token verification are amended, it still, like the original spec, returns a 400 series error for backward compatibility. The new introspection endpoint, which is a POST request, always returns a 200. At some point when clients have caught up, will likely adjust accordingly. 

There is a slight reformatting of the POST action handler, which now uses two switch statements, one for action, the other for grant_type=. The reason for this is somewhat practical. 

For grant_type, we only support 1 right now, but the new amendment decided at the popup was to include refresh_tokens as a recommendation in the spec(https://github.com/indieweb/indieauth/issues/81) so there would be a new grant_type, which I intend to submit as a separate PR.  In https://github.com/indieweb/indieauth/issues/87, @Zegnat proposes extending action as part of the Ticket Auth proposal, so might as well structure for that as well.

