### PR TITLE
Refresh Tokens

### DIFF
--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -220,7 +220,7 @@ class IndieAuth_Authorization_Endpoint {
 		if ( ! isset( $params['response_type'] ) || 'id' === $params['response_type'] ) {
 			$params['response_type'] = 'code';
 		}
-		if ( 'code' !== $params['response_type'] ) {
+		if ( 'code' === $params['response_type'] ) {
 			return $this->code( $params );
 		}
 
@@ -447,8 +447,14 @@ class IndieAuth_Authorization_Endpoint {
 
 
 		$response_type = isset( $_POST['response_type'] ) ? wp_unslash( $_POST['response_type'] ) : null;
+
+
+		/* Add UUID for reference.  
+		 */
+		$uuid = wp_generate_uuid4();
+
 		/// phpcs:enable
-		$token = compact( 'response_type', 'client_id', 'redirect_uri', 'scope', 'me', 'code_challenge', 'code_challenge_method', 'user' );
+		$token = compact( 'response_type', 'client_id', 'redirect_uri', 'scope', 'me', 'code_challenge', 'code_challenge_method', 'user', 'uuid' );
 		$token = array_filter( $token );
 		$code  = self::set_code( $current_user->ID, $token );
 		$url   = add_query_params_to_url(

--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -154,14 +154,15 @@ class IndieAuth_Authorization_Endpoint {
 				$scopes = array_values( $scopes );
 				echo '<div class="create_scope">';
 				echo wp_kses(
-					sprintf( '<li><input type="radio" name="scope[]" value="create"><strong>create</strong> - %1$s</li>', esc_html( self::scopes( 'create' ) ) ),
+					sprintf( '<li><input type="radio" name="scope[]" value="create" %1$s><strong>create</strong> - %2$s</li>', esc_attr( 'checked' ), esc_html( self::scopes( 'create' ) ) ),
 					array(
 						'li'     => array(),
 						'strong' => array(),
 						'input'  => array(
-							'type'  => array(),
-							'name'  => array(),
-							'value' => array(),
+							'type'    => array(),
+							'name'    => array(),
+							'value'   => array(),
+							'checked' => array(),
 						),
 					)
 				);

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -7,8 +7,11 @@
 
 class IndieAuth_Token_Endpoint {
 	private $tokens;
+	private $refresh_tokens;
 	public function __construct() {
-		$this->tokens = new Token_User( '_indieauth_token_' );
+		$this->tokens         = new Token_User( '_indieauth_token_' );
+		$this->refresh_tokens = new Token_User( '_indieauth_refresh_' );
+
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 	}
 
@@ -119,16 +122,47 @@ class IndieAuth_Token_Endpoint {
 		return rest_ensure_response( $token );
 	}
 
-	public function set_token( $token, $expiration = null ) {
+	public function set_token( $token, $expiration = null, $user_id = null ) {
 		if ( ! isset( $token['me'] ) ) {
 			return false;
 		}
-		$user = get_user_by_identifier( $token['me'] );
-		if ( $user instanceof WP_User ) {
-			$this->tokens->set_user( $user->ID );
-			return $this->tokens->set( $token, $expiration );
+		if ( ! $user_id ) {
+			$user_id = get_user_by_identifier( $token['me'] );
+			if ( $user instanceof WP_User ) {
+				$user_id = $user_id->ID;
+			} else {
+				return false;
+			}
 		}
-		return false;
+
+		$this->tokens->set_user( $user_id );
+
+		return $this->tokens->set( $token, $expiration );
+	}
+
+	/*
+	 * Sets a refresh token based on an access token.
+	 * @param array $token Access Token Return.
+	 * @param int $user User ID.
+	 * @return string Refresh Token.
+	 */
+	public function set_refresh_token( $token, $user ) {
+		$refresh = array(
+			'scope'     => $token['scope'],
+			'client_id' => $token['client_id'],
+			'iat'       => time(),
+			'me'        => $token['me'],
+			'uuid'      => $token['uuid'], // Uses the token UUID from the access token and adds it to the refresh token allowing them to be associated.
+		);
+		$this->refresh_tokens->set_user( $user );
+		$expires_in = array_key_exists( 'expires_in', $token ) ? $token['expires_in'] : null;
+
+		return $this->refresh_tokens->set( $refresh, $expires_in );
+	}
+
+	public function delete_refresh_token( $id, $user_id = null ) {
+		$this->refresh_tokens->set_user( $user_id );
+		return $this->refresh_tokens->destroy( $id );
 	}
 
 	public function delete_token( $id, $user_id = null ) {
@@ -172,6 +206,8 @@ class IndieAuth_Token_Endpoint {
 				// Request Token
 				case 'authorization_code':
 					return $this->authorization_code( $params );
+				case 'refresh_token':
+					return $this->refresh_token( $params );
 				default:
 					return new WP_OAuth_Response( 'unsupported_grant_type', __( 'Unsupported grant_type.', 'indieauth' ), 400 );
 			}
@@ -192,13 +228,37 @@ class IndieAuth_Token_Endpoint {
 		return new WP_OAuth_Response( 'invalid_request', __( 'Invalid Request', 'indieauth' ), 400 );
 	}
 
+
+	// Refresh Token Grant Type.
+	public function refresh_token( $params ) {
+
+		$diff = array_diff( array( 'refresh_token' ), array_keys( $params ) );
+		if ( ! empty( $diff ) ) {
+			return new WP_OAuth_Response( 'invalid_request', __( 'The request is missing one or more required parameters', 'indieauth' ), 400 );
+		}
+		$refresh = $this->refresh_tokens->get( $params['refresh_token'] );
+		if ( ! $refresh ) {
+			return new WP_OAuth_Response( 'invalid_grant', __( 'Invalid Token', 'indieauth' ), 400 );
+		}
+
+		// Destroy the refresh token.
+		$this->refresh_tokens->destroy( $params['refresh_token'] );
+
+		if ( array_key_exists( 'client_id', $params ) && ( $refresh['client_id'] !== $params['client_id'] ) ) {
+			return new WP_OAuth_Response( 'invalid_grant', __( 'Client ID does not match', 'indieauth' ), 400 );
+		}
+
+		return $this->generate_token_response( $refresh );
+
+	}
+
 	// Authorization Code Grant Type.
 	public function authorization_code( $params ) {
 		$diff = array_diff( array( 'code', 'client_id', 'redirect_uri' ), array_keys( $params ) );
 		if ( ! empty( $diff ) ) {
 			return new WP_OAuth_Response( 'invalid_request', __( 'The request is missing one or more required parameters', 'indieauth' ), 400 );
 		}
-		$args     = array_filter(
+		$args                  = array_filter(
 			array(
 				'code'          => $params['code'],
 				'redirect_uri'  => $params['redirect_uri'],
@@ -206,13 +266,19 @@ class IndieAuth_Token_Endpoint {
 				'code_verifier' => isset( $params['code_verifier'] ) ? $params['code_verifier'] : null,
 			)
 		);
-		$response = indieauth_verify_local_authorization_code( $args );
+		$response              = indieauth_verify_local_authorization_code( $args );
+		$response['client_id'] = $params['client_id'];
 
 		$error = get_oauth_error( $response );
 		if ( $error ) {
 			return $error;
 		}
 
+		return $this->generate_token_response( $response );
+
+	}
+
+	public function generate_token_response( $response ) {
 		$return = array(
 			'me' => $response['me'],
 		);
@@ -220,28 +286,31 @@ class IndieAuth_Token_Endpoint {
 		if ( isset( $response['scope'] ) ) {
 			$scopes = array_filter( explode( ' ', $response['scope'] ) );
 			if ( ! array_key_exists( 'user', $response ) ) {
-				$user = get_user_by_identifier( $response['me'] );
-				$user = $user->ID;
-			} else {
-				$user = $response['user'];
+				$user             = get_user_by_identifier( $response['me'] );
+				$response['user'] = $user->ID;
 			}
 			if ( in_array( 'profile', $scopes, true ) ) {
-				$return['profile'] = indieauth_get_user( $user, in_array( 'email', $scopes, true ) );
+				$return['profile'] = indieauth_get_user( $response['user'], in_array( 'email', $scopes, true ) );
 			}
 
 			// Issue a token
 			if ( ! empty( $scopes ) ) {
-				$info                 = new IndieAuth_Client_Discovery( $params['client_id'] );
+				$info                 = new IndieAuth_Client_Discovery( $response['client_id'] );
 				$return['token_type'] = 'Bearer';
 
-				/* Add UUID for reference. In case you’d like to build infrastructure for additional properties and store them in an alternate location.
-				 * This idea came from the core application password implementation.
-				 */
-				$return['uuid'] = wp_generate_uuid4();
+				if ( ! array_key_exists( 'uuid', $response ) ) {
+					/* Add UUID for reference. In case you’d like to build infrastructure for additional properties and store them in an alternate location.
+					 * As of 4.1.0, the uuid is passed from the authorization code to the access token and refresh token. But if not, it is added here.
+					 * This idea came from the core application password implementation.
+					 */
+					$return['uuid'] = wp_generate_uuid4();
+				} else {
+					$return['uuid'] = $response['uuid'];
+				}
 
 				$return['scope']       = $response['scope'];
 				$return['issued_by']   = rest_url( 'indieauth/1.0/token' );
-				$return['client_id']   = $params['client_id'];
+				$return['client_id']   = $response['client_id'];
 				$return['client_name'] = $info->get_name();
 				$return['client_icon'] = $info->get_icon();
 				$return['iat']         = time();
@@ -250,11 +319,13 @@ class IndieAuth_Token_Endpoint {
 
 				$return = array_filter( $return );
 
-				$return['access_token'] = $this->set_token( $return, $expires );
+				$return['access_token'] = $this->set_token( $return, $expires, $response['user'] );
 
 				// Do Not Add Expires In for the Return Until After It is Saved to the Database
 				if ( 0 !== $expires ) {
 					$return['expires_in'] = $expires;
+					// For now, the refresh token will only last 1.5x the expiry of the access token.
+					$return['refresh_token'] = $this->set_refresh_token( $return, $response['user'] );
 				}
 			}
 		}
@@ -271,6 +342,7 @@ class IndieAuth_Token_Endpoint {
 						'me',
 						'profile',
 						'expires_in',
+						'refresh_token',
 					)
 				),
 				200, // Status Code

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -244,10 +244,6 @@ class IndieAuth_Token_Endpoint {
 		// Destroy the refresh token.
 		$this->refresh_tokens->destroy( $params['refresh_token'] );
 
-		if ( array_key_exists( 'client_id', $params ) && ( $refresh['client_id'] !== $params['client_id'] ) ) {
-			return new WP_OAuth_Response( 'invalid_grant', __( 'Client ID does not match', 'indieauth' ), 400 );
-		}
-
 		return $this->generate_token_response( $refresh );
 
 	}
@@ -267,7 +263,6 @@ class IndieAuth_Token_Endpoint {
 			)
 		);
 		$response              = indieauth_verify_local_authorization_code( $args );
-		$response['client_id'] = $params['client_id'];
 
 		$error = get_oauth_error( $response );
 		if ( $error ) {

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -157,7 +157,7 @@ class IndieAuth_Token_Endpoint {
 		$this->refresh_tokens->set_user( $user );
 		$expires_in = array_key_exists( 'expires_in', $token ) ? $token['expires_in'] : null;
 
-		return $this->refresh_tokens->set( $refresh, $expires_in );
+		return $this->refresh_tokens->set( $refresh, $expires_in + 300 );
 	}
 
 	public function delete_refresh_token( $id, $user_id = null ) {
@@ -324,7 +324,6 @@ class IndieAuth_Token_Endpoint {
 				// Do Not Add Expires In for the Return Until After It is Saved to the Database
 				if ( 0 !== $expires ) {
 					$return['expires_in'] = $expires;
-					// For now, the refresh token will only last 1.5x the expiry of the access token.
 					$return['refresh_token'] = $this->set_refresh_token( $return, $response['user'] );
 				}
 			}

--- a/includes/class-token-generic.php
+++ b/includes/class-token-generic.php
@@ -91,7 +91,7 @@ abstract class Token_Generic {
 	 * @return int Timestamp when this will expire.
 	 */
 	public function expires( $expiration ) {
-		return time() + $expiration;
+		return round( time() + $expiration );
 	}
 
 	/**

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -246,20 +246,20 @@ class Token_User extends Token_Generic {
 		return $user_ids;
 	}
 
-	/** 
+	/**
 	 * Find tokens by UUID.
 	 *
 	 * @param string $uuid UUID.
 	 * @return array Results.
 	 */
-	 public function find_by_uuid( $uuid, $user = null ) {
-	 	$tokens = $this->get_all( $user );
+	public function find_by_uuid( $uuid, $user = null ) {
+		$tokens = $this->get_all( $user );
 		$return = array();
-		foreach( $tokens as $key => $token ) {
+		foreach ( $tokens as $key => $token ) {
 			if ( array_key_exists( 'uuid', $token ) && ( $uuid === $token['uuid'] ) ) {
 				$return[ $key ] = $token;
 			}
 		}
 		return $return;
-	 }
+	}
 }

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -245,4 +245,21 @@ class Token_User extends Token_Generic {
 		}
 		return $user_ids;
 	}
+
+	/** 
+	 * Find tokens by UUID.
+	 *
+	 * @param string $uuid UUID.
+	 * @return array Results.
+	 */
+	 public function find_by_uuid( $uuid, $user = null ) {
+	 	$tokens = $this->get_all( $user );
+		$return = array();
+		foreach( $tokens as $key => $token ) {
+			if ( array_key_exists( 'uuid', $token ) && ( $uuid === $token['uuid'] ) ) {
+				$return[ $key ] = $token;
+			}
+		}
+		return $return;
+	 }
 }

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -247,16 +247,17 @@ class Token_User extends Token_Generic {
 	}
 
 	/**
-	 * Find tokens by UUID.
+	 * Find tokens by field.
 	 *
-	 * @param string $uuid UUID.
+	 * @param string $field Field.
+	 * @param string $value Value.
 	 * @return array Results.
 	 */
-	public function find_by_uuid( $uuid, $user = null ) {
+	public function find_by_field( $field, $value, $user = null ) {
 		$tokens = $this->get_all( $user );
 		$return = array();
 		foreach ( $tokens as $key => $token ) {
-			if ( array_key_exists( 'uuid', $token ) && ( $uuid === $token['uuid'] ) ) {
+			if ( array_key_exists( $field, $token ) && ( $value === $token[ $field ] ) ) {
 				$return[ $key ] = $token;
 			}
 		}

--- a/indieauth.php
+++ b/indieauth.php
@@ -79,6 +79,9 @@ class IndieAuth_Plugin {
 		$t = new Token_User( '_indieauth_token_', $user_id );
 		$t->get_all();
 		$t = new Token_User( '_indieauth_code_', $user_id );
+		$t->get_all();
+		$t = new Token_User( '_indieauth_refresh_token_', $user_id );
+		$t->get_all();
 		$t = new External_User_Token();
 		$t->expire_all_tokens();
 	}

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: IndieAuth 4.1.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2021-09-13 02:58:46+00:00\n"
+"POT-Creation-Date: 2021-09-19 04:08:37+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -298,49 +298,48 @@ msgstr ""
 msgid "No Description Available"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:181
+#: includes/class-indieauth-authorization-endpoint.php:182
 msgid "Token will have no privileges to create posts"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:218
+#: includes/class-indieauth-authorization-endpoint.php:228
 msgid "Unsupported Response Type"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:224
-#: includes/class-indieauth-authorization-endpoint.php:278
+#: includes/class-indieauth-authorization-endpoint.php:243
+#: includes/class-indieauth-authorization-endpoint.php:319
 #. translators: Name of missing parameter
 msgid "Missing Parameter: %1$s"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:244
+#: includes/class-indieauth-authorization-endpoint.php:262
 msgid "Invalid scope request"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:248
+#: includes/class-indieauth-authorization-endpoint.php:268
 msgid "Cannot request email scope without profile scope"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:282
-#: includes/class-indieauth-token-endpoint.php:160
+#: includes/class-indieauth-authorization-endpoint.php:305
 msgid "Endpoint only accepts authorization_code grant_type"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:290
+#: includes/class-indieauth-authorization-endpoint.php:329
 #: includes/class-indieauth-local-authorize.php:117 includes/functions.php:548
 msgid "Invalid authorization code"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:295
+#: includes/class-indieauth-authorization-endpoint.php:334
 msgid "The authorization code expired"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:303
-#: includes/class-indieauth-authorization-endpoint.php:307
+#: includes/class-indieauth-authorization-endpoint.php:342
+#: includes/class-indieauth-authorization-endpoint.php:346
 #: includes/functions.php:553 includes/functions.php:557
 msgid "Failed PKCE Validation"
 msgstr ""
 
-#: includes/class-indieauth-authorization-endpoint.php:324
+#: includes/class-indieauth-authorization-endpoint.php:363
 msgid ""
 "There was an error verifying the authorization code. Check that the "
 "client_id and redirect_uri match the original request."
@@ -391,7 +390,7 @@ msgid "These settings control the behavior of the endpoints"
 msgstr ""
 
 #: includes/class-indieauth-local-authorize.php:95
-#: includes/class-indieauth-token-endpoint.php:111
+#: includes/class-indieauth-token-endpoint.php:119
 msgid "Invalid access token"
 msgstr ""
 
@@ -462,52 +461,76 @@ msgid ""
 "response. Without this only a display name, avatar, and url will be returned"
 msgstr ""
 
-#: includes/class-indieauth-ticket-endpoint.php:81
+#: includes/class-indieauth-ticket-endpoint.php:83
 msgid "Cannot Find Token Endpoint"
 msgstr ""
 
-#: includes/class-indieauth-ticket-endpoint.php:107
+#: includes/class-indieauth-ticket-endpoint.php:109
 msgid "Your Ticket Has Been Redeemed. Thank you for your trust!"
 msgstr ""
 
-#: includes/class-indieauth-ticket-endpoint.php:114
-#: includes/class-indieauth-token-endpoint.php:149
-#: includes/class-indieauth-token-endpoint.php:176
+#: includes/class-indieauth-ticket-endpoint.php:116
+#: includes/class-indieauth-token-endpoint.php:228
 msgid "Invalid Request"
 msgstr ""
 
-#: includes/class-indieauth-ticket-endpoint.php:120
+#: includes/class-indieauth-ticket-endpoint.php:122
 msgid "Me Property Missing From Response"
 msgstr ""
 
-#: includes/class-indieauth-ticket-endpoint.php:126
+#: includes/class-indieauth-ticket-endpoint.php:128
 msgid "Unable to Identify User Associated with Me Property"
 msgstr ""
 
-#: includes/class-indieauth-ticket-endpoint.php:159
+#: includes/class-indieauth-ticket-endpoint.php:161
 msgid "On Trying to Redeem a Token the Response was Invalid"
 msgstr ""
 
-#: includes/class-indieauth-ticket-endpoint.php:172
+#: includes/class-indieauth-ticket-endpoint.php:174
 msgid "Unable to Redeem Ticket for Unknown Reasons."
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:101
+#: includes/class-indieauth-token-endpoint.php:109
 msgid ""
 "Bearer Token Not Supplied or Server Misconfigured to Not Pass Token. Run "
 "diagnostic script in WordPress Admin\n"
 "\t\t\t\tIndieAuth Settings Page"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:145
+#: includes/class-indieauth-token-endpoint.php:184
+msgid "Please choose either an action or a grant_type"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:194
 msgid "The Token Provided is No Longer Valid"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:183
+#: includes/class-indieauth-token-endpoint.php:196
+msgid "Revoke is Missing Required Parameter token"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:199
+msgid "Unsupported Action"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:212
+msgid "Unsupported grant_type."
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:237
+#: includes/class-indieauth-token-endpoint.php:259
 msgid "The request is missing one or more required parameters"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:267
+#: includes/class-indieauth-token-endpoint.php:241
+msgid "Invalid Token"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:248
+msgid "Client ID does not match"
+msgstr ""
+
+#: includes/class-indieauth-token-endpoint.php:354
 msgid "There was an error in response."
 msgstr ""
 
@@ -663,7 +686,7 @@ msgstr ""
 msgid "Invalid User Profile URL"
 msgstr ""
 
-#: indieauth.php:170
+#: indieauth.php:173
 #. translators: 1. Path to file unable to load
 msgid "Unable to load: %1s"
 msgstr ""

--- a/readme.md
+++ b/readme.md
@@ -182,6 +182,8 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 * Misc Bug Fixes discovered in unit testing
 * Updating of settings configuration
 * Improved default for user who gets to identify as root of site.
+* Introduce Refresh Token Functionality
+* Create was not pre-checked in new selections when offered as an option.
 
 ### 4.0.0 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -183,6 +183,7 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 * Updating of settings configuration
 * Improved default for user who gets to identify as root of site.
 * Introduce Refresh Token Functionality
+* Create was not pre-checked in new selections when offered as an option.
 
 = 4.0.0 = 
 

--- a/readme.txt
+++ b/readme.txt
@@ -182,6 +182,7 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 * Misc Bug Fixes discovered in unit testing
 * Updating of settings configuration
 * Improved default for user who gets to identify as root of site.
+* Introduce Refresh Token Functionality
 
 = 4.0.0 = 
 

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -29,7 +29,7 @@ class TokensTest extends WP_UnitTestCase {
 		$uuid = wp_generate_uuid4();
 		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'uuid' => $uuid );
 		$access_token = $tokens->set( $token );
-		$return = $tokens->find_by_uuid( $uuid, $user_id_1 );
+		$return = $tokens->find_by_field( 'uuid', $uuid, $user_id_1 );
 		$first = reset( $return );
 		$this->assertEquals( $uuid, $first['uuid'], wp_json_encode( $return ) );
 	}

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -23,6 +23,17 @@ class TokensTest extends WP_UnitTestCase {
 		$this->assertEquals( $users, array( $user_id_1, $user_id_2 ) );
 	}
 
+	public function test_find_by_uuid() {
+		$user_id_1 = self::factory()->user->create();
+		$tokens = new Token_User( '_indieauth_code_', $user_id_1 );
+		$uuid = wp_generate_uuid4();
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'uuid' => $uuid );
+		$access_token = $tokens->set( $token );
+		$return = $tokens->find_by_uuid( $uuid, $user_id_1 );
+		$first = reset( $return );
+		$this->assertEquals( $uuid, $first['uuid'], wp_json_encode( $return ) );
+	}
+
 
 
 	public function test_expired_token() {


### PR DESCRIPTION
Introduce Refresh Tokens and what came with it.

Introduce uuid into the auth code, so that if by some chance the auth code isn't revoked, we can tie it to the right access token. UUID for refresh token is the same as the access token so that we can revoke appropriately. Introduction of find by uuid function with testing.

Also, found two minor bugs introduced in previous PRs approved that are now fixed.