### PR TITLE
Fix deprecation notice

### DIFF
--- a/includes/class-indieauth-client-taxonomy.php
+++ b/includes/class-indieauth-client-taxonomy.php
@@ -118,7 +118,7 @@ final class IndieAuth_Client_Taxonomy {
 		// strip leading www, if any.
 		$host = preg_replace( '/^www\./', '', $host );
 		$path = wp_parse_url( $url, PHP_URL_PATH );
-		$path = str_replace( '/', '_', $title );
+		$path = str_replace( '/', '_', $path );
 		return sanitize_title( $host . $path );
 	}
 

--- a/includes/class-web-signin.php
+++ b/includes/class-web-signin.php
@@ -120,7 +120,7 @@ class Web_Signin {
 		if ( $user instanceof WP_User ) {
 			return $user;
 		}
-		$redirect_to = array_key_exists( 'redirect_to', $_REQUEST ) ? $_REQUEST['redirect_to'] : null;
+		$redirect_to = array_key_exists( 'redirect_to', $_REQUEST ) ? $_REQUEST['redirect_to'] : '';
 		$redirect_to = rawurldecode( $redirect_to );
 		$token       = new Token_Transient( 'indieauth_state' );
 		if ( array_key_exists( 'code', $_REQUEST ) && array_key_exists( 'state', $_REQUEST ) ) {


### PR DESCRIPTION
`rawurldecode()` does not or no longer (I'm on PHP 8.1 right now) accept `null` as a first param. As such, a deprecation warning occasionally pops up in WordPress' debug log (if it happens to be enabled, of course).

By setting it to an empty string instead, this is notice no longer appears.

Also, later on `wp_login_url( $redirect_to )` is run; I checked the [documentation for `wp_login_url()`](https://developer.wordpress.org/reference/functions/wp_login_url/) and found that the default value for its first argument is an empty string, and that it actually expects a _string_. I.e., I think a string is okay. :-)