### PR TITLE
Add IndieAuth Metadata Endpoint

### DIFF
--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -462,6 +462,7 @@ class IndieAuth_Authorization_Endpoint {
 			array(
 				'code'  => $code,
 				'state' => $state,
+				'iss'   => indieauth_get_issuer(),
 			),
 			$redirect_uri
 		);

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -14,7 +14,6 @@ abstract class IndieAuth_Authorize {
 		// It validates the logged in cookie at 20 and can be overridden by something with a higher priority
 		add_filter( 'determine_current_user', array( $this, 'determine_current_user' ), 15 );
 		add_filter( 'rest_authentication_errors', array( $this, 'rest_authentication_errors' ) );
-		add_filter( 'rest_index', array( $this, 'register_index' ) );
 
 		add_action( 'template_redirect', array( $this, 'http_header' ) );
 		add_action( 'wp_head', array( $this, 'html_header' ) );
@@ -60,30 +59,6 @@ abstract class IndieAuth_Authorize {
 			$current_user = null; // phpcs:ignore
 		}
 		return $class;
-	}
-
-	/**
-	 * Add authentication information into the REST API Index
-	 *
-	 * @param WP_REST_Response $response REST API Response Object
-	 *
-	 * @return WP_REST_Response Response object with endpoint info added
-	 **/
-	public function register_index( WP_REST_Response $response ) {
-		$data      = $response->get_data();
-		$endpoints = array(
-			'authorization' => $this->get_authorization_endpoint(),
-			'token'         => $this->get_token_endpoint(),
-		);
-		$endpoints = array_filter( $endpoints );
-		if ( empty( $endpoints ) ) {
-			return $response;
-		}
-		$data['authentication']['indieauth'] = array(
-			'endpoints' => $endpoints,
-		);
-		$response->set_data( $data );
-		return $response;
 	}
 
 	public function get_indieauth_scopes( $scopes ) {

--- a/includes/class-indieauth-metadata-endpoint.php
+++ b/includes/class-indieauth-metadata-endpoint.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Metadata Endpoint Functionality
+ */
+class IndieAuth_Metadata_Endpoint {
+
+	public function __construct() {
+		add_filter( 'rest_index', array( $this, 'register_index' ) );
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		add_action( 'wp_head', array( $this, 'html_header' ) );
+		add_action( 'template_redirect', array( $this, 'http_header' ) );
+	}
+
+	/**
+	 * Returns the URL for the metadata endpoint.
+	 **/
+	public static function get_metadata_endpoint() {
+		return rest_url( '/indieauth/1.0/metadata' );
+	}
+
+	/**
+	 * Add authentication information into the REST API Index
+	 *
+	 * @param WP_REST_Response $response REST API Response Object
+	 *
+	 * @return WP_REST_Response Response object with endpoint info added
+	 **/
+	public function register_index( WP_REST_Response $response ) {
+		$data      = $response->get_data();
+		$endpoints = array(
+			'authorization' => indieauth_get_authorization_endpoint(),
+			'token'         => indieauth_get_token_endpoint(),
+			'metadata'      => indieauth_get_metadata_endpoint(),
+		);
+		$endpoints = array_filter( $endpoints );
+		if ( empty( $endpoints ) ) {
+			return $response;
+		}
+		$data['authentication']['indieauth'] = array(
+			'endpoints' => $endpoints,
+		);
+		$response->set_data( $data );
+		return $response;
+	}
+
+	public function http_header() {
+		if ( is_author() || is_front_page() ) {
+			header( sprintf( 'Link: <%s>; rel="indieauth-metadata"', static::get_metadata_endpoint() ), false );
+		}
+	}
+	public static function html_header() {
+		$kses = array(
+			'link' => array(
+				'href' => array(),
+				'rel'  => array(),
+			),
+		);
+		if ( empty( $auth ) || empty( $token ) ) {
+			return;
+		}
+		if ( is_author() || is_front_page() ) {
+			echo wp_kses( sprintf( '<link rel="indieauth-metadata" href="%s" />' . PHP_EOL, static::get_metadata_endpoint() ), $kses );
+		}
+	}
+
+	/**
+	 * Register the Route.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'indieauth/1.0',
+			'/metadata',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'metadata' ),
+					'args'                => array(),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+	}
+
+	/*
+	 * Metadata Endpoint GET request handler.
+	 *
+	 * @param WP_REST_Request $request The Request Object.
+	 * @return Response to Return to the REST Server.
+	 */
+	public function metadata( $request ) {
+		$grants = array( 'authorization_code', 'refresh_token' );
+		if ( class_exists( 'IndieAuth_Ticket_Endpoint' ) ) {
+			$grants[] = 'ticket';
+		}
+
+		$metadata = array(
+			'issuer'                           => indieauth_get_issuer(),
+			'authorization_endpoint'           => indieauth_get_authorization_endpoint(),
+			'scopes_supported'                 => IndieAuth_Plugin::$scopes->get_names(),
+			'response_types_supported'         => array( 'code' ),
+			'grant_types_supported'            => $grants,
+			'service_documentation'            => 'https://indieauth.spec.indieweb.org',
+			'token_endpoint'                   => indieauth_get_token_endpoint(),
+			'code_challenge_methods_supported' => array( 'S256' ),
+			'authorization_response_iss_parameter_supported' => true,
+		);
+
+		$metadata = apply_filters( 'indieauth_metadata', $metadata );
+		return new WP_REST_Response(
+			$metadata,
+			200,
+			array(
+				'Content-Type' => 'application/json',
+			)
+		);
+	}
+
+}

--- a/includes/class-indieauth-metadata-endpoint.php
+++ b/includes/class-indieauth-metadata-endpoint.php
@@ -11,9 +11,9 @@ class IndieAuth_Metadata_Endpoint {
 		add_action( 'template_redirect', array( $this, 'http_header' ) );
 	}
 
-	/**
+	/*
 	 * Returns the URL for the metadata endpoint.
-	 **/
+	 */
 	public static function get_metadata_endpoint() {
 		return rest_url( '/indieauth/1.0/metadata' );
 	}
@@ -81,12 +81,12 @@ class IndieAuth_Metadata_Endpoint {
 		);
 	}
 
-	/*
+	/**
 	 * Metadata Endpoint GET request handler.
 	 *
 	 * @param WP_REST_Request $request The Request Object.
 	 * @return Response to Return to the REST Server.
-	 */
+	 **/
 	public function metadata( $request ) {
 		$grants = array( 'authorization_code', 'refresh_token' );
 		if ( class_exists( 'IndieAuth_Ticket_Endpoint' ) ) {

--- a/includes/class-indieauth-scopes.php
+++ b/includes/class-indieauth-scopes.php
@@ -271,4 +271,3 @@ class IndieAuth_Scopes {
 	}
 }
 
-new IndieAuth_Scopes();

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -572,3 +572,11 @@ function indieauth_get_authorization_endpoint() {
 function indieauth_get_token_endpoint() {
 	return IndieAuth_Plugin::$indieauth->get_token_endpoint();
 }
+
+function indieauth_get_metadata_endpoint() {
+	return IndieAuth_Plugin::$metadata->get_metadata_endpoint();
+}
+
+function indieauth_get_issuer() {
+	return rest_url( '/indieauth/1.0' );
+}

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 4.1.1
+ * Version: 4.2.0
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT
@@ -33,6 +33,8 @@ add_action( 'indieauth_cleanup', array( 'IndieAuth_Plugin', 'expires' ) );
 
 class IndieAuth_Plugin {
 	public static $indieauth = null; // Loaded instance of authorize class
+	public static $metadata  = null; // Loaded instance of metadata class
+	public static $scopes    = null; // Loaded instance of scopes class
 
 	/*
 	 * Process to Trigger on Plugin Update.
@@ -104,6 +106,8 @@ class IndieAuth_Plugin {
 			)
 		);
 
+		static::$scopes = new IndieAuth_Scopes();
+
 		new IndieAuth_Admin();
 
 		// Classes Required for the Local Endpoint
@@ -112,6 +116,7 @@ class IndieAuth_Plugin {
 			'class-token-user.php',
 			'class-indieauth-token-endpoint.php', // Token Endpoint
 			'class-indieauth-authorization-endpoint.php', // Authorization Endpoint
+			'class-indieauth-metadata-endpoint.php', // Metadata Endpoint
 			'class-token-list-table.php', // Token Management UI
 			'class-indieauth-token-ui.php',
 			'class-indieauth-local-authorize.php',
@@ -135,6 +140,7 @@ class IndieAuth_Plugin {
 				new IndieAuth_Authorization_Endpoint();
 				new IndieAuth_Token_Endpoint();
 				static::$indieauth = new IndieAuth_Local_Authorize();
+				static::$metadata  = new IndieAuth_Metadata_Endpoint();
 				break;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.6  
 **Tested up to:** 5.8  
-**Stable tag:** 4.1.1  
+**Stable tag:** 4.2.0  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -70,7 +70,7 @@ We recommend your site uses HTTPS to ensure your credentials are not sent in cle
 
 ### What is a token endpoint? ###
 
-Once you have proven your identity, the token endpoint issues a token, which applications can use to authenticate as you to your site. The plugin supports you using an external token endpoint if you want, but by having it built into your WordPress site, it is under your control.
+Once you have proven your identity, the token endpoint issues a token, which applications can use to authenticate as you to your site. The plugin does offer an expert mode to allow you to use an external token endpoint if you want, but by having it built into your WordPress site, it is under your control.
 
 You can manage and revoke tokens under User->Manage Tokens if you are using the local configuration only. You will only see tokens for the currently logged in user.
 
@@ -143,6 +143,11 @@ Since the extension is developing, there is currently not a specified way to tra
 
 ## Upgrade Notice ##
 
+- 4.2.0 =
+
+Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard
+to take advantage of the latest opportunities.
+
 ### 4.1.0 ###
 
 Introduces experimental Ticket Auth Endpoint, which allows the receipt of tickets and the storage of external tokens. This is disabled by default and can only be enabled through a flag.
@@ -172,6 +177,11 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 4.2.0 ###
+
+* Add Server Metadata Endpoint
+* Add Issuer Property to Authorization Response
 
 ### 4.1.1 ###
 

--- a/readme.md
+++ b/readme.md
@@ -145,8 +145,7 @@ Since the extension is developing, there is currently not a specified way to tra
 
 - 4.2.0 =
 
-Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard
-to take advantage of the latest opportunities.
+Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard to take advantage of the latest opportunities.
 
 ### 4.1.0 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.6
 Tested up to: 5.8
-Stable tag: 4.1.1
+Stable tag: 4.2.0
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -70,7 +70,7 @@ We recommend your site uses HTTPS to ensure your credentials are not sent in cle
 
 = What is a token endpoint? =
 
-Once you have proven your identity, the token endpoint issues a token, which applications can use to authenticate as you to your site. The plugin supports you using an external token endpoint if you want, but by having it built into your WordPress site, it is under your control.
+Once you have proven your identity, the token endpoint issues a token, which applications can use to authenticate as you to your site. The plugin does offer an expert mode to allow you to use an external token endpoint if you want, but by having it built into your WordPress site, it is under your control.
 
 You can manage and revoke tokens under User->Manage Tokens if you are using the local configuration only. You will only see tokens for the currently logged in user.
 
@@ -143,6 +143,11 @@ Since the extension is developing, there is currently not a specified way to tra
 
 == Upgrade Notice ==
 
+- 4.2.0 =
+
+Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard
+to take advantage of the latest opportunities.
+
 = 4.1.0 =
 
 Introduces experimental Ticket Auth Endpoint, which allows the receipt of tickets and the storage of external tokens. This is disabled by default and can only be enabled through a flag.
@@ -172,6 +177,11 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 4.2.0 =
+
+* Add Server Metadata Endpoint
+* Add Issuer Property to Authorization Response
 
 = 4.1.1 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -145,8 +145,7 @@ Since the extension is developing, there is currently not a specified way to tra
 
 - 4.2.0 =
 
-Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard
-to take advantage of the latest opportunities.
+Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard to take advantage of the latest opportunities.
 
 = 4.1.0 =
 


### PR DESCRIPTION
This adds a metadata endpoint, as merged into the spec, into the plugin. It also adds the issuer URL to the authorization response return, also merged into the spec.

As a side effect, some other minor tweaks were necessary. The rest_index functionality is very similar to metadata, so it moved over to that file.

Need someone to check the code on a WordPress level, and on a new spec level.