### PR TITLE
Prevent returning 401 for other successful OAuth2 plugins

### DIFF
--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -90,7 +90,7 @@ class IndieAuth_Authorize {
 	 */
 	public function rest_authentication_errors( $error = null ) {
 		if ( is_user_logged_in() ) {
-			// Another OAuth plugin successfully authenticated.
+			// Another OAuth2 plugin successfully authenticated.
 			return null;
 		}
 

--- a/includes/class-indieauth-authorize.php
+++ b/includes/class-indieauth-authorize.php
@@ -89,6 +89,11 @@ class IndieAuth_Authorize {
 	 * @return WP_Error|null Error if one is set, otherwise null.
 	 */
 	public function rest_authentication_errors( $error = null ) {
+		if ( is_user_logged_in() ) {
+			// Another OAuth plugin successfully authenticated.
+			return null;
+		}
+
 		if ( ! empty( $error ) ) {
 			return $error;
 		}

--- a/tests/test-authorize.php
+++ b/tests/test-authorize.php
@@ -63,6 +63,8 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$authorize->load();
 		$user_id = apply_filters( 'determine_current_user', false );
 		$this->assertEquals( $user_id, self::$author_id );
+		wp_set_current_user( $user_id );
+		$this->assertNull( $authorize->rest_authentication_errors() );
 	}
 
 	public function test_authorize_bearer_other_non_matching_provider() {
@@ -80,6 +82,8 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$authorize->load();
 		$user_id = apply_filters( 'determine_current_user', false );
 		$this->assertEquals( $user_id, self::$author_id );
+		wp_set_current_user( $user_id );
+		$this->assertNull( $authorize->rest_authentication_errors() );
 	}
 
 	public function test_authorize_bearer_other_provider() {
@@ -96,6 +100,8 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$authorize->load();
 		$user_id = apply_filters( 'determine_current_user', false );
 		$this->assertEquals( $user_id, self::$author_id );
+		wp_set_current_user( $user_id );
+		$this->assertNull( $authorize->rest_authentication_errors() );
 	}
 
 	public function test_authorize_bearer_no_valid_token_other_provider() {
@@ -112,6 +118,7 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$authorize->load();
 		$user_id = apply_filters( 'determine_current_user', false );
 		$this->assertFalse( $user_id );
+		$this->assertTrue( is_wp_error( $authorize->rest_authentication_errors() ) );
 	}
 
 	// Tests map_meta_cap for standard permissions

--- a/tests/test-authorize.php
+++ b/tests/test-authorize.php
@@ -118,6 +118,7 @@ class AuthorizeTest extends WP_UnitTestCase {
 		$authorize->load();
 		$user_id = apply_filters( 'determine_current_user', false );
 		$this->assertFalse( $user_id );
+		wp_set_current_user( $user_id );
 		$this->assertTrue( is_wp_error( $authorize->rest_authentication_errors() ) );
 	}
 


### PR DESCRIPTION
Fixes https://github.com/akirk/enable-mastodon-apps/issues/43

IndieAuth interferes with the Enable Mastodon Apps plugin when it successfully authenticates the user. This is a follow up to #245 where we checked for a successful authentication but the REST response is still `{"error":"invalid_token","error_description":"Invalid access token"}` coming from the `rest_authentication_errors` hook.