### PR TITLE
Remove discovery on each load if Client is Already Cached

### DIFF
--- a/includes/class-indieauth-authorization-endpoint.php
+++ b/includes/class-indieauth-authorization-endpoint.php
@@ -425,7 +425,7 @@ class IndieAuth_Authorization_Endpoint extends IndieAuth_Endpoint {
 		$current_user = wp_get_current_user();
 		// phpcs:disable
 		$client_id     = esc_url_raw( wp_unslash( $_GET['client_id'] ) ); // WPCS: CSRF OK
-		$client_term                 = IndieAuth_Client_Taxonomy::add_client_with_discovery( $client_id );
+		$client_term                 = IndieAuth_Client_Taxonomy::add_client( $client_id );
 		if ( ! is_wp_error( $client_term ) ) {
 			$client_name = $client_term['name'];
 			$client_icon = $client_term['icon'];

--- a/includes/class-indieauth-client-discovery.php
+++ b/includes/class-indieauth-client-discovery.php
@@ -186,6 +186,10 @@ class IndieAuth_Client_Discovery {
 		return $this->client_name;
 	}
 
+	public function get_uri() {
+		return $this->client_uri;
+	}
+
 	// Separate function for possible improved size picking later
 	private function determine_icon( $input ) {
 		if ( ! is_array( $input ) || empty( $input ) ) {

--- a/includes/class-indieauth-client-discovery.php
+++ b/includes/class-indieauth-client-discovery.php
@@ -32,8 +32,9 @@ class IndieAuth_Client_Discovery {
 		if ( 'localhost' === wp_parse_url( $client_id, PHP_URL_HOST ) ) {
 			return;
 		}
-
+		error_log( 'Pre-Parse' );
 		$response = self::parse( $client_id );
+		error_log( 'Post-Parse' );
 		if ( is_wp_error( $response ) ) {
 			error_log( __( 'Failed to Retrieve IndieAuth Client Details ', 'indieauth' ) . wp_json_encode( $response ) ); // phpcs:ignore
 			return;
@@ -113,15 +114,8 @@ class IndieAuth_Client_Discovery {
 				$this->client_uri = $this->json['client_uri'];
 			}
 		} elseif ( 'text/html' === $content_type ) {
-			$content     = wp_remote_retrieve_body( $response );
-			$domdocument = new DOMDocument();
-			libxml_use_internal_errors( true );
-			if ( function_exists( 'mb_convert_encoding' ) ) {
-				$content = mb_convert_encoding( $content, 'HTML-ENTITIES', mb_detect_encoding( $content ) );
-			}
-			$domdocument->loadHTML( $content );
-			libxml_use_internal_errors( false );
-			$this->get_mf2( $domdocument, $url );
+			$content = wp_remote_retrieve_body( $response );
+			$this->get_mf2( $content, $url );
 			if ( ! empty( $this->mf2 ) ) {
 				if ( array_key_exists( 'name', $this->mf2 ) ) {
 					$this->client_name = $this->mf2['name'][0];

--- a/includes/class-indieauth-client-taxonomy.php
+++ b/includes/class-indieauth-client-taxonomy.php
@@ -215,6 +215,7 @@ final class IndieAuth_Client_Taxonomy {
 					'name'          => $term->name,
 					'id'            => $term->term_id,
 					'icon'          => get_term_meta( $term->term_id, 'icon', true ),
+					'uri'          => get_term_meta( $term->term_id, 'client_uri', true ),
 					'last_modified' => get_term_meta( $term->term_id, 'last_modified', true ),
 				);
 			}
@@ -248,6 +249,7 @@ final class IndieAuth_Client_Taxonomy {
 			'name'          => $term->name,
 			'id'            => $term->term_id,
 			'icon'          => get_term_meta( $term->term_id, 'icon', true ),
+			'uri'          => get_term_meta( $term->term_id, 'client_uri', true ),
 			'last_modified' => get_term_meta( $term->term_id, 'last_modified', true ),
 		);
 	}

--- a/includes/class-indieauth-client-taxonomy.php
+++ b/includes/class-indieauth-client-taxonomy.php
@@ -53,9 +53,9 @@ final class IndieAuth_Client_Taxonomy {
 			'public'             => true,
 			'publicly_queryable' => true,
 			'hierarchical'       => false,
-			'show_ui'            => false,
+			'show_ui'            => true,
 			'show_in_menu'       => false,
-			'show_in_nav_menus'  => true,
+			'show_in_nav_menus'  => false,
 			'show_in_rest'       => false,
 			'show_tagcloud'      => false,
 			'show_in_quick_edit' => false,
@@ -79,14 +79,17 @@ final class IndieAuth_Client_Taxonomy {
 				'show_in_rest'      => true,
 			)
 		);
-	}
-
-	/**
-	 * Add Client from Discovery
-	 */
-	public static function add_client_with_discovery( $url ) {
-		$client = new IndieAuth_Client_Discovery( $url );
-		return self::add_client( $url, $client->get_name(), $client->get_icon() );
+		register_meta(
+			'term',
+			'last_modified',
+			array(
+				'object_subtype' => 'indieauth_client',
+				'type'           => 'integer',
+				'description'    => __( 'Last Modified Client Timestamp', 'indieauth' ),
+				'single'         => true,
+				'show_in_rest'   => true,
+			)
+		);
 	}
 
 	/**
@@ -157,6 +160,7 @@ final class IndieAuth_Client_Taxonomy {
 			return $term;
 		}
 		add_term_meta( $term['term_id'], 'icon', $icon );
+		add_term_meta( $term['term_id'], 'last_modified', time() );
 		return array_filter(
 			array(
 				'url'  => $url,
@@ -182,10 +186,11 @@ final class IndieAuth_Client_Taxonomy {
 			$clients = array();
 			foreach ( $terms as $term ) {
 				$clients[] = array(
-					'url'  => $term->description,
-					'name' => $term->name,
-					'id'   => $term->term_id,
-					'icon' => get_term_meta( $term->term_id, 'icon', true ),
+					'url'           => $term->description,
+					'name'          => $term->name,
+					'id'            => $term->term_id,
+					'icon'          => get_term_meta( $term->term_id, 'icon', true ),
+					'last_modified' => get_term_meta( $term->term_id, 'last_modified', true ),
 				);
 			}
 			return $clients;
@@ -214,10 +219,11 @@ final class IndieAuth_Client_Taxonomy {
 		$term = $terms[0];
 
 		return array(
-			'url'  => $term->description,
-			'name' => $term->name,
-			'id'   => $term->term_id,
-			'icon' => get_term_meta( $term->term_id, 'icon', true ),
+			'url'           => $term->description,
+			'name'          => $term->name,
+			'id'            => $term->term_id,
+			'icon'          => get_term_meta( $term->term_id, 'icon', true ),
+			'last_modified' => get_term_meta( $term->term_id, 'last_modified', true ),
 		);
 	}
 

--- a/includes/class-indieauth-client-taxonomy.php
+++ b/includes/class-indieauth-client-taxonomy.php
@@ -81,6 +81,18 @@ final class IndieAuth_Client_Taxonomy {
 		);
 		register_meta(
 			'term',
+			'client_uri',
+			array(
+				'object_subtype'    => 'indieauth_client',
+				'type'              => 'string',
+				'description'       => __( 'IndieAuth Client Application URI', 'indieauth' ),
+				'single'            => true,
+				'sanitize_callback' => 'esc_url_raw',
+				'show_in_rest'      => true,
+			)
+		);
+		register_meta(
+			'term',
 			'last_modified',
 			array(
 				'object_subtype' => 'indieauth_client',
@@ -136,6 +148,8 @@ final class IndieAuth_Client_Taxonomy {
 			return $exists;
 		}
 
+		$client_uri = '';
+
 		if ( empty( $name ) ) {
 			$client = new IndieAuth_Client_Discovery( $url );
 			if ( defined( 'INDIEAUTH_UNIT_TESTS' ) ) {
@@ -143,8 +157,9 @@ final class IndieAuth_Client_Taxonomy {
 					'client_id' => $url,
 				);
 			}
-			$name = $client->get_name();
-			$icon = $client->get_icon();
+			$name       = $client->get_name();
+			$icon       = $client->get_icon();
+			$client_uri = $client->get_uri();
 			if ( empty( $name ) ) {
 				$name = self::generate_slug( $url );
 			}
@@ -163,7 +178,13 @@ final class IndieAuth_Client_Taxonomy {
 		if ( is_wp_error( $term ) ) {
 			return $term;
 		}
-		add_term_meta( $term['term_id'], 'icon', $icon );
+		if ( ! empty( $icon ) ) {
+			add_term_meta( $term['term_id'], 'icon', $icon );
+		}
+		if ( ! empty( $client_uri ) ) {
+			add_term_meta( $term['term_id'], 'client_uri', $client_uri );
+		}
+
 		add_term_meta( $term['term_id'], 'last_modified', time() );
 		return array_filter(
 			array(

--- a/includes/class-indieauth-client-taxonomy.php
+++ b/includes/class-indieauth-client-taxonomy.php
@@ -143,7 +143,11 @@ final class IndieAuth_Client_Taxonomy {
 					'client_id' => $url,
 				);
 			}
-			return self::add_client( $url, $client->get_name(), $client->get_icon() );
+			$name = $client->get_name();
+			$icon = $client->get_icon();
+			if ( empty( $name ) ) {
+				$name = self::generate_slug( $url );
+			}
 		}
 
 		$icon = self::sideload_icon( $icon, $url );

--- a/includes/class-indieauth-token-endpoint.php
+++ b/includes/class-indieauth-token-endpoint.php
@@ -258,7 +258,7 @@ class IndieAuth_Token_Endpoint extends IndieAuth_Endpoint {
 
 			// Issue a token
 			if ( ! empty( $scopes ) ) {
-				$client = IndieAuth_Client_Taxonomy::add_client_with_discovery( $response['client_id'] );
+				$client = IndieAuth_Client_Taxonomy::add_client( $response['client_id'] );
 				if ( is_wp_error( $client ) ) {
 					$client = array( 'id' => $client->get_error_message() );
 				}

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 4.5.1
+ * Version: 4.5.2
  * Author: IndieWeb WordPress Outreach Club
  * Author URI: https://indieweb.org/WordPress_Outreach_Club
  * License: MIT

--- a/languages/indieauth.pot
+++ b/languages/indieauth.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: IndieAuth 4.5.1\n"
+"Project-Id-Version: IndieAuth 4.5.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/indieauth\n"
-"POT-Creation-Date: 2024-08-14 00:32:52+00:00\n"
+"POT-Creation-Date: 2024-08-26 02:02:31+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -375,19 +375,19 @@ msgstr ""
 msgid "Invalid access token"
 msgstr ""
 
-#: includes/class-indieauth-client-discovery.php:38
+#: includes/class-indieauth-client-discovery.php:39
 msgid "Failed to Retrieve IndieAuth Client Details "
 msgstr ""
 
-#: includes/class-indieauth-client-discovery.php:69
+#: includes/class-indieauth-client-discovery.php:70
 msgid "Failed to Retrieve Client Details"
 msgstr ""
 
-#: includes/class-indieauth-client-discovery.php:100
+#: includes/class-indieauth-client-discovery.php:101
 msgid "Discovery Has Returned an Empty JSON Document"
 msgstr ""
 
-#: includes/class-indieauth-client-discovery.php:103
+#: includes/class-indieauth-client-discovery.php:104
 msgid "No Client ID Found in JSON Client Metadata"
 msgstr ""
 
@@ -399,11 +399,19 @@ msgstr ""
 msgid "IndieAuth Client Application Icon"
 msgstr ""
 
-#: includes/class-indieauth-client-taxonomy.php:207
+#: includes/class-indieauth-client-taxonomy.php:88
+msgid "IndieAuth Client Application URI"
+msgstr ""
+
+#: includes/class-indieauth-client-taxonomy.php:100
+msgid "Last Modified Client Timestamp"
+msgstr ""
+
+#: includes/class-indieauth-client-taxonomy.php:238
 msgid "No Term Found"
 msgstr ""
 
-#: includes/class-indieauth-client-taxonomy.php:211
+#: includes/class-indieauth-client-taxonomy.php:242
 msgid "Multiple Terms Found"
 msgstr ""
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.9.9  
 **Requires PHP:** 7.2  
 **Tested up to:** 6.6  
-**Stable tag:** 4.5.1  
+**Stable tag:** 4.5.2  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 **Donate link:** https://opencollective.com/indieweb  
@@ -188,6 +188,10 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog ##
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 4.5.2 ###
+* Fix issue with loop on adding new clients
+* Store client_uri and last modified date for new clients.
 
 ### 4.5.1 ###
 * Fix issue with failure if logo_uri is not a URL

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: IndieAuth, IndieWeb, IndieWebCamp, login
 Requires at least: 4.9.9
 Requires PHP: 7.2
 Tested up to: 6.6
-Stable tag: 4.5.1
+Stable tag: 4.5.2
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 Donate link: https://opencollective.com/indieweb
@@ -188,6 +188,10 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 == Changelog ==
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+= 4.5.2 =
+* Fix issue with loop on adding new clients
+* Store client_uri and last modified date for new clients.
 
 = 4.5.1 =
 * Fix issue with failure if logo_uri is not a URL


### PR DESCRIPTION
This removes the discovery on each client load, instead only doing it initially for each unique client ID. However, it starts storing a new meta key called last_modified, which can be used in the future to opt to refresh after a certain period of time. Right now, only manual refreshing is allowed.

Also fixes a loop in the discovery process.