### PR TITLE
Move plugin initialization to init hook to avoid debug.log spam

### DIFF
--- a/indieauth.php
+++ b/indieauth.php
@@ -89,7 +89,7 @@ class IndieAuth_Plugin {
 		}
 	}
 
-	public static function plugins_loaded() {
+	public static function init() {
 		// Load Core Classes that are always loaded
 		self::load(
 			array(
@@ -175,4 +175,4 @@ class IndieAuth_Plugin {
 	}
 }
 
-add_action( 'plugins_loaded', array( 'IndieAuth_Plugin', 'plugins_loaded' ), 2 );
+add_action( 'init', array( 'IndieAuth_Plugin', 'init' ), 2 );


### PR DESCRIPTION
Since WordPress 6.7 translations [should not be loaded until at least `after_setup_theme`](https://core.trac.wordpress.org/changeset/59127), but probably to `init` according to the error message. WordPress-IndieAuth currently loads translations in `plugins_loaded`, resulting in quickly-ballooning debug.log files across the WordPress indieweb!

This is the error message emitted at least once per page load:
```
[16-Aug-2025 23:10:10 UTC] PHP Notice:  Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>indieauth</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /home/c1020f/public_html_jb/wp-includes/functions.php on line 6121
```

This PR moves WordPress-IndieAuth's initialization to WordPress's `init` hook, after the current user is set so that translations can be loaded properly.

I inspected everything that happens in the now-renamed `IndieAuth_Plugin::init()` function and most of the code simply adds actions to hooks that happen after `init`. The only other thing that happens during IndieAuth's init is the `IndieAuth_Plugin::scopes` is initialized, which is where the translation errors are coming from.

_If_ it is considered too risky to change the hook the plugin initializes on, it may be possible to delay initializing `IndieAuth_Plugin::scopes` to WordPress's `init`, since I'm pretty sure IndieAuth doesn't do anything before `init` anyway.

