### PR TITLE
Use readme.md as the WordPress.org readme source

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,3 +15,4 @@ jobs:
        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
        SLUG: indieauth
+       README_NAME: readme.md

--- a/.github/workflows/update-assets.yml
+++ b/.github/workflows/update-assets.yml
@@ -1,17 +1,26 @@
 name: Plugin asset/readme update
+
 on:
   push:
     branches:
-    - trunk
+      - trunk
+    paths:
+      - '.wordpress-org/**'
+      - 'readme.md'
+      - 'readme.txt'
+
 jobs:
-  trunk:
-    name: Push to trunk
+  update-assets:
+    name: Update plugin assets
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
-      env:
-        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-        SLUG: indieauth
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: WordPress.org plugin asset/readme update
+        uses: 10up/action-wordpress-plugin-asset-update@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: indieauth
+          README_NAME: readme.md


### PR DESCRIPTION
Sync the markdown `readme.md` to WordPress.org as the readme, in both wp.org workflows.

**`update-assets.yml`** (push to trunk)
- Add a `paths` filter so it runs on `.wordpress-org/**`, `readme.md`, and `readme.txt` changes.
- Set `README_NAME: readme.md`.

**`deploy.yml`** (tagged release)
- Set `README_NAME: readme.md` so tagged deploys use the same readme source.

Branch (`trunk`) and `SLUG: indieauth` kept for this repo.