### PR TITLE
Add preliminary support for json metadata client discovery

### DIFF
--- a/includes/class-indieauth-client-discovery.php
+++ b/includes/class-indieauth-client-discovery.php
@@ -8,6 +8,7 @@ class IndieAuth_Client_Discovery {
 	public $client_id   = '';
 	public $client_name = '';
 	public $client_icon = '';
+	public $client_uri = '';
 
 	public function __construct( $client_id ) {
 		$this->client_id = $client_id;
@@ -48,6 +49,7 @@ class IndieAuth_Client_Discovery {
 			'client_id'   => $this->client_id,
 			'client_name' => $this->client_name,
 			'client_icon' => $this->client_icon,
+			'client_uri'  => $this->client_uri,
 		);
 	}
 
@@ -93,6 +95,9 @@ class IndieAuth_Client_Discovery {
 			}
 			if ( array_key_exists( 'logo_uri', $this->json ) ) {
 				$this->client_icon = $this->json['logo_uri'];
+			}
+			if ( array_key_exists( 'client_uri', $this->json ) ) {
+				$this->client_uri = $this->json['client_uri'];
 			}
 		} elseif ( 'text/html' === $content_type ) {
 			$content     = wp_remote_retrieve_body( $response );

--- a/includes/class-indieauth-client-discovery.php
+++ b/includes/class-indieauth-client-discovery.php
@@ -8,7 +8,7 @@ class IndieAuth_Client_Discovery {
 	public $client_id   = '';
 	public $client_name = '';
 	public $client_icon = '';
-	public $client_uri = '';
+	public $client_uri  = '';
 
 	public function __construct( $client_id ) {
 		$this->client_id = $client_id;
@@ -83,6 +83,19 @@ class IndieAuth_Client_Discovery {
 		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
 		if ( 'application/json' === $content_type ) {
 			$this->json = json_decode( wp_remote_retrieve_body( $response ), true );
+			/**
+			 * Expected format is per the IndieAuth standard as revised 2024-06-23 to include a JSON Client Metadata File
+			 *
+			 * @param array $json {
+			 *      An array of metadata about a client
+			 *
+			 *      @type string $client_uri URL of a webpage providing information about the client.
+			 *      @type string $client_id The client identifier.
+			 *      @type string $client_name Human Readable Name of the Client. Optional.
+			 *      @type string $logo_uri URL that references a logo or icon for the client. Optional.
+			 *      @type array $redirect_uris An array of redirect URIs. Optional.
+			 *  }
+			 **/
 			if ( ! is_array( $this->json ) || empty( $this->json ) ) {
 					return new WP_Error( 'empty_json', __( 'Discovery Has Returned an Empty JSON Document', 'indieauth' ) );
 			}
@@ -151,7 +164,7 @@ class IndieAuth_Client_Discovery {
 	}
 
 	private function get_html( $input ) {
-		$xpath               = new DOMXPath( $input );
+		$xpath = new DOMXPath( $input );
 		if ( ! empty( $xpath ) ) {
 			$title = $xpath->query( '//title' );
 			if ( ! empty( $title ) ) {

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 4.4.2
+ * Version: 4.4.3
  * Author: IndieWeb WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -1,11 +1,10 @@
-# Copyright (C) 2024 IndieWebCamp WordPress Outreach Club
+# Copyright (C) 2024 IndieWeb WordPress Outreach Club
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 4.4.2\n"
-"Report-Msgid-Bugs-To: "
-"https://wordpress.org/support/plugin/wordpress-indieauth\n"
-"POT-Creation-Date: 2024-01-12 20:14:40+00:00\n"
+"Project-Id-Version: IndieAuth 4.4.3\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
+"POT-Creation-Date: 2024-06-17 21:55:46+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -376,11 +375,11 @@ msgstr ""
 msgid "Invalid access token"
 msgstr ""
 
-#: includes/class-indieauth-client-discovery.php:33
+#: includes/class-indieauth-client-discovery.php:34
 msgid "Failed to Retrieve IndieAuth Client Details "
 msgstr ""
 
-#: includes/class-indieauth-client-discovery.php:63
+#: includes/class-indieauth-client-discovery.php:64
 msgid "Failed to Retrieve Client Details"
 msgstr ""
 
@@ -900,7 +899,7 @@ msgid ""
 msgstr ""
 
 #. Author of the plugin/theme
-msgid "IndieWebCamp WordPress Outreach Club"
+msgid "IndieWeb WordPress Outreach Club"
 msgstr ""
 
 #. Author URI of the plugin/theme

--- a/readme.md
+++ b/readme.md
@@ -3,8 +3,8 @@
 **Tags:** IndieAuth, IndieWeb, IndieWebCamp, login  
 **Requires at least:** 4.9.9  
 **Requires PHP:** 5.6  
-**Tested up to:** 6.4  
-**Stable tag:** 4.4.2  
+**Tested up to:** 6.5  
+**Stable tag:** 4.4.3  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: indieweb, pfefferle, dshanske
 Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 5.6
-Tested up to: 6.4
-Stable tag: 4.4.2
+Tested up to: 6.5
+Stable tag: 4.4.3
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb


### PR DESCRIPTION
#267 per request, basic support for the client ID being a JSON file using the properties identified.

@aaronpk This should work based on the notes.

If this gets adopted into the spec, I'll probably cut the unsupported manifest side file code, as that proposal never took off, and simplify for JSON with a HTML MF2 fallback.