### PR TITLE
Fix .gitattributes so the distributed archive includes a readme

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,8 +22,5 @@
 /tests/              export-ignore
 /vendor/             export-ignore
 
-# Documentation (readme.txt is kept for WordPress.org)
-/CLAUDE.md           export-ignore
+# Documentation (readme.md is kept for WordPress.org)
 /LICENSE.md          export-ignore
-/README.md           export-ignore
-/readme.md           export-ignore


### PR DESCRIPTION
## Problem

`readme.txt` was removed in #296, but `.gitattributes` was never updated to match. It still:

- `export-ignore`d `readme.md` — the only remaining readme — so the distributed archive (built by `10up/action-wordpress-plugin-deploy` on tag push) shipped **with no readme at all**.
- Referenced a `readme.txt` in the comment that no longer exists.
- Listed dead `/README.md` and `/CLAUDE.md` entries (no such files in this repo).

## Change

- Stop `export-ignore`ing `readme.md` so it ships in the archive.
- Remove the dead `/README.md` and `/CLAUDE.md` entries.
- Update the comment.

Verified with `git check-attr export-ignore readme.md` → now `unspecified` (ships).

## Note

WordPress.org's plugin page is rendered specifically from `readme.txt`, not `readme.md`. This PR ensures a readme is present in the archive, but if the intent is a proper wp.org listing (parsed stable tag / description / changelog), a `readme.txt` should be reintroduced as the canonical source (the `composer wp2md` script already expects `readme.txt` → `readme.md`). Happy to do that in a follow-up.