### PR TITLE
Fix critical error when client not found in taxonomy

### DIFF
--- a/includes/class-token-list-table.php
+++ b/includes/class-token-list-table.php
@@ -149,8 +149,12 @@ class Token_List_Table extends WP_List_Table {
 		);
 		if ( ! isset( $item['client_name'] ) ) {
 			if ( isset( $item['client_id'] ) ) {
-				$client              = IndieAuth_Client_Taxonomy::get_client( $item['client_id'] );
-				$item['client_name'] = $client['name'];
+				$client = IndieAuth_Client_Taxonomy::get_client( $item['client_id'] );
+				if ( is_wp_error( $client ) ) {
+					$item['client_name'] = __( 'Unknown', 'indieauth' );
+				} else {
+					$item['client_name'] = $client['name'];
+				}
 			} else {
 				$item['client_name'] = __( 'Not Provided', 'indieauth' );
 			}


### PR DESCRIPTION
## Summary
- Add `is_wp_error()` check in `column_client_name()` before accessing client data
- Display "Unknown" as fallback when client lookup fails
- Follows existing pattern used in `column_client_icon()`

Fixes #300

## Test plan
- [ ] Generate a token via web sign-in with a client that isn't stored in the taxonomy
- [ ] Navigate to "Manage IndieAuth Tokens" in the dashboard
- [ ] Verify the page loads without critical error
- [ ] Verify the client name shows "Unknown" for the token