### PR TITLE
Bump version to 4.6.0 and raise minimum PHP to 7.4

### DIFF
--- a/.github/workflows/wp-phpunit.yml
+++ b/.github/workflows/wp-phpunit.yml
@@ -32,11 +32,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.2', '8.3', '8.5']
+        php-versions: ['7.4', '8.3', '8.5']
         wp-version: ['latest']
         include:
           - wp-version: '6.5'
-            php-versions: '7.2'
+            php-versions: '7.4'
           - wp-version: trunk
             php-versions: '8.5'
     steps:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.2",
+		"php": ">=7.4",
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 4.5.5
+ * Version: 4.6.0
  * Requires at least: 6.2
  * Requires PHP: 7.4
  * Requires CP: 2.1

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 - Donate link: https://opencollective.com/indieweb
 - Tags: IndieAuth, IndieWeb, login, oauth
 - Tested up to: 7.0
-- Stable tag: 4.5.5
+- Stable tag: 4.6.0
 - Requires PHP: 7.4
 - License: MIT
 - License URI: https://opensource.org/licenses/MIT
@@ -188,6 +188,12 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 4.6.0
+
+* Add FedCM (Federated Credential Management) support
+* Fix critical error when client is not found in the taxonomy
+* Raise minimum required PHP version to 7.4
 
 ### 4.5.5
 


### PR DESCRIPTION
## Summary

- Bump plugin version 4.5.5 → 4.6.0
- Raise minimum required PHP version from 7.2 → 7.4 in `composer.json` (headers were already at 7.4)
- Add 4.6.0 changelog entry to `readme.md`

## Changelog (4.6.0)

* Add FedCM (Federated Credential Management) support
* Fix critical error when client is not found in the taxonomy
* Raise minimum required PHP version to 7.4

Note: dependency bumps and dev-tooling changes since 4.5.5 (wp-env migration, PHPUnit/PHPCS setup, etc.) are intentionally omitted from the user-facing changelog. `Tested up to: 7.0` is unchanged.