### PR TITLE
Resolve Issue 237

### DIFF
--- a/includes/class-indieauth-metadata-endpoint.php
+++ b/includes/class-indieauth-metadata-endpoint.php
@@ -57,9 +57,6 @@ class IndieAuth_Metadata_Endpoint {
 				'rel'  => array(),
 			),
 		);
-		if ( empty( $auth ) || empty( $token ) ) {
-			return;
-		}
 		if ( is_author() || is_front_page() ) {
 			echo wp_kses( sprintf( '<link rel="indieauth-metadata" href="%s" />' . PHP_EOL, static::get_metadata_endpoint() ), $kses );
 		}

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 4.2.0
+ * Version: 4.2.1
  * Author: IndieWebCamp WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2021 IndieWebCamp WordPress Outreach Club
+# Copyright (C) 2022 IndieWebCamp WordPress Outreach Club
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 4.2.0\n"
+"Project-Id-Version: IndieAuth 4.2.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2021-12-02 14:38:26+00:00\n"
+"POT-Creation-Date: 2022-12-21 15:18:26+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2021-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2022-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 1.0.3\n"

--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,8 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.6  
-**Tested up to:** 5.8  
-**Stable tag:** 4.2.0  
+**Tested up to:** 6.1  
+**Stable tag:** 4.2.1  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -176,6 +176,10 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 4.2.1 ###
+* Fix issue with not loading User Token library with old remote endpoint code
+* Fix issue with not loading metadata endpoint when not logging in
 
 ### 4.2.0 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.6
-Tested up to: 5.8
-Stable tag: 4.2.0
+Tested up to: 6.1
+Stable tag: 4.2.1
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -176,6 +176,10 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 4.2.1 =
+* Fix issue with not loading User Token library with old remote endpoint code
+* Fix issue with not loading metadata endpoint when not logging in
 
 = 4.2.0 =
 


### PR DESCRIPTION
This resolves #237 and bumps the version to release for the last few minor fixes, and to show WordPress 6.1 support.