### PR TITLE
New Endpoints

### DIFF
--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -162,6 +162,9 @@ abstract class IndieAuth_Authorize {
 			return 0;
 		}
 		if ( is_array( $params ) ) {
+			// If this is a token auth response, add this constant.
+			define( 'INDIEAUTH_TOKEN', true );
+
 			$this->response = $params;
 			$this->scopes   = explode( ' ', $params['scope'] );
 			// The User ID must be passed in the request

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -30,10 +30,10 @@ abstract class IndieAuth_Authorize {
 	 * Ensures responses to any IndieAuth endpoints are always OAuth Responses rather than WP_Error.
 	 */
 	public static function return_oauth_error( $response, $handler, $request ) {
-		if( 0 !== strpos( $request->get_route(), '/indieauth/1.0/' ) ) {
+		if ( 0 !== strpos( $request->get_route(), '/indieauth/1.0/' ) ) {
 			return $response;
 		}
-		
+
 		if ( is_wp_error( $response ) ) {
 			return wp_error_to_oauth_response( $response );
 		}

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -21,8 +21,25 @@ abstract class IndieAuth_Authorize {
 		add_filter( 'indieauth_scopes', array( $this, 'get_indieauth_scopes' ), 9 );
 		add_filter( 'indieauth_response', array( $this, 'get_indieauth_response' ), 9 );
 		add_filter( 'wp_rest_server_class', array( $this, 'wp_rest_server_class' ) );
+		add_filter( 'rest_request_after_callbacks', array( $this, 'return_oauth_error' ), 10, 3 );
 
 	}
+
+
+	/*
+	 * Ensures responses to any IndieAuth endpoints are always OAuth Responses rather than WP_Error.
+	 */
+	public static function return_oauth_error( $response, $handler, $request ) {
+		if( 0 !== strpos( $request->get_route(), '/indieauth/1.0/' ) ) {
+			return $response;
+		}
+		
+		if ( is_wp_error( $response ) ) {
+			return wp_error_to_oauth_response( $response );
+		}
+		return $response;
+	}
+
 
 	/**
 	 * Returns the URL for the authorization endpoint.

--- a/includes/class-indieauth-endpoint.php
+++ b/includes/class-indieauth-endpoint.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ *
+ *
+ * Implements Endpoint Functionality
+ */
+
+class IndieAuth_Endpoint {
+	protected $tokens;
+	protected $refresh_tokens;
+	public function __construct() {
+		$this->tokens         = new Token_User( '_indieauth_token_' );
+		$this->refresh_tokens = new Token_User( '_indieauth_refresh_' );
+	}
+
+
+	/**
+	 * Extracts the token from the given authorization header.
+	 *
+	 * @param string $header Authorization header.
+	 *
+	 * @return string|null Token on success, null on failure.
+	 */
+	public function get_token_from_bearer_header( $header ) {
+		if ( is_string( $header ) && preg_match( '/Bearer ([\x20-\x7E]+)/', trim( $header ), $matches ) ) {
+			return $matches[1];
+		}
+		return null;
+	}
+
+	public function permission_callback( $request ) {
+		if ( defined( 'INDIEAUTH_TOKEN' ) && INDIEAUTH_TOKEN ) {
+			return true;
+		}
+
+		$error = new WP_OAuth_Response(
+			'invalid_token',
+			__(
+				'The access token provided is expired, revoked, or invalid',
+				'indieauth'
+			),
+			401
+		);
+		return $error->to_wp_error();
+	}
+
+	public function get_token( $token, $hash = true, $type = null ) {
+		switch ( $type ) {
+			case 'access_token':
+				return $this->tokens->get( $token, $hash );
+			case 'refresh_token':
+				return $this->refresh_tokens->get( $token, $hash );
+			default:
+				$token = $this->tokens->get( $token, $hash );
+				if ( $token ) {
+					return $token;
+				}
+				$refresh = $this->refresh_tokens->get( $token, $hash );
+				return $refresh;
+		}
+	}
+
+	public function delete_token( $id, $user_id = null, $type = null ) {
+		switch ( $type ) {
+			case 'access_token':
+				$this->tokens->set_user( $user_id );
+				return $this->tokens->destroy( $id );
+			case 'refresh_token':
+				$this->refresh_tokens->set_user( $user_id );
+				return $this->refresh_tokens->destroy( $id );
+			default:
+				$this->tokens->set_user( $user_id );
+				$token = $this->tokens->destroy( $id );
+				if ( $token ) {
+					return $token;
+				}
+				$this->refresh_tokens->set_user( $user_id );
+				return $this->refresh_tokens->destroy( $id );
+		}
+	}
+
+
+	public function set_token( $token, $expiration = null, $user_id = null ) {
+		if ( ! isset( $token['me'] ) ) {
+			return false;
+		}
+		if ( ! $user_id ) {
+			$user_id = get_user_by_identifier( $token['me'] );
+			if ( $user instanceof WP_User ) {
+				$user_id = $user_id->ID;
+			} else {
+				return false;
+			}
+		}
+
+		$this->tokens->set_user( $user_id );
+
+		return $this->tokens->set( $token, $expiration );
+	}
+
+	/*
+	 * Sets a refresh token based on an access token.
+	 * @param array $token Access Token Return.
+	 * @param int $user User ID.
+	 * @return string Refresh Token.
+	 */
+	public function set_refresh_token( $token, $user ) {
+		$refresh = array(
+			'scope'     => $token['scope'],
+			'client_id' => $token['client_id'],
+			'iat'       => time(),
+			'me'        => $token['me'],
+			'uuid'      => $token['uuid'], // Uses the token UUID from the access token and adds it to the refresh token allowing them to be associated.
+		);
+		$this->refresh_tokens->set_user( $user );
+		$expires_in = array_key_exists( 'expires_in', $token ) ? $token['expires_in'] : null;
+
+		return $this->refresh_tokens->set( $refresh, $expires_in + 300 );
+	}
+
+	public function delete_refresh_token( $id, $user_id = null ) {
+		$this->refresh_tokens->set_user( $user_id );
+		return $this->refresh_tokens->destroy( $id );
+	}
+
+}
+

--- a/includes/class-indieauth-endpoint.php
+++ b/includes/class-indieauth-endpoint.php
@@ -28,22 +28,6 @@ class IndieAuth_Endpoint {
 		return null;
 	}
 
-	public function permission_callback( $request ) {
-		if ( defined( 'INDIEAUTH_TOKEN' ) && INDIEAUTH_TOKEN ) {
-			return true;
-		}
-
-		$error = new WP_OAuth_Response(
-			'invalid_token',
-			__(
-				'The access token provided is expired, revoked, or invalid',
-				'indieauth'
-			),
-			401
-		);
-		return $error->to_wp_error();
-	}
-
 	public function get_token( $token, $hash = true, $type = null ) {
 		switch ( $type ) {
 			case 'access_token':

--- a/includes/class-indieauth-introspection-endpoint.php
+++ b/includes/class-indieauth-introspection-endpoint.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Introspection Endpoint Functionality
+ */
+class IndieAuth_Introspection_Endpoint extends IndieAuth_Endpoint {
+
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the Route.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'indieauth/1.0',
+			'/introspection',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'introspection' ),
+					'args'                => array(
+						'token'           => array(
+							'required' => true,
+						),
+						'token_type_hint' => array(
+							'default' => 'all',
+						), // A hint about the type of the token submitted for revocation, options are access_token or refresh_token.
+					),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+	}
+
+	/*
+	 * Introspection Endpoint request handler.
+	 *
+	 * @param WP_REST_Request $request The Request Object.
+	 * @return Response to Return to the REST Server.
+	 */
+
+	public function introspection( $request ) {
+		$params = $request->get_params();
+		$token  = $this->get_token( $params['token'], $params['token_type_hint'] );
+		if ( $token ) {
+			$token['active'] = 'true';
+		} else {
+			$token = array( 'active' => false );
+		}
+
+		return rest_ensure_response( $token );
+	}
+
+}

--- a/includes/class-indieauth-metadata-endpoint.php
+++ b/includes/class-indieauth-metadata-endpoint.php
@@ -31,6 +31,8 @@ class IndieAuth_Metadata_Endpoint {
 			'authorization' => indieauth_get_authorization_endpoint(),
 			'token'         => indieauth_get_token_endpoint(),
 			'metadata'      => indieauth_get_metadata_endpoint(),
+			'revocation'    => rest_url( 'indieauth/1.0/revocation' ),
+			'introspection' => rest_url( 'indieauth/1.0/introspection' ),
 		);
 		$endpoints = array_filter( $endpoints );
 		if ( empty( $endpoints ) ) {
@@ -94,16 +96,24 @@ class IndieAuth_Metadata_Endpoint {
 		}
 
 		$metadata = array(
-			'issuer'                           => indieauth_get_issuer(),
-			'authorization_endpoint'           => indieauth_get_authorization_endpoint(),
-			'scopes_supported'                 => IndieAuth_Plugin::$scopes->get_names(),
-			'response_types_supported'         => array( 'code' ),
-			'grant_types_supported'            => $grants,
-			'service_documentation'            => 'https://indieauth.spec.indieweb.org',
-			'token_endpoint'                   => indieauth_get_token_endpoint(),
-			'code_challenge_methods_supported' => array( 'S256' ),
+			'issuer'                                     => indieauth_get_issuer(),
+			'authorization_endpoint'                     => indieauth_get_authorization_endpoint(),
+			'scopes_supported'                           => IndieAuth_Plugin::$scopes->get_names(),
+			'response_types_supported'                   => array( 'code' ),
+			'grant_types_supported'                      => $grants,
+			'service_documentation'                      => 'https://indieauth.spec.indieweb.org',
+			'token_endpoint'                             => indieauth_get_token_endpoint(),
+			'revocation_endpoint'                        => rest_url( '/indieauth/1.0/revocation' ),
+			'revocation_endpoint_auth_methods_supported' => array( 'none' ),
+			'introspection_endpoint'                     => rest_url( '/indieauth/1.0/introspection' ),
+			'introspection_endpoint_auth_methods_supported' => array( 'none' ),
+			'code_challenge_methods_supported'           => array( 'S256' ),
 			'authorization_response_iss_parameter_supported' => true,
 		);
+
+		if ( class_exists( 'IndieAuth_Ticket_Endpoint' ) ) {
+			$metadata['ticket_endpoint'] = rest_url( 'indieauth/1.0/ticket' );
+		}
 
 		$metadata = apply_filters( 'indieauth_metadata', $metadata );
 		return new WP_REST_Response(

--- a/includes/class-indieauth-revocation-endpoint.php
+++ b/includes/class-indieauth-revocation-endpoint.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Revocation Endpoint Functionality
+ */
+class IndieAuth_Revocation_Endpoint extends IndieAuth_Endpoint {
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the Route.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'indieauth/1.0',
+			'/revocation',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'revoke' ),
+					'args'                => array(
+						'token'           => array(
+							'required' => true,
+						),
+						'token_type_hint' => array(
+							'default' => 'all',
+						), // A hint about the type of the token submitted for revocation, options are access_token or refresh_token.
+					),
+					'permission_callback' => '__return_true',
+				),
+			)
+		);
+	}
+
+	/*
+	 * Revocation Endpoint request handler.
+	 *
+	 * @param WP_REST_Request $request The Request Object.
+	 * @return Response to Return to the REST Server.
+	 */
+
+	public function revoke( $request ) {
+		$params = $request->get_params();
+		$this->delete_token( $params['token'], $params['token_type_hint'] );
+		return new WP_REST_Response(
+			__( 'The Token Provided is No Longer Valid', 'indieauth' ),
+			200
+		);
+	}
+
+
+}

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -184,7 +184,7 @@ class IndieAuth_Token_Endpoint extends IndieAuth_Endpoint {
 		if ( ! empty( $diff ) ) {
 			return new WP_OAuth_Response( 'invalid_request', __( 'The request is missing one or more required parameters', 'indieauth' ), 400 );
 		}
-		$args                  = array_filter(
+		$args     = array_filter(
 			array(
 				'code'          => $params['code'],
 				'redirect_uri'  => $params['redirect_uri'],
@@ -192,7 +192,7 @@ class IndieAuth_Token_Endpoint extends IndieAuth_Endpoint {
 				'code_verifier' => isset( $params['code_verifier'] ) ? $params['code_verifier'] : null,
 			)
 		);
-		$response              = indieauth_verify_local_authorization_code( $args );
+		$response = indieauth_verify_local_authorization_code( $args );
 
 		$error = get_oauth_error( $response );
 		if ( $error ) {
@@ -248,7 +248,7 @@ class IndieAuth_Token_Endpoint extends IndieAuth_Endpoint {
 
 				// Do Not Add Expires In for the Return Until After It is Saved to the Database
 				if ( 0 !== $expires ) {
-					$return['expires_in'] = $expires;
+					$return['expires_in']    = $expires;
 					$return['refresh_token'] = $this->set_refresh_token( $return, $response['user'] );
 				}
 			}

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -5,29 +5,11 @@
  * Implements IndieAuth Token Endpoint
  */
 
-class IndieAuth_Token_Endpoint {
-	private $tokens;
-	private $refresh_tokens;
+class IndieAuth_Token_Endpoint extends IndieAuth_Endpoint {
+
 	public function __construct() {
-		$this->tokens         = new Token_User( '_indieauth_token_' );
-		$this->refresh_tokens = new Token_User( '_indieauth_refresh_' );
-
+		parent::__construct();
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
-	}
-
-
-	/**
-	 * Extracts the token from the given authorization header.
-	 *
-	 * @param string $header Authorization header.
-	 *
-	 * @return string|null Token on success, null on failure.
-	 */
-	public function get_token_from_bearer_header( $header ) {
-		if ( is_string( $header ) && preg_match( '/Bearer ([\x20-\x7E]+)/', trim( $header ), $matches ) ) {
-			return $matches[1];
-		}
-		return null;
 	}
 
 	/**
@@ -86,10 +68,6 @@ class IndieAuth_Token_Endpoint {
 		);
 	}
 
-	public function get_token( $token, $hash = true ) {
-		return $this->tokens->get( $token, $hash );
-	}
-
 	/*
 	 * Token Endpoint GET Handler.
 	 *
@@ -120,54 +98,6 @@ class IndieAuth_Token_Endpoint {
 		}
 		$token['active'] = 'true';
 		return rest_ensure_response( $token );
-	}
-
-	public function set_token( $token, $expiration = null, $user_id = null ) {
-		if ( ! isset( $token['me'] ) ) {
-			return false;
-		}
-		if ( ! $user_id ) {
-			$user_id = get_user_by_identifier( $token['me'] );
-			if ( $user instanceof WP_User ) {
-				$user_id = $user_id->ID;
-			} else {
-				return false;
-			}
-		}
-
-		$this->tokens->set_user( $user_id );
-
-		return $this->tokens->set( $token, $expiration );
-	}
-
-	/*
-	 * Sets a refresh token based on an access token.
-	 * @param array $token Access Token Return.
-	 * @param int $user User ID.
-	 * @return string Refresh Token.
-	 */
-	public function set_refresh_token( $token, $user ) {
-		$refresh = array(
-			'scope'     => $token['scope'],
-			'client_id' => $token['client_id'],
-			'iat'       => time(),
-			'me'        => $token['me'],
-			'uuid'      => $token['uuid'], // Uses the token UUID from the access token and adds it to the refresh token allowing them to be associated.
-		);
-		$this->refresh_tokens->set_user( $user );
-		$expires_in = array_key_exists( 'expires_in', $token ) ? $token['expires_in'] : null;
-
-		return $this->refresh_tokens->set( $refresh, $expires_in + 300 );
-	}
-
-	public function delete_refresh_token( $id, $user_id = null ) {
-		$this->refresh_tokens->set_user( $user_id );
-		return $this->refresh_tokens->destroy( $id );
-	}
-
-	public function delete_token( $id, $user_id = null ) {
-		$this->tokens->set_user( $user_id );
-		return $this->tokens->destroy( $id );
 	}
 
 	/*

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -143,17 +143,6 @@ class IndieAuth_Token_Endpoint extends IndieAuth_Endpoint {
 			}
 		}
 
-		// If there is no action or grant_type, that means this is a token introspection request.
-		if ( isset( $params['token'] ) ) {
-			$token = $this->get_token( $params['token'] );
-			if ( $token ) {
-				$token['active'] = 'true';
-				return rest_ensure_response( $token );
-			} else {
-				return rest_ensure_response( array( 'active' => 'false' ) );
-			}
-		}
-
 		// Everything Failed
 		return new WP_OAuth_Response( 'invalid_request', __( 'Invalid Request', 'indieauth' ), 400 );
 	}

--- a/includes/class-indieauth-userinfo-endpoint.php
+++ b/includes/class-indieauth-userinfo-endpoint.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * User Info Endpoint Functionality
+ */
+class IndieAuth_Userinfo_Endpoint extends IndieAuth_Endpoint {
+
+	public function __construct() {
+		parent::__construct();
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register the Route.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			'indieauth/1.0',
+			'/userinfo',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'userinfo' ),
+					'args'                => array(),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+			)
+		);
+	}
+
+
+	/*
+	 * User Info Endpoint request handler.
+	 *
+	 * @param WP_REST_Request $request The Request Object.
+	 * @return Response to Return to the REST Server.
+	 */
+	public function userinfo( $request ) {
+		if ( ! indieauth_check_scope( 'profile' ) ) {
+			return new WP_OAuth_Response(
+				'insufficient_scope',
+				__(
+					'Bearer Token does not have profile scope',
+					'indieauth'
+				),
+				403
+			);
+		}
+
+		return indieauth_get_user( wp_get_current_user(), indieauth_check_scope( 'email' ) );
+	}
+
+}

--- a/includes/class-oauth-response.php
+++ b/includes/class-oauth-response.php
@@ -10,7 +10,7 @@ class WP_OAuth_Response extends WP_REST_Response {
 				'error_description' => $error_description,
 			)
 		);
-		if ( is_array( $debug ) ) {
+		if ( is_array( $debug ) && ! empty( $debug ) ) {
 			$this->set_debug( $debug );
 		}
 		if ( WP_DEBUG ) {
@@ -24,11 +24,15 @@ class WP_OAuth_Response extends WP_REST_Response {
 	}
 
 	public function to_wp_error() {
-		$data   = $this->get_data();
+		$data              = $this->get_data();
+		$error             = $data['error'];
+		$error_description = $data['error_description'];
+		unset( $data['error'] );
+		unset( $data['error_description'] );
 		$status = $this->get_status();
 		return new WP_Error(
-			$data['error'],
-			$data['error_description'],
+			$error,
+			$error_description,
 			array(
 				'status' => $status,
 				'data'   => $data,

--- a/indieauth.php
+++ b/indieauth.php
@@ -118,6 +118,9 @@ class IndieAuth_Plugin {
 			'class-indieauth-token-endpoint.php', // Token Endpoint
 			'class-indieauth-authorization-endpoint.php', // Authorization Endpoint
 			'class-indieauth-metadata-endpoint.php', // Metadata Endpoint
+			'class-indieauth-revocation-endpoint.php', // Revocation Endpoint
+			'class-indieauth-introspection-endpoint.php', // Introspection Endpoint
+			'class-indieauth-userinfo-endpoint.php', // User Info Endpoint
 			'class-token-list-table.php', // Token Management UI
 			'class-indieauth-token-ui.php',
 			'class-indieauth-local-authorize.php',
@@ -142,6 +145,9 @@ class IndieAuth_Plugin {
 				new IndieAuth_Token_Endpoint();
 				static::$indieauth = new IndieAuth_Local_Authorize();
 				static::$metadata  = new IndieAuth_Metadata_Endpoint();
+				new IndieAuth_Revocation_Endpoint();
+				new IndieAuth_Introspection_Endpoint();
+				new IndieAuth_Userinfo_Endpoint();
 				break;
 		}
 

--- a/indieauth.php
+++ b/indieauth.php
@@ -114,6 +114,7 @@ class IndieAuth_Plugin {
 		$localfiles = array(
 			'class-indieauth-client-discovery.php', // Client Discovery
 			'class-token-user.php',
+			'class-indieauth-endpoint.php', // Endpoint Base Class
 			'class-indieauth-token-endpoint.php', // Token Endpoint
 			'class-indieauth-authorization-endpoint.php', // Authorization Endpoint
 			'class-indieauth-metadata-endpoint.php', // Metadata Endpoint

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 4.1.1\n"
+"Project-Id-Version: IndieAuth 4.2.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2021-10-07 17:19:26+00:00\n"
+"POT-Creation-Date: 2021-12-02 14:38:26+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -345,7 +345,7 @@ msgid ""
 "client_id and redirect_uri match the original request."
 msgstr ""
 
-#: includes/class-indieauth-authorize.php:183
+#: includes/class-indieauth-authorize.php:178
 msgid "User Not Found on this Site"
 msgstr ""
 
@@ -390,7 +390,8 @@ msgid "These settings control the behavior of the endpoints"
 msgstr ""
 
 #: includes/class-indieauth-local-authorize.php:95
-#: includes/class-indieauth-token-endpoint.php:119
+#: includes/class-indieauth-token-endpoint.php:97
+#: includes/class-indieauth-userinfo-endpoint.php:57
 msgid "Invalid access token"
 msgstr ""
 
@@ -416,6 +417,11 @@ msgstr ""
 
 #: includes/class-indieauth-remote-authorize.php:163
 msgid "Supplied Token is Invalid"
+msgstr ""
+
+#: includes/class-indieauth-revocation-endpoint.php:47
+#: includes/class-indieauth-token-endpoint.php:124
+msgid "The Token Provided is No Longer Valid"
 msgstr ""
 
 #: includes/class-indieauth-scopes.php:45
@@ -470,7 +476,7 @@ msgid "Your Ticket Has Been Redeemed. Thank you for your trust!"
 msgstr ""
 
 #: includes/class-indieauth-ticket-endpoint.php:116
-#: includes/class-indieauth-token-endpoint.php:228
+#: includes/class-indieauth-token-endpoint.php:147
 msgid "Invalid Request"
 msgstr ""
 
@@ -490,43 +496,40 @@ msgstr ""
 msgid "Unable to Redeem Ticket for Unknown Reasons."
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:109
+#: includes/class-indieauth-token-endpoint.php:87
+#: includes/class-indieauth-userinfo-endpoint.php:47
 msgid ""
 "Bearer Token Not Supplied or Server Misconfigured to Not Pass Token. Run "
 "diagnostic script in WordPress Admin\n"
 "\t\t\t\tIndieAuth Settings Page"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:184
+#: includes/class-indieauth-token-endpoint.php:114
 msgid "Please choose either an action or a grant_type"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:194
-msgid "The Token Provided is No Longer Valid"
-msgstr ""
-
-#: includes/class-indieauth-token-endpoint.php:196
+#: includes/class-indieauth-token-endpoint.php:126
 msgid "Revoke is Missing Required Parameter token"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:199
+#: includes/class-indieauth-token-endpoint.php:129
 msgid "Unsupported Action"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:212
+#: includes/class-indieauth-token-endpoint.php:142
 msgid "Unsupported grant_type."
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:237
-#: includes/class-indieauth-token-endpoint.php:255
+#: includes/class-indieauth-token-endpoint.php:156
+#: includes/class-indieauth-token-endpoint.php:174
 msgid "The request is missing one or more required parameters"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:241
+#: includes/class-indieauth-token-endpoint.php:160
 msgid "Invalid Token"
 msgstr ""
 
-#: includes/class-indieauth-token-endpoint.php:349
+#: includes/class-indieauth-token-endpoint.php:268
 msgid "There was an error in response."
 msgstr ""
 
@@ -575,6 +578,10 @@ msgstr ""
 
 #: includes/class-indieauth-token-ui.php:131
 msgid "Add New Token"
+msgstr ""
+
+#: includes/class-indieauth-userinfo-endpoint.php:63
+msgid "Bearer Token does not have profile scope"
 msgstr ""
 
 #: includes/class-token-list-table.php:11
@@ -682,7 +689,7 @@ msgstr ""
 msgid "Invalid User Profile URL"
 msgstr ""
 
-#: indieauth.php:175
+#: indieauth.php:188
 #. translators: 1. Path to file unable to load
 msgid "Unable to load: %1s"
 msgstr ""

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ Since the extension is developing, there is currently not a specified way to tra
 
 - 4.2.0 =
 
-Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard to take advantage of the latest opportunities.
+Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard to take advantage of the latest opportunities. Old methods will remain until adoption of the metadata endpoint is sufficient.
 
 ### 4.1.0 ###
 
@@ -181,6 +181,9 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 
 * Add Server Metadata Endpoint
 * Add Issuer Property to Authorization Response
+* In 4.1.0, introspection endpoint was introduced and shared an endpoint with the token endpoint. This approach was abandoned with the metadata endpoint and the introspection endpoint no longer shares. As this was only in for a short time deprecation is immediate.
+* Revocation endpoint added. Old revocation method will remain until metadata endpoint adoption is sufficient.
+* User Info Endpoint added. This returns the user profile offered during the authorization flow.
 
 ### 4.1.1 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -145,7 +145,7 @@ Since the extension is developing, there is currently not a specified way to tra
 
 - 4.2.0 =
 
-Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard to take advantage of the latest opportunities.
+Changes in the 4.2.0 branch implement future breaking changes to IndieAuth. Backward compatibility will be maintained for the foreseeable future, but clients are advised to update to the latest version of the standard to take advantage of the latest opportunities. Old methods will remain until adoption of the metadata endpoint is sufficient.
 
 = 4.1.0 =
 
@@ -181,6 +181,9 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 
 * Add Server Metadata Endpoint
 * Add Issuer Property to Authorization Response
+* In 4.1.0, introspection endpoint was introduced and shared an endpoint with the token endpoint. This approach was abandoned with the metadata endpoint and the introspection endpoint no longer shares. As this was only in for a short time deprecation is immediate.
+* Revocation endpoint added. Old revocation method will remain until metadata endpoint adoption is sufficient.
+* User Info Endpoint added. This returns the user profile offered during the authorization flow.
 
 = 4.1.1 =
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,8 @@
  * @package Wordpress_Indieauth
  */
 
+define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', __DIR__ . '/../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php' );
+
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 define( 'INDIEAUTH_UNIT_TESTS', 1 );

--- a/tests/test-introspection-endpoint.php
+++ b/tests/test-introspection-endpoint.php
@@ -1,0 +1,113 @@
+<?php
+class IntrospectionEndpointTest extends WP_UnitTestCase {
+
+	protected static $author_id;
+	protected static $subscriber_id;
+
+
+	protected static $test_token = array(
+		'token_type' => 'Bearer',
+		'scope'      => 'create update media',
+		'issued_by'  => 'https://example.org/wp-json/indieauth/1.0/token',
+		'client_id'  => 'https://quill.p3k.io/',
+	        'uuid' => '5e97048d-460c-4fb8-af0e-74db61d4b419',
+		'iat'  => 1532569712,
+	);
+
+	protected static $refresh_token = array (
+	    'scope' => 'create update media',
+	    'client_id' => 'https://quill.p3k.io/',
+	    'uuid' => '5e97048d-460c-4fb8-af0e-74db61d4b419',
+	    'iat' => 1632019982,
+	 );
+
+
+	protected static $test_auth_code = array(
+		 'client_id' => 'https://app.example.com',
+		 'redirect_uri' => 'https://app.example.com/redirect',
+		 'scope' => 'create',
+	);
+
+	public function setUp() {
+		global $wp_rest_server;
+		$wp_rest_server = new Spy_REST_Server;
+		do_action( 'rest_api_init', $wp_rest_server );
+		parent::setUp();
+	}
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$author_id = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		static::$test_auth_code['me'] = get_author_posts_url( static::$author_id );
+		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$refresh_token['me'] = get_author_posts_url( static::$author_id );
+		static::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$author_id );
+		self::delete_user( self::$subscriber_id );
+	}
+
+	// Sets a test access token
+	public function set_access_token() {
+		$tokens    = new Token_User( '_indieauth_token_' );
+		$tokens->set_user( self::$author_id );
+		return $tokens->set( static::$test_token );
+	}
+
+	// Sets a test access token
+	public function set_refresh_token() {
+		$tokens    = new Token_User( '_indieauth_refresh_' );
+		$tokens->set_user( self::$author_id );
+		return $tokens->set( static::$refresh_token );
+	}
+
+	// Gets a test access token
+	public function get_access_token( $token ) {
+		$tokens    = new Token_User( '_indieauth_token_' );
+		return $tokens->get( $token );
+	}
+
+	// Gets a test refresh  token
+	public function get_refresh_token( $token ) {
+		$tokens    = new Token_User( '_indieauth_refresh_' );
+		return $tokens->get( $token );
+	}
+
+	// Form Encoded Request
+	public function create_form( $method, $params = array(), $headers = array() ) {
+		$request = new WP_REST_Request( $method, '/indieauth/1.0/introspection' );
+		$request->set_header( 'Content-Type', 'application/x-www-form-urlencoded' );
+		if ( ! empty( $params ) ) {
+			$request->set_body_params( $params );
+		}
+
+		if ( ! empty( $headers ) ) {
+			$request->set_headers( $headers );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	// Sets a token and verifies it using Access Token Introspection
+	public function test_token_introspection() {
+		$token   = self::set_access_token();
+		$response = $this->create_form( 'POST',
+				array( 
+					'token' => $token
+				)
+			);
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$response_token = $response->get_data();
+		unset( $response_token['user'] );
+		unset( $response_token['active'] );
+		$this->assertEquals( static::$test_token, $response_token );
+	}
+}

--- a/tests/test-revocation-endpoint.php
+++ b/tests/test-revocation-endpoint.php
@@ -1,0 +1,120 @@
+<?php
+class RevocationEndpointTest extends WP_UnitTestCase {
+
+	protected static $author_id;
+	protected static $subscriber_id;
+
+
+	protected static $test_token = array(
+		'token_type' => 'Bearer',
+		'scope'      => 'create update media',
+		'issued_by'  => 'https://example.org/wp-json/indieauth/1.0/token',
+		'client_id'  => 'https://quill.p3k.io/',
+	        'uuid' => '5e97048d-460c-4fb8-af0e-74db61d4b419',
+		'iat'  => 1532569712,
+	);
+
+	protected static $refresh_token = array (
+	    'scope' => 'create update media',
+	    'client_id' => 'https://quill.p3k.io/',
+	    'uuid' => '5e97048d-460c-4fb8-af0e-74db61d4b419',
+	    'iat' => 1632019982,
+	 );
+
+
+	protected static $test_auth_code = array(
+		 'client_id' => 'https://app.example.com',
+		 'redirect_uri' => 'https://app.example.com/redirect',
+		 'scope' => 'create',
+	);
+
+	public function setUp() {
+		global $wp_rest_server;
+		$wp_rest_server = new Spy_REST_Server;
+		do_action( 'rest_api_init', $wp_rest_server );
+		parent::setUp();
+	}
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$author_id = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		static::$test_auth_code['me'] = get_author_posts_url( static::$author_id );
+		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$refresh_token['me'] = get_author_posts_url( static::$author_id );
+		static::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$author_id );
+		self::delete_user( self::$subscriber_id );
+	}
+
+	// Sets a test access token
+	public function set_access_token() {
+		$tokens    = new Token_User( '_indieauth_token_' );
+		$tokens->set_user( self::$author_id );
+		return $tokens->set( static::$test_token );
+	}
+
+	// Sets a test access token
+	public function set_refresh_token() {
+		$tokens    = new Token_User( '_indieauth_refresh_' );
+		$tokens->set_user( self::$author_id );
+		return $tokens->set( static::$refresh_token );
+	}
+
+	// Gets a test access token
+	public function get_access_token( $token ) {
+		$tokens    = new Token_User( '_indieauth_token_' );
+		return $tokens->get( $token );
+	}
+
+	// Gets a test refresh  token
+	public function get_refresh_token( $token ) {
+		$tokens    = new Token_User( '_indieauth_refresh_' );
+		return $tokens->get( $token );
+	}
+
+	// Form Encoded Request
+	public function create_form( $method, $params = array(), $headers = array() ) {
+		$request = new WP_REST_Request( $method, '/indieauth/1.0/revocation' );
+		$request->set_header( 'Content-Type', 'application/x-www-form-urlencoded' );
+		if ( ! empty( $params ) ) {
+			$request->set_body_params( $params );
+		}
+
+		if ( ! empty( $headers ) ) {
+			$request->set_headers( $headers );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	// To Make Sure that Revokation Works, Test the Helper Function First.
+	public function test_test_get_access_token() {
+		$token   = self::set_access_token();
+		$check = self::get_access_token( $token );
+		unset( $check['user'] );
+		$this->assertEquals( static::$test_token, $check );
+	}
+
+	// Sets a token, revokes it, then verifies it is not there.
+	public function test_token_revokation() {
+		$token   = self::set_access_token();
+		$response = $this->create_form( 'POST', 
+			array( 
+				'token' => $token 
+			) 
+		);
+		$response_token = $response->get_data();
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$check = self::get_access_token( $token );
+		$this->assertFalse( $check, $check );
+	}
+}

--- a/tests/test-token-endpoint.php
+++ b/tests/test-token-endpoint.php
@@ -269,22 +269,6 @@ class TokenEndpointTest extends WP_UnitTestCase {
 		$this->assertEquals( static::$test_token, $response_token );
 	}
 
-	// Sets a token and verifies it using Access Token Introspection
-	public function test_token_introspection() {
-		$token   = self::set_access_token();
-		$response = $this->create_form( 'POST',
-				array( 
-					'token' => $token
-				)
-			);
-		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
-		$response_token = $response->get_data();
-		unset( $response_token['user'] );
-		unset( $response_token['active'] );
-		$this->assertEquals( static::$test_token, $response_token );
-	}
-
-
 	// To Make Sure that Revokation Works, Test the Helper Function First.
 	public function test_test_get_access_token() {
 		$token   = self::set_access_token();

--- a/tests/test-userinfo-endpoint.php
+++ b/tests/test-userinfo-endpoint.php
@@ -1,0 +1,93 @@
+<?php
+class UserInfoEndpointTest extends WP_UnitTestCase {
+
+	protected static $author_id;
+	protected static $subscriber_id;
+
+
+	protected static $test_token = array(
+		'token_type' => 'Bearer',
+		'scope'      => 'profile',
+		'issued_by'  => 'https://example.org/wp-json/indieauth/1.0/token',
+		'client_id'  => 'https://quill.p3k.io/',
+	        'uuid' => '5e97048d-460c-4fb8-af0e-74db61d4b419',
+		'iat'  => 1532569712,
+	);
+
+	public function setUp() {
+		global $wp_rest_server;
+		$wp_rest_server = new Spy_REST_Server;
+		do_action( 'rest_api_init', $wp_rest_server );
+		parent::setUp();
+	}
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$author_id = $factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$author_id );
+		self::delete_user( self::$subscriber_id );
+	}
+
+	// Sets a test access token
+	public function set_access_token() {
+		$tokens    = new Token_User( '_indieauth_token_' );
+		$tokens->set_user( self::$author_id );
+		return $tokens->set( static::$test_token );
+	}
+
+	// Gets a test access token
+	public function get_access_token( $token ) {
+		$tokens    = new Token_User( '_indieauth_token_' );
+		return $tokens->get( $token );
+	}
+
+	// Form Encoded Request
+	public function create_form( $method, $params = array(), $headers = array() ) {
+		$request = new WP_REST_Request( $method, '/indieauth/1.0/userinfo' );
+		$request->set_header( 'Content-Type', 'application/x-www-form-urlencoded' );
+		if ( ! empty( $params ) ) {
+			$request->set_body_params( $params );
+		}
+
+		if ( ! empty( $headers ) ) {
+			$request->set_headers( $headers );
+		}
+		return rest_get_server()->dispatch( $request );
+	}
+
+	// Test UserInfo Endpoint with no Token
+	public function test_userinfo_endpoint_with_no_token() {
+		$response = $this->create_form( 'GET' );
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+	}
+
+	// Test UserInfo Endpoint with Profile
+	public function test_userinfo_endpoint_with_profile() {
+		$token   = self::set_access_token();
+
+		$response = $this->create_form( 
+				'GET', 
+				array(), 
+				array(
+					'Authorization' => 'Bearer ' . $token
+				)
+			);
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response) );
+		$data = $response->get_data();
+		$this->assertEquals( indieauth_get_user( static::$author_id ), $data, 'Response: ' . wp_json_encode( $data ) );
+	}
+
+
+}


### PR DESCRIPTION
This, as a continuation of the previous PR, introduces a dedicated revocation, introspection, and userinfo endpoint. These all separate functions previously in the single endpoint, now that the metadata endpoint allows this without having to overload it. This is reflected in current PRs discussed at the last popup awaiting merge. The Metadata endpoint was already merged, which is why the introspection endpoint is being adjusted appropriately, as that was changed after this decision.

It keeps the built-in functionality for now, until there is more adoption.