### PR TITLE
SUB claim for Pure OAuth client Compatibility

### DIFF
--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -190,6 +190,7 @@ class Token_User extends Token_Generic {
 		}
 
 		$value['user'] = $user_id;
+		$value['sub'] = $value['me'];
 		return $value;
 	}
 

--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -190,7 +190,9 @@ class Token_User extends Token_Generic {
 		}
 
 		$value['user'] = $user_id;
-		$value['sub'] = $value['me'];
+		if ( isset( $value['me'] ) ) {
+			$value['sub'] = $value['me'];
+		}
 		return $value;
 	}
 

--- a/tests/test-introspection-endpoint.php
+++ b/tests/test-introspection-endpoint.php
@@ -43,6 +43,7 @@ class IntrospectionEndpointTest extends WP_UnitTestCase {
 		);
 		static::$test_auth_code['me'] = get_author_posts_url( static::$author_id );
 		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$test_token['sub'] = static::$test_token['me'];
 		static::$refresh_token['me'] = get_author_posts_url( static::$author_id );
 		static::$subscriber_id = $factory->user->create(
 			array(

--- a/tests/test-revocation-endpoint.php
+++ b/tests/test-revocation-endpoint.php
@@ -43,6 +43,7 @@ class RevocationEndpointTest extends WP_UnitTestCase {
 		);
 		static::$test_auth_code['me'] = get_author_posts_url( static::$author_id );
 		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$test_token['sub'] = static::$test_token['me'];
 		static::$refresh_token['me'] = get_author_posts_url( static::$author_id );
 		static::$subscriber_id = $factory->user->create(
 			array(

--- a/tests/test-token-endpoint.php
+++ b/tests/test-token-endpoint.php
@@ -43,6 +43,7 @@ class TokenEndpointTest extends WP_UnitTestCase {
 		);
 		static::$test_auth_code['me'] = get_author_posts_url( static::$author_id );
 		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$test_token['sub'] = static::$test_token['me'];
 		static::$refresh_token['me'] = get_author_posts_url( static::$author_id );
 		static::$subscriber_id = $factory->user->create(
 			array(

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -4,7 +4,7 @@ class TokensTest extends WP_UnitTestCase {
 	public function test_set_and_get_user_token() {
 		$user_id = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id );
-		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com' );
 		$key = $tokens->set( $token );
 		$get = $tokens->get( $key );
 		unset( $get['user'] );
@@ -15,7 +15,7 @@ class TokensTest extends WP_UnitTestCase {
 		$user_id_1 = self::factory()->user->create();
 		$user_id_2 = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id_1 );
-		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com' );
 		$tokens->set( $token );
 		$tokens->set_user( $user_id_2 );
 		$key = $tokens->set( $token );
@@ -27,7 +27,7 @@ class TokensTest extends WP_UnitTestCase {
 		$user_id_1 = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id_1 );
 		$uuid = wp_generate_uuid4();
-		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'uuid' => $uuid );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com', 'uuid' => $uuid );
 		$access_token = $tokens->set( $token );
 		$return = $tokens->find_by_field( 'uuid', $uuid, $user_id_1 );
 		$first = reset( $return );
@@ -39,7 +39,7 @@ class TokensTest extends WP_UnitTestCase {
 	public function test_expired_token() {
 		$user_id = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id );
-		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com' );
 		$key = $tokens->set( $token, -30 );
 		$get = $tokens->get( $key );
 		$this->assertFalse( $get );
@@ -48,7 +48,7 @@ class TokensTest extends WP_UnitTestCase {
 	public function test_destroy_token() {
 		$user_id = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id );
-		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com' );
 		$key = $tokens->set( $token, 300 );
 		$get = $tokens->get( $key );
 		unset( $get['user'] );

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -8,6 +8,7 @@ class TokensTest extends WP_UnitTestCase {
 		$key = $tokens->set( $token );
 		$get = $tokens->get( $key );
 		unset( $get['user'] );
+		$token['sub'] = $token['me'];
 		$this->assertEquals( $token, $get );
 	}
 
@@ -53,6 +54,7 @@ class TokensTest extends WP_UnitTestCase {
 		$get = $tokens->get( $key );
 		unset( $get['user'] );
 		unset( $get['exp' ] );
+		$token['sub'] = $token['me'];
 		$this->assertEquals( $get, $token );
 		$destroy = $tokens->destroy( $key );
 		$this->assertTrue( $destroy );


### PR DESCRIPTION
the sub claim is required to be compatible with [mod_oauth2](https://github.com/OpenIDC/mod_oauth2) (a pure OAuth client for Apache).

This is the minimal implementation of https://github.com/indieweb/wordpress-indieauth/issues/286.