### PR TITLE
Attempt to Resolve Issues 218 and 187

### DIFF
--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -141,10 +141,10 @@ class IndieAuth_Admin {
 				'type'         => 'int',
 				'description'  => __( 'User Who is Represented by the Site URL', 'indieauth' ),
 				'show_in_rest' => true,
-				'default'      => get_option( 'iw_default_author', 0 ),
 			)
 		);
 	}
+
 
 	public function admin_init() {
 		add_settings_field( 'indieauth_general_settings', __( 'IndieAuth Settings', 'indieauth' ), array( $this, 'general_settings' ), 'general', 'default' );

--- a/includes/class-indieauth-admin.php
+++ b/includes/class-indieauth-admin.php
@@ -136,26 +136,6 @@ class IndieAuth_Admin {
 		);
 		register_setting(
 			'indieauth',
-			'indieauth_show_login_form',
-			array(
-				'type'         => 'boolean',
-				'description'  => __( 'Offer IndieAuth on Login Form', 'indieauth' ),
-				'show_in_rest' => true,
-				'default'      => 0,
-			)
-		);
-		register_setting(
-			'indieauth',
-			'indieauth_expires_in',
-			array(
-				'type'         => 'numer',
-				'description'  => __( 'IndieAuth Default Expiry Time', 'indieauth' ),
-				'show_in_rest' => true,
-				'default'      => 1209600, // Two Weeks.
-			)
-		);
-		register_setting(
-			'indieauth',
 			'indieauth_root_user',
 			array(
 				'type'         => 'int',

--- a/includes/class-indieauth-local-authorize.php
+++ b/includes/class-indieauth-local-authorize.php
@@ -5,10 +5,75 @@
  */
 class IndieAuth_Local_Authorize extends IndieAuth_Authorize {
 
-
 	public function __construct( $load = true ) {
+		$this->register_settings();
+		// Load the hooks for this class only if true. This allows for debugging of the functions
 		if ( true === $load ) {
+			add_action( 'admin_init', array( get_called_class(), 'admin_init' ) );
 			$this->load();
+		}
+	}
+
+	public function register_settings() {
+		register_setting(
+			'indieauth',
+			'indieauth_expires_in',
+			array(
+				'type'         => 'number',
+				'description'  => __( 'IndieAuth Default Expiry Time', 'indieauth' ),
+				'show_in_rest' => true,
+				'default'      => 1209600, // Two Weeks.
+			)
+		);
+	}
+
+	public static function admin_init() {
+		$cls  = get_called_class();
+		$page = 'indieauth';
+
+		add_settings_section(
+			'indieauth',
+			'IndieAuth Endpoint Settings',
+			array( $cls, 'endpoint_settings' ),
+			$page
+		);
+		add_settings_field(
+			'indieauth_expires_in',
+			__( 'Default Token Expiration Time', 'indieauth' ),
+			array( $cls, 'numeric_field' ),
+			$page,
+			'indieauth',
+			array(
+				'label_for'   => 'indieauth_expires_in',
+				'class'       => 'widefat',
+				'description' => __( 'Set the Number of Seconds until a Token expires (Default is Two Weeks). 0 to Disable Expiration.', 'indieauth' ),
+				'default'     => '',
+				'min'         => 0,
+			)
+		);
+	}
+
+
+	public static function endpoint_settings() {
+		esc_html_e( 'These settings control the behavior of the endpoints', 'indieauth' );
+	}
+
+
+	public static function numeric_field( $args ) {
+		$props = array();
+		if ( array_key_exists( 'min', $args ) && is_numeric( $args['min'] ) ) {
+			$props[] = 'min=' . $args['min'];
+		}
+		if ( array_key_exists( 'max', $args ) && is_numeric( $args['max'] ) ) {
+			$props[] = 'max=' . $args['max'];
+		}
+		if ( array_key_exists( 'step', $args ) && is_numeric( $args['step'] ) ) {
+			$props[] = 'step=' . $args['step'];
+		}
+		$props = implode( ' ', $props );
+		printf( '<label for="%1$s"><input id="%1$s" name="%1$s" type="number" value="%2$s" %3$s />', esc_attr( $args['label_for'] ), esc_attr( get_option( $args['label_for'], $args['default'] ) ), esc_html( $props ) );
+		if ( array_key_exists( 'description', $args ) && ! empty( $args['description'] ) ) {
+			printf( '<p>%1$s</p>', esc_html( $args['description'] ) );
 		}
 	}
 

--- a/includes/class-web-signin.php
+++ b/includes/class-web-signin.php
@@ -5,6 +5,8 @@
 class Web_Signin {
 
 	public function __construct() {
+		add_action( 'init', array( $this, 'settings' ) );
+
 		add_action( 'login_form', array( $this, 'login_form' ) );
 		add_filter( 'login_form_defaults', array( $this, 'login_form_defaults' ), 10, 1 );
 		add_filter( 'gettext', array( $this, 'register_text' ), 10, 3 );
@@ -12,6 +14,20 @@ class Web_Signin {
 
 		add_action( 'authenticate', array( $this, 'authenticate' ), 20, 2 );
 		add_action( 'authenticate', array( $this, 'authenticate_url_password' ), 10, 3 );
+	}
+
+	public function settings() {
+
+		register_setting(
+			'indieauth',
+			'indieauth_show_login_form',
+			array(
+				'type'         => 'boolean',
+				'description'  => __( 'Offer IndieAuth on Login Form', 'indieauth' ),
+				'show_in_rest' => true,
+				'default'      => 0,
+			)
+		);
 	}
 
 	/**

--- a/templates/indieauth-settings.php
+++ b/templates/indieauth-settings.php
@@ -78,17 +78,6 @@
 						</label>
 					</td>
 				</tr>
-				<tr>
-					<th>
-						<?php esc_html_e( 'Set Default Expiration', 'indieauth' ); ?>
-					</th>
-					<td>
-						<label for="indieauth_expires_in">
-							<input type="number" min="0" name="indieauth_expires_in" id="indieauth_expires_in" value="<?php echo intval( get_option( 'indieauth_expires_in' ) ); ?>" />
-							<?php esc_html_e( 'Set the Number of Seconds An IndieAuth Tokens Will Expire In (Default is Two Weeks). 0 to Disable', 'indieauth' ); ?>
-						</label>
-					</td>
-				</tr>
 			</tbody>
 		</table>
 


### PR DESCRIPTION
This tries to resolve #218 and also rewrites where that message is generated. 

It also attempts to resolve #187 by moving the search functionality for looking for the root user to a new function. Now, it will always set single users or single authors as the root URL, unless it is expressly set to None in the settings. This is a change due to the sheer number of people who were surprised that the URL was /author/username by default because they didn't set this field. 