### PR TITLE
Add sub claim for OAuth client compatibility

### DIFF
--- a/includes/class-token-user.php
+++ b/includes/class-token-user.php
@@ -190,6 +190,9 @@ class Token_User extends Token_Generic {
 		}
 
 		$value['user'] = $user_id;
+		if ( isset( $value['me'] ) ) {
+			$value['sub'] = $value['me'];
+		}
 		return $value;
 	}
 

--- a/tests/test-introspection-endpoint.php
+++ b/tests/test-introspection-endpoint.php
@@ -43,6 +43,7 @@ class IntrospectionEndpointTest extends WP_UnitTestCase {
 		);
 		static::$test_auth_code['me'] = get_author_posts_url( static::$author_id );
 		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$test_token['sub'] = static::$test_token['me'];
 		static::$refresh_token['me'] = get_author_posts_url( static::$author_id );
 		static::$subscriber_id = $factory->user->create(
 			array(

--- a/tests/test-revocation-endpoint.php
+++ b/tests/test-revocation-endpoint.php
@@ -43,6 +43,7 @@ class RevocationEndpointTest extends WP_UnitTestCase {
 		);
 		static::$test_auth_code['me'] = get_author_posts_url( static::$author_id );
 		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$test_token['sub'] = static::$test_token['me'];
 		static::$refresh_token['me'] = get_author_posts_url( static::$author_id );
 		static::$subscriber_id = $factory->user->create(
 			array(

--- a/tests/test-token-endpoint.php
+++ b/tests/test-token-endpoint.php
@@ -43,6 +43,7 @@ class TokenEndpointTest extends WP_UnitTestCase {
 		);
 		static::$test_auth_code['me'] = get_author_posts_url( static::$author_id );
 		static::$test_token['me'] = get_author_posts_url( static::$author_id );
+		static::$test_token['sub'] = static::$test_token['me'];
 		static::$refresh_token['me'] = get_author_posts_url( static::$author_id );
 		static::$subscriber_id = $factory->user->create(
 			array(

--- a/tests/test-tokens.php
+++ b/tests/test-tokens.php
@@ -4,10 +4,11 @@ class TokensTest extends WP_UnitTestCase {
 	public function test_set_and_get_user_token() {
 		$user_id = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id );
-		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com' );
 		$key = $tokens->set( $token );
 		$get = $tokens->get( $key );
 		unset( $get['user'] );
+		$token['sub'] = $token['me'];
 		$this->assertEquals( $token, $get );
 	}
 
@@ -15,7 +16,7 @@ class TokensTest extends WP_UnitTestCase {
 		$user_id_1 = self::factory()->user->create();
 		$user_id_2 = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id_1 );
-		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com' );
 		$tokens->set( $token );
 		$tokens->set_user( $user_id_2 );
 		$key = $tokens->set( $token );
@@ -27,7 +28,7 @@ class TokensTest extends WP_UnitTestCase {
 		$user_id_1 = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id_1 );
 		$uuid = wp_generate_uuid4();
-		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'uuid' => $uuid );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com', 'uuid' => $uuid );
 		$access_token = $tokens->set( $token );
 		$return = $tokens->find_by_field( 'uuid', $uuid, $user_id_1 );
 		$first = reset( $return );
@@ -39,7 +40,7 @@ class TokensTest extends WP_UnitTestCase {
 	public function test_expired_token() {
 		$user_id = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id );
-		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com' );
 		$key = $tokens->set( $token, -30 );
 		$get = $tokens->get( $key );
 		$this->assertFalse( $get );
@@ -48,11 +49,12 @@ class TokensTest extends WP_UnitTestCase {
 	public function test_destroy_token() {
 		$user_id = self::factory()->user->create();
 		$tokens = new Token_User( '_indieauth_code_', $user_id );
-		$token = array( 'foo' => 'foo', 'bar' => 'bar' );
+		$token = array( 'foo' => 'foo', 'bar' => 'bar', 'me' => 'https://example.com' );
 		$key = $tokens->set( $token, 300 );
 		$get = $tokens->get( $key );
 		unset( $get['user'] );
 		unset( $get['exp' ] );
+		$token['sub'] = $token['me'];
 		$this->assertEquals( $get, $token );
 		$destroy = $tokens->destroy( $key );
 		$this->assertTrue( $destroy );


### PR DESCRIPTION
## Summary

Adds the `sub` claim to token responses, setting it to the same value as `me`. This is required for compatibility with pure OAuth clients like mod_oauth2.

- Only sets `sub` when `me` property is present (safety check)
- Updates tests to include `me` in test tokens and expect `sub` in responses

Fixes #286

Based on #288 by @carrvo