### PR TITLE
Allow other OAuth2 providers

### DIFF
--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -155,15 +155,16 @@ abstract class IndieAuth_Authorize {
 
 		$params = $this->verify_access_token( $token );
 		if ( ! isset( $params ) ) {
-			return 0;
+			return $user_id;
 		}
 		if ( is_oauth_error( $params ) ) {
-			$this->error = $params;
-			return 0;
+			return $user_id;
 		}
 		if ( is_array( $params ) ) {
-			// If this is a token auth response, add this constant.
-			define( 'INDIEAUTH_TOKEN', true );
+			// If this is a token auth response and not a test run, add this constant.
+			if ( ! function_exists( 'tests_add_filter' ) ) {
+				define( 'INDIEAUTH_TOKEN', true );
+			}
 
 			$this->response = $params;
 			$this->scopes   = explode( ' ', $params['scope'] );

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -158,6 +158,7 @@ abstract class IndieAuth_Authorize {
 			return $user_id;
 		}
 		if ( is_oauth_error( $params ) ) {
+			$this->error = $params;
 			return $user_id;
 		}
 		if ( is_array( $params ) ) {
@@ -182,7 +183,7 @@ abstract class IndieAuth_Authorize {
 				'response' => $me,
 			)
 		);
-		return 0;
+		return $user_id;
 
 	}
 

--- a/tests/test-authorize.php
+++ b/tests/test-authorize.php
@@ -65,7 +65,7 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$this->assertEquals( $user_id, self::$author_id );
 	}
 
-	public function test_authorize_bearer_other_non_matchign_provider() {
+	public function test_authorize_bearer_other_non_matching_provider() {
 		$token = self::set_token();
 		$self_author_id = self::$author_id;
 		add_filter( 'determine_current_user', function( $user_id ) use ( $self_author_id ) {
@@ -98,7 +98,7 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$this->assertEquals( $user_id, self::$author_id );
 	}
 
-	public function test_authorize_bearer_no_other_provider() {
+	public function test_authorize_bearer_no_valid_token_other_provider() {
 		$self_author_id = self::$author_id;
 		add_filter( 'determine_current_user', function( $user_id ) use ( $self_author_id ) {
 			if ( 'Bearer other-valid-token' === $_SERVER['HTTP_AUTHORIZATION'] ) {

--- a/tests/test-authorize.php
+++ b/tests/test-authorize.php
@@ -65,6 +65,23 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$this->assertEquals( $user_id, self::$author_id );
 	}
 
+	public function test_authorize_bearer_other_non_matchign_provider() {
+		$token = self::set_token();
+		$self_author_id = self::$author_id;
+		add_filter( 'determine_current_user', function( $user_id ) use ( $self_author_id ) {
+			if ( 'Bearer other-valid-token' === $_SERVER['HTTP_AUTHORIZATION'] ) {
+				return $self_author_id + 1;
+			}
+			return $user_id;
+		} );
+		$_REQUEST['micropub']       = 'endpoint';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+		$authorize = new Indieauth_Local_Authorize();
+		$authorize->load();
+		$user_id = apply_filters( 'determine_current_user', false );
+		$this->assertEquals( $user_id, self::$author_id );
+	}
+
 	public function test_authorize_bearer_other_provider() {
 		$self_author_id = self::$author_id;
 		add_filter( 'determine_current_user', function( $user_id ) use ( $self_author_id ) {

--- a/tests/test-authorize.php
+++ b/tests/test-authorize.php
@@ -81,6 +81,22 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$this->assertEquals( $user_id, self::$author_id );
 	}
 
+	public function test_authorize_bearer_no_other_provider() {
+		$self_author_id = self::$author_id;
+		add_filter( 'determine_current_user', function( $user_id ) use ( $self_author_id ) {
+			if ( 'Bearer other-valid-token' === $_SERVER['HTTP_AUTHORIZATION'] ) {
+				return $self_author_id;
+			}
+			return $user_id;
+		} );
+		$_REQUEST['micropub']       = 'endpoint';
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer other-invalid-token';
+		$authorize = new Indieauth_Local_Authorize();
+		$authorize->load();
+		$user_id = apply_filters( 'determine_current_user', false );
+		$this->assertFalse( $user_id );
+	}
+
 	// Tests map_meta_cap for standard permissions
 	public function test_publish_posts_with_scopes() {				
 		add_filter( 'indieauth_scopes', 


### PR DESCRIPTION
If there is another OAuth2 provider plugin installed, IndieAuth overrules it and doesn't give it a chance to authenticate the user. This is because the `determine_current_user` filter doesn't act as a filter but makes a definite decision by returning `0`. This changes that behavior and adds tests for it.