### PR TITLE
Align endpoints with IndieAuth spec changes since 2020

### DIFF
--- a/includes/class-client-discovery.php
+++ b/includes/class-client-discovery.php
@@ -110,7 +110,7 @@ class Client_Discovery {
 		if ( 'localhost' === \wp_parse_url( $this->client_id, PHP_URL_HOST ) ) {
 			return;
 		}
-		$response = self::parse( $this->client_id );
+		$response = $this->parse( $this->client_id );
 		if ( \is_wp_error( $response ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			\error_log( \__( 'Failed to Retrieve IndieAuth Client Details ', 'indieauth' ) . \wp_json_encode( $response ) );

--- a/includes/class-client-discovery.php
+++ b/includes/class-client-discovery.php
@@ -69,6 +69,13 @@ class Client_Discovery {
 	public $client_uri = '';
 
 	/**
+	 * The redirect URIs published by the client.
+	 *
+	 * @var array
+	 */
+	protected $redirect_uris = array();
+
+	/**
 	 * Constructor. Fetches and parses client information.
 	 *
 	 * @param string $client_id The client identifier URL.
@@ -79,8 +86,16 @@ class Client_Discovery {
 		if ( defined( 'INDIEAUTH_UNIT_TESTS' ) ) {
 			return;
 		}
+
+		$this->discover();
+	}
+
+	/**
+	 * Fetches and parses the client information document.
+	 */
+	public function discover() {
 		// Validate if this is an IP address.
-		$ip         = filter_var( \wp_parse_url( $client_id, PHP_URL_HOST ), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 );
+		$ip         = filter_var( \wp_parse_url( $this->client_id, PHP_URL_HOST ), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 );
 		$donotfetch = array(
 			'127.0.0.1',
 			'0000:0000:0000:0000:0000:0000:0000:0001',
@@ -92,10 +107,10 @@ class Client_Discovery {
 			return;
 		}
 
-		if ( 'localhost' === \wp_parse_url( $client_id, PHP_URL_HOST ) ) {
+		if ( 'localhost' === \wp_parse_url( $this->client_id, PHP_URL_HOST ) ) {
 			return;
 		}
-		$response = self::parse( $client_id );
+		$response = self::parse( $this->client_id );
 		if ( \is_wp_error( $response ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			\error_log( \__( 'Failed to Retrieve IndieAuth Client Details ', 'indieauth' ) . \wp_json_encode( $response ) );
@@ -160,6 +175,8 @@ class Client_Discovery {
 			return $response;
 		}
 
+		$this->redirect_uris = self::parse_redirect_uris_from_link_headers( $response, $url );
+
 		$content_type = \wp_remote_retrieve_header( $response, 'content-type' );
 		if ( 'application/json' === $content_type ) {
 			$this->json = json_decode( \wp_remote_retrieve_body( $response ), true );
@@ -192,6 +209,9 @@ class Client_Discovery {
 			if ( array_key_exists( 'client_uri', $this->json ) ) {
 				$this->client_uri = $this->json['client_uri'];
 			}
+			if ( array_key_exists( 'redirect_uris', $this->json ) && is_array( $this->json['redirect_uris'] ) ) {
+				$this->redirect_uris = array_merge( $this->redirect_uris, $this->json['redirect_uris'] );
+			}
 		} elseif ( 'text/html' === $content_type ) {
 			$content = \wp_remote_retrieve_body( $response );
 			$this->get_mf2( $content, $url );
@@ -207,10 +227,15 @@ class Client_Discovery {
 					}
 				}
 			} else {
-				$domdocument       = new \DOMDocument( \wp_remote_retrieve_body( $response ) );
+				$domdocument = new \DOMDocument();
+				\libxml_use_internal_errors( true );
+				$domdocument->loadHTML( $content );
+				\libxml_clear_errors();
 				$this->client_icon = $this->determine_icon( $this->rels );
 				$this->get_html( $domdocument );
-				$this->client_name = $this->html['title'];
+				if ( ! empty( $this->html['title'] ) ) {
+					$this->client_name = $this->html['title'];
+				}
 			}
 
 			if ( ! empty( $this->client_icon ) ) {
@@ -229,9 +254,12 @@ class Client_Discovery {
 		if ( ! class_exists( 'Mf2\Parser' ) ) {
 			require_once \plugin_dir_path( __DIR__ ) . 'lib/mf2/Parser.php';
 		}
-		$mf = Mf2\parse( $input, $url );
+		$mf = \Mf2\parse( $input, $url );
 		if ( array_key_exists( 'rels', $mf ) ) {
-			$this->rels = \wp_array_slice_assoc( $mf['rels'], array( 'apple-touch-icon', 'icon', 'mask-icon' ) );
+			$this->rels = \wp_array_slice_assoc( $mf['rels'], array( 'apple-touch-icon', 'icon', 'mask-icon', 'redirect_uri' ) );
+			if ( ! empty( $this->rels['redirect_uri'] ) ) {
+				$this->redirect_uris = array_merge( $this->redirect_uris, (array) $this->rels['redirect_uri'] );
+			}
 		}
 		if ( array_key_exists( 'items', $mf ) ) {
 			foreach ( $mf['items'] as $item ) {
@@ -252,7 +280,7 @@ class Client_Discovery {
 		$xpath = new \DOMXPath( $input );
 		if ( ! empty( $xpath ) ) {
 			$title = $xpath->query( '//title' );
-			if ( ! empty( $title ) ) {
+			if ( $title instanceof \DOMNodeList && $title->length > 0 ) {
 				$this->html['title'] = $title->item( 0 )->textContent;
 			}
 		}
@@ -321,6 +349,10 @@ class Client_Discovery {
 			$icons = $input['icon'];
 		}
 
+		if ( empty( $icons ) ) {
+			return '';
+		}
+
 		if ( is_array( $icons ) && ! \wp_is_numeric_array( $icons ) && isset( $icons['url'] ) ) {
 			return $icons['url'];
 		} elseif ( is_string( $icons[0] ) ) {
@@ -341,5 +373,42 @@ class Client_Discovery {
 	 */
 	public function get_icon() {
 		return $this->client_icon;
+	}
+
+	/**
+	 * Returns the redirect URIs published by the client.
+	 *
+	 * @return array The published redirect URIs.
+	 */
+	public function get_redirect_uris() {
+		return array_values( array_unique( $this->redirect_uris ) );
+	}
+
+	/**
+	 * Extracts redirect URIs from Link headers of a response.
+	 *
+	 * A client MAY publish one or more Link HTTP headers with a rel attribute
+	 * of redirect_uri at the client_id URL.
+	 *
+	 * @param array  $response The HTTP response.
+	 * @param string $url      The requested URL, used to make relative URLs absolute.
+	 * @return array The redirect URIs found in Link headers.
+	 */
+	private static function parse_redirect_uris_from_link_headers( $response, $url ) {
+		$redirect_uris = array();
+		$links         = \wp_remote_retrieve_header( $response, 'link' );
+		if ( empty( $links ) ) {
+			return $redirect_uris;
+		}
+		// Multiple Link headers are returned as an array, a single one as a string that may hold comma-separated values.
+		if ( is_string( $links ) ) {
+			$links = explode( ',', $links );
+		}
+		foreach ( (array) $links as $link ) {
+			if ( preg_match( '/<\s*([^>]+)\s*>\s*;\s*rel\s*=\s*"?redirect_uri"?/i', $link, $matches ) ) {
+				$redirect_uris[] = \WP_Http::make_absolute_url( trim( $matches[1] ), $url );
+			}
+		}
+		return $redirect_uris;
 	}
 }

--- a/includes/class-client-discovery.php
+++ b/includes/class-client-discovery.php
@@ -434,7 +434,19 @@ class Client_Discovery {
 			$links = explode( ',', $links );
 		}
 		foreach ( (array) $links as $link ) {
-			if ( preg_match( '/<\s*([^>]+)\s*>\s*;\s*rel\s*=\s*"?redirect_uri"?/i', $link, $matches ) ) {
+			if ( ! preg_match( '/<\s*([^>]+?)\s*>\s*;\s*(.*)$/', $link, $matches ) ) {
+				continue;
+			}
+
+			// The rel parameter may be quoted or bare.
+			if ( ! preg_match( '/rel\s*=\s*"([^"]*)"/i', $matches[2], $rel )
+				&& ! preg_match( '/rel\s*=\s*([^;\s]+)/i', $matches[2], $rel ) ) {
+				continue;
+			}
+
+			// A rel value is a space-separated list of link types, and the types are case-insensitive.
+			$types = preg_split( '/\s+/', strtolower( trim( $rel[1] ) ) );
+			if ( in_array( 'redirect_uri', $types, true ) ) {
 				$redirect_uris[] = \WP_Http::make_absolute_url( trim( $matches[1] ), $url );
 			}
 		}

--- a/includes/class-client-discovery.php
+++ b/includes/class-client-discovery.php
@@ -163,6 +163,33 @@ class Client_Discovery {
 	}
 
 	/**
+	 * Get the media type of a response, without any parameters.
+	 *
+	 * Servers usually send something like "application/json; charset=utf-8", so
+	 * the raw header cannot be compared to a media type directly.
+	 *
+	 * @param array|\WP_Error $response The HTTP response.
+	 * @return string The lowercased media type, or an empty string if there is none.
+	 */
+	private static function parse_content_type( $response ) {
+		$content_type = \wp_remote_retrieve_header( $response, 'content-type' );
+
+		// A repeated header comes back as an array.
+		if ( is_array( $content_type ) ) {
+			$content_type = end( $content_type );
+		}
+
+		if ( ! is_string( $content_type ) ) {
+			return '';
+		}
+
+		// Drop parameters like "; charset=utf-8". The type itself is case-insensitive.
+		$parts = explode( ';', $content_type );
+
+		return strtolower( trim( $parts[0] ) );
+	}
+
+	/**
 	 * Parses the client URL to extract client metadata.
 	 *
 	 * @param string $url The client URL to parse.
@@ -177,7 +204,7 @@ class Client_Discovery {
 
 		$this->redirect_uris = self::parse_redirect_uris_from_link_headers( $response, $url );
 
-		$content_type = \wp_remote_retrieve_header( $response, 'content-type' );
+		$content_type = self::parse_content_type( $response );
 		if ( 'application/json' === $content_type ) {
 			$this->json = json_decode( \wp_remote_retrieve_body( $response ), true );
 			/**

--- a/includes/class-client-discovery.php
+++ b/includes/class-client-discovery.php
@@ -101,20 +101,17 @@ class Client_Discovery {
 	 * Fetches and parses the client information document.
 	 */
 	public function discover() {
-		// Validate if this is an IP address.
-		$ip         = filter_var( \wp_parse_url( $this->client_id, PHP_URL_HOST ), FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 );
-		$donotfetch = array(
-			'127.0.0.1',
-			'0000:0000:0000:0000:0000:0000:0000:0001',
-			'::1',
-		);
+		// An IPv6 host arrives bracketed.
+		$host = trim( (string) \wp_parse_url( $this->client_id, PHP_URL_HOST ), '[]' );
 
-		// If this is an IP address on the donotfetch list then do not fetch.
-		if ( $ip && ! in_array( $ip, $donotfetch, true ) ) {
+		// Never fetch a bare IP address. Only loopback addresses are valid client
+		// identifiers, and a native app listening on one serves no client
+		// information document; anything else is not a valid identifier at all.
+		if ( filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6 ) ) {
 			return;
 		}
 
-		if ( 'localhost' === \wp_parse_url( $this->client_id, PHP_URL_HOST ) ) {
+		if ( 'localhost' === strtolower( $host ) ) {
 			return;
 		}
 		$response = $this->parse( $this->client_id );

--- a/includes/class-client-discovery.php
+++ b/includes/class-client-discovery.php
@@ -76,6 +76,13 @@ class Client_Discovery {
 	protected $redirect_uris = array();
 
 	/**
+	 * Whether the client document was successfully fetched and parsed.
+	 *
+	 * @var bool
+	 */
+	protected $discovered = false;
+
+	/**
 	 * Constructor. Fetches and parses client information.
 	 *
 	 * @param string $client_id The client identifier URL.
@@ -116,6 +123,21 @@ class Client_Discovery {
 			\error_log( \__( 'Failed to Retrieve IndieAuth Client Details ', 'indieauth' ) . \wp_json_encode( $response ) );
 			return;
 		}
+
+		$this->discovered = true;
+	}
+
+	/**
+	 * Whether the client document was fetched and parsed.
+	 *
+	 * A client that published nothing and a client that could not be reached both
+	 * end up with no redirect URIs, but they are not the same answer. Only the
+	 * first is a statement about the client.
+	 *
+	 * @return bool True if discovery completed.
+	 */
+	public function is_discovered() {
+		return $this->discovered;
 	}
 
 	/**
@@ -146,7 +168,7 @@ class Client_Discovery {
 		$wp_version = \get_bloginfo( 'version' );
 		$user_agent = \apply_filters( 'http_headers_useragent', 'WordPress/' . $wp_version . '; ' . \get_bloginfo( 'url' ) );
 		$args       = array(
-			'timeout'             => 100,
+			'timeout'             => 5,
 			'limit_response_size' => 1048576,
 			'redirection'         => 3,
 			'user-agent'          => "$user_agent; IndieAuth Client Information Discovery",
@@ -190,6 +212,117 @@ class Client_Discovery {
 	}
 
 	/**
+	 * Whether a media type should be parsed as JSON client metadata.
+	 *
+	 * @param string $content_type The media type.
+	 * @return bool True for a JSON media type.
+	 */
+	private static function is_json_type( $content_type ) {
+		return 'application/json' === $content_type || (bool) preg_match( '#^application/[\w.+-]+\+json$#', $content_type );
+	}
+
+	/**
+	 * Whether a media type should be parsed as HTML.
+	 *
+	 * @param string $content_type The media type.
+	 * @return bool True for an HTML media type.
+	 */
+	private static function is_html_type( $content_type ) {
+		return in_array( $content_type, array( 'text/html', 'application/xhtml+xml' ), true );
+	}
+
+	/**
+	 * Extracts redirect URIs from <link> elements in the document head.
+	 *
+	 * Only the head is read. Body markup is user-generated on plenty of sites,
+	 * and a redirect URI decides where an authorization code gets delivered.
+	 *
+	 * @param string $content The HTML document.
+	 * @param string $url     The requested URL, used to make relative URLs absolute.
+	 * @return array The redirect URIs published in the head.
+	 */
+	private static function parse_redirect_uris_from_head( $content, $url ) {
+		$redirect_uris = array();
+
+		if ( '' === trim( (string) $content ) ) {
+			return $redirect_uris;
+		}
+
+		$domdocument     = new \DOMDocument();
+		$libxml_previous = \libxml_use_internal_errors( true );
+		$loaded          = $domdocument->loadHTML( $content );
+		\libxml_clear_errors();
+		\libxml_use_internal_errors( $libxml_previous );
+
+		if ( ! $loaded ) {
+			return $redirect_uris;
+		}
+
+		$xpath = new \DOMXPath( $domdocument );
+
+		foreach ( $xpath->query( '//head/link[@rel and @href]' ) as $link ) {
+			// A rel value is a space-separated list, and the types are case-insensitive.
+			$types = preg_split( '/\s+/', strtolower( trim( $link->getAttribute( 'rel' ) ) ) );
+			if ( in_array( 'redirect_uri', $types, true ) ) {
+				$redirect_uris[] = \WP_Http::make_absolute_url( trim( $link->getAttribute( 'href' ) ), $url );
+			}
+		}
+
+		return $redirect_uris;
+	}
+
+	/**
+	 * Splits a Link header value into its individual link-values.
+	 *
+	 * A comma only separates links when it is outside a quoted parameter, so
+	 * `<https://example.com/cb>; title="Foo, Bar"` is one link, not two.
+	 *
+	 * @param string $header The Link header value.
+	 * @return array The individual link-values.
+	 */
+	private static function split_link_header( $header ) {
+		$links   = array();
+		$current = '';
+		$quoted  = false;
+		$escaped = false;
+		$length  = strlen( $header );
+
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $header[ $i ];
+
+			if ( $escaped ) {
+				$escaped  = false;
+				$current .= $char;
+				continue;
+			}
+
+			if ( '\\' === $char && $quoted ) {
+				$escaped  = true;
+				$current .= $char;
+				continue;
+			}
+
+			if ( '"' === $char ) {
+				$quoted   = ! $quoted;
+				$current .= $char;
+				continue;
+			}
+
+			if ( ',' === $char && ! $quoted ) {
+				$links[] = $current;
+				$current = '';
+				continue;
+			}
+
+			$current .= $char;
+		}
+
+		$links[] = $current;
+
+		return array_filter( array_map( 'trim', $links ) );
+	}
+
+	/**
 	 * Parses the client URL to extract client metadata.
 	 *
 	 * @param string $url The client URL to parse.
@@ -205,8 +338,14 @@ class Client_Discovery {
 		$this->redirect_uris = self::parse_redirect_uris_from_link_headers( $response, $url );
 
 		$content_type = self::parse_content_type( $response );
-		if ( 'application/json' === $content_type ) {
-			$this->json = json_decode( \wp_remote_retrieve_body( $response ), true );
+		$body         = \wp_remote_retrieve_body( $response );
+
+		if ( '' === trim( (string) $body ) ) {
+			return new \WP_Error( 'empty_body', \__( 'Client Information Document Was Empty', 'indieauth' ) );
+		}
+
+		if ( self::is_json_type( $content_type ) ) {
+			$this->json = json_decode( $body, true );
 			/**
 			 * Expected format is per the IndieAuth standard as revised 2024-06-23 to include a JSON Client Metadata File
 			 *
@@ -237,10 +376,16 @@ class Client_Discovery {
 				$this->client_uri = $this->json['client_uri'];
 			}
 			if ( array_key_exists( 'redirect_uris', $this->json ) && is_array( $this->json['redirect_uris'] ) ) {
-				$this->redirect_uris = array_merge( $this->redirect_uris, $this->json['redirect_uris'] );
+				// Published by an untrusted party, so only usable strings survive.
+				foreach ( $this->json['redirect_uris'] as $redirect_uri ) {
+					if ( is_string( $redirect_uri ) && '' !== trim( $redirect_uri ) ) {
+						$this->redirect_uris[] = \WP_Http::make_absolute_url( trim( $redirect_uri ), $url );
+					}
+				}
 			}
-		} elseif ( 'text/html' === $content_type ) {
-			$content = \wp_remote_retrieve_body( $response );
+		} elseif ( self::is_html_type( $content_type ) ) {
+			$content             = $body;
+			$this->redirect_uris = array_merge( $this->redirect_uris, self::parse_redirect_uris_from_head( $content, $url ) );
 			$this->get_mf2( $content, $url );
 			if ( ! empty( $this->mf2 ) ) {
 				if ( array_key_exists( 'name', $this->mf2 ) ) {
@@ -285,10 +430,11 @@ class Client_Discovery {
 		}
 		$mf = \Mf2\parse( $input, $url );
 		if ( array_key_exists( 'rels', $mf ) ) {
-			$this->rels = \wp_array_slice_assoc( $mf['rels'], array( 'apple-touch-icon', 'icon', 'mask-icon', 'redirect_uri' ) );
-			if ( ! empty( $this->rels['redirect_uri'] ) ) {
-				$this->redirect_uris = array_merge( $this->redirect_uris, (array) $this->rels['redirect_uri'] );
-			}
+			// Deliberately no redirect_uri here. The mf2 parser collects rels from
+			// anywhere in the document, including body content that is often
+			// user-generated, and a redirect target decides where an authorization
+			// code is delivered. Those come from <head> and the Link header only.
+			$this->rels = \wp_array_slice_assoc( $mf['rels'], array( 'apple-touch-icon', 'icon', 'mask-icon' ) );
 		}
 		if ( array_key_exists( 'items', $mf ) ) {
 			foreach ( $mf['items'] as $item ) {
@@ -429,25 +575,36 @@ class Client_Discovery {
 		if ( empty( $links ) ) {
 			return $redirect_uris;
 		}
-		// Multiple Link headers are returned as an array, a single one as a string that may hold comma-separated values.
-		if ( is_string( $links ) ) {
-			$links = explode( ',', $links );
+		// A repeated header comes back as an array, and any single value may still
+		// carry several comma-separated links.
+		$values = array();
+		foreach ( (array) $links as $header ) {
+			if ( is_string( $header ) ) {
+				$values = array_merge( $values, self::split_link_header( $header ) );
+			}
 		}
-		foreach ( (array) $links as $link ) {
-			if ( ! preg_match( '/<\s*([^>]+?)\s*>\s*;\s*(.*)$/', $link, $matches ) ) {
+
+		foreach ( $values as $link ) {
+			// Each link-value is one target in <> followed by its own parameters,
+			// so a rel can never be read off a neighbouring link.
+			if ( ! preg_match( '/^<\s*([^>]*?)\s*>\s*(?:;\s*(.*))?$/', $link, $matches ) ) {
+				continue;
+			}
+
+			if ( '' === $matches[1] || ! isset( $matches[2] ) ) {
 				continue;
 			}
 
 			// The rel parameter may be quoted or bare.
-			if ( ! preg_match( '/rel\s*=\s*"([^"]*)"/i', $matches[2], $rel )
-				&& ! preg_match( '/rel\s*=\s*([^;\s]+)/i', $matches[2], $rel ) ) {
+			if ( ! preg_match( '/(?:^|;)\s*rel\s*=\s*"([^"]*)"/i', $matches[2], $rel )
+				&& ! preg_match( '/(?:^|;)\s*rel\s*=\s*([^;\s]+)/i', $matches[2], $rel ) ) {
 				continue;
 			}
 
 			// A rel value is a space-separated list of link types, and the types are case-insensitive.
 			$types = preg_split( '/\s+/', strtolower( trim( $rel[1] ) ) );
 			if ( in_array( 'redirect_uri', $types, true ) ) {
-				$redirect_uris[] = \WP_Http::make_absolute_url( trim( $matches[1] ), $url );
+				$redirect_uris[] = \WP_Http::make_absolute_url( $matches[1], $url );
 			}
 		}
 		return $redirect_uris;

--- a/includes/class-client-discovery.php
+++ b/includes/class-client-discovery.php
@@ -255,9 +255,11 @@ class Client_Discovery {
 				}
 			} else {
 				$domdocument = new \DOMDocument();
-				\libxml_use_internal_errors( true );
+				// This is a global setting, so put it back the way it was.
+				$libxml_previous = \libxml_use_internal_errors( true );
 				$domdocument->loadHTML( $content );
 				\libxml_clear_errors();
+				\libxml_use_internal_errors( $libxml_previous );
 				$this->client_icon = $this->determine_icon( $this->rels );
 				$this->get_html( $domdocument );
 				if ( ! empty( $this->html['title'] ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -426,6 +426,65 @@ if ( ! function_exists( 'IndieAuth\same_origin' ) ) {
 	}
 }
 
+if ( ! function_exists( 'IndieAuth\is_loopback_url' ) ) {
+	/**
+	 * Whether a URL points at the loopback interface.
+	 *
+	 * Native apps redirect to a loopback address on an ephemeral port, which they
+	 * cannot know in advance and cannot publish anywhere, so the port is not part
+	 * of the identity of such a client.
+	 *
+	 * @see https://datatracker.ietf.org/doc/html/rfc8252#section-7.3
+	 *
+	 * @param string $url URL to check.
+	 * @return bool True if the host is a loopback address.
+	 */
+	function is_loopback_url( $url ) {
+		if ( ! is_string( $url ) ) {
+			return false;
+		}
+
+		$host = \wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			return false;
+		}
+
+		$host = strtolower( trim( $host, '[]' ) );
+
+		if ( 'localhost' === $host ) {
+			return true;
+		}
+
+		// Any 127.0.0.0/8 address, and the IPv6 loopback in any notation.
+		if ( filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+			return 0 === strpos( $host, '127.' );
+		}
+
+		if ( filter_var( $host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 ) ) {
+			return in_array( inet_pton( $host ), array( inet_pton( '::1' ) ), true );
+		}
+
+		return false;
+	}
+}
+
+if ( ! function_exists( 'IndieAuth\deprecation_notice' ) ) {
+	/**
+	 * Emit a developer notice about a deprecated endpoint behavior.
+	 *
+	 * Call this only once the request has been authenticated or validated.
+	 * These endpoints are public, so emitting on the way in lets an anonymous
+	 * caller fill the debug log by looping on them.
+	 *
+	 * @param string $function_name The function that was called.
+	 * @param string $message       The deprecation message.
+	 * @param string $version       The version the behavior was deprecated in.
+	 */
+	function deprecation_notice( $function_name, $message, $version ) {
+		\_doing_it_wrong( \esc_html( $function_name ), \esc_html( $message ), \esc_html( $version ) );
+	}
+}
+
 if ( ! function_exists( 'IndieAuth\add_deprecation_headers' ) ) {
 	/**
 	 * Add deprecation headers to a REST response.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -387,6 +387,59 @@ if ( ! function_exists( 'IndieAuth\build_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'IndieAuth\same_origin' ) ) {
+	/**
+	 * Check whether two URLs share the same origin.
+	 *
+	 * The origin is the scheme, host and port; a missing port counts as the
+	 * default port for the scheme.
+	 *
+	 * @param string $url1 First URL.
+	 * @param string $url2 Second URL.
+	 * @return bool Whether both URLs have the same origin.
+	 */
+	function same_origin( $url1, $url2 ) {
+		$parts1 = \wp_parse_url( $url1 );
+		$parts2 = \wp_parse_url( $url2 );
+
+		if ( ! isset( $parts1['scheme'], $parts1['host'], $parts2['scheme'], $parts2['host'] ) ) {
+			return false;
+		}
+
+		if ( $parts1['scheme'] !== $parts2['scheme'] || $parts1['host'] !== $parts2['host'] ) {
+			return false;
+		}
+
+		$defaults     = array(
+			'http'  => 80,
+			'https' => 443,
+		);
+		$default_port = isset( $defaults[ $parts1['scheme'] ] ) ? $defaults[ $parts1['scheme'] ] : null;
+		$port1        = isset( $parts1['port'] ) ? (int) $parts1['port'] : $default_port;
+		$port2        = isset( $parts2['port'] ) ? (int) $parts2['port'] : $default_port;
+
+		return $port1 === $port2;
+	}
+}
+
+if ( ! function_exists( 'IndieAuth\add_deprecation_headers' ) ) {
+	/**
+	 * Add deprecation headers to a REST response.
+	 *
+	 * Used by endpoints that still accept behavior removed from the IndieAuth
+	 * specification.
+	 *
+	 * @param \WP_REST_Response $response The response object.
+	 * @return \WP_REST_Response The response with deprecation headers added.
+	 */
+	function add_deprecation_headers( $response ) {
+		$response->header( 'Deprecation', 'true' );
+		$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"' );
+
+		return $response;
+	}
+}
+
 if ( ! function_exists( 'IndieAuth\normalize_url' ) ) {
 	/**
 	 * Normalize a URL by adding slash if no path and converting hostname to lowercase.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -406,7 +406,11 @@ if ( ! function_exists( 'IndieAuth\same_origin' ) ) {
 			return false;
 		}
 
-		if ( $parts1['scheme'] !== $parts2['scheme'] || $parts1['host'] !== $parts2['host'] ) {
+		// Schemes and hosts are case-insensitive.
+		$scheme1 = strtolower( $parts1['scheme'] );
+		$scheme2 = strtolower( $parts2['scheme'] );
+
+		if ( $scheme1 !== $scheme2 || strtolower( $parts1['host'] ) !== strtolower( $parts2['host'] ) ) {
 			return false;
 		}
 
@@ -414,7 +418,7 @@ if ( ! function_exists( 'IndieAuth\same_origin' ) ) {
 			'http'  => 80,
 			'https' => 443,
 		);
-		$default_port = isset( $defaults[ $parts1['scheme'] ] ) ? $defaults[ $parts1['scheme'] ] : null;
+		$default_port = isset( $defaults[ $scheme1 ] ) ? $defaults[ $scheme1 ] : null;
 		$port1        = isset( $parts1['port'] ) ? (int) $parts1['port'] : $default_port;
 		$port2        = isset( $parts2['port'] ) ? (int) $parts2['port'] : $default_port;
 
@@ -434,7 +438,8 @@ if ( ! function_exists( 'IndieAuth\add_deprecation_headers' ) ) {
 	 */
 	function add_deprecation_headers( $response ) {
 		$response->header( 'Deprecation', 'true' );
-		$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"' );
+		// Append, so an existing Link header is not dropped.
+		$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"', false );
 
 		return $response;
 	}

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -296,8 +296,27 @@ class Authorization_Controller extends \WP_REST_Controller {
 	 */
 	public function get( $request ) {
 		$params = $request->get_params();
-		if ( ! isset( $params['response_type'] ) || 'id' === $params['response_type'] ) {
+
+		/*
+		 * The response_type parameter is required as of IndieAuth 1.1 and `id` was removed
+		 * from the specification. Both are still accepted for older clients, but are
+		 * deprecated. The REST API fills in the registered default of `code`, so a request
+		 * that omitted the parameter is only visible in the raw query parameters.
+		 */
+		$raw_params = $request->get_query_params();
+		if ( ! isset( $raw_params['response_type'] ) || 'id' === $params['response_type'] ) {
+			\_doing_it_wrong(
+				'IndieAuth\Rest\Authorization_Controller::get',
+				\esc_html__( 'Omitting response_type or using response_type=id was removed from the IndieAuth specification. Clients must send response_type=code.', 'indieauth' ),
+				'indieauth 4.7.0'
+			);
 			$params['response_type'] = 'code';
+			$response                = $this->code( $params );
+			if ( $response instanceof \WP_REST_Response ) {
+				$response->header( 'Deprecation', 'true' );
+				$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"' );
+			}
+			return $response;
 		}
 		if ( 'code' === $params['response_type'] ) {
 			return $this->code( $params );

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -19,6 +19,8 @@ use function IndieAuth\indieauth_get_user;
 use function IndieAuth\pkce_verifier;
 use function IndieAuth\add_query_params_to_url;
 use function IndieAuth\get_url_from_user;
+use function IndieAuth\same_origin;
+use function IndieAuth\add_deprecation_headers;
 
 /**
  * IndieAuth Authorization Controller class.
@@ -305,25 +307,25 @@ class Authorization_Controller extends \WP_REST_Controller {
 		 * that omitted the parameter is only visible in the raw query parameters.
 		 */
 		$raw_params = $request->get_query_params();
-		if ( ! isset( $raw_params['response_type'] ) || 'id' === $params['response_type'] ) {
+		$deprecated = ! isset( $raw_params['response_type'] ) || 'id' === $params['response_type'];
+		if ( $deprecated ) {
 			\_doing_it_wrong(
 				'IndieAuth\Rest\Authorization_Controller::get',
 				\esc_html__( 'Omitting response_type or using response_type=id was removed from the IndieAuth specification. Clients must send response_type=code.', 'indieauth' ),
 				'indieauth 4.7.0'
 			);
 			$params['response_type'] = 'code';
-			$response                = $this->code( $params );
-			if ( $response instanceof \WP_REST_Response ) {
-				$response->header( 'Deprecation', 'true' );
-				$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"' );
-			}
-			return $response;
-		}
-		if ( 'code' === $params['response_type'] ) {
-			return $this->code( $params );
 		}
 
-		return new OAuth_Response( 'unsupported_response_type', \__( 'Unsupported Response Type', 'indieauth' ), 400 );
+		if ( 'code' !== $params['response_type'] ) {
+			return new OAuth_Response( 'unsupported_response_type', \__( 'Unsupported Response Type', 'indieauth' ), 400 );
+		}
+
+		$response = $this->code( $params );
+		if ( $deprecated && $response instanceof \WP_REST_Response ) {
+			add_deprecation_headers( $response );
+		}
+		return $response;
 	}
 
 	/**
@@ -395,8 +397,19 @@ class Authorization_Controller extends \WP_REST_Controller {
 			return (array) $redirect_uris;
 		}
 
-		$discovery = new Client_Discovery( $client_id );
-		return $discovery->get_redirect_uris();
+		// The authorization flow verifies twice (authorization request and consent
+		// submission); cache briefly so the client document is fetched only once.
+		$cache_key     = 'indieauth_client_redirect_uris_' . md5( $client_id );
+		$redirect_uris = \get_transient( $cache_key );
+		if ( false !== $redirect_uris ) {
+			return (array) $redirect_uris;
+		}
+
+		$discovery     = new Client_Discovery( $client_id );
+		$redirect_uris = $discovery->get_redirect_uris();
+		\set_transient( $cache_key, $redirect_uris, 5 * MINUTE_IN_SECONDS );
+
+		return $redirect_uris;
 	}
 
 	/**
@@ -411,15 +424,7 @@ class Authorization_Controller extends \WP_REST_Controller {
 	 * @return bool Whether the redirect URI is valid for this client.
 	 */
 	public static function verify_redirect_uri( $client_id, $redirect_uri ) {
-		$client   = \wp_parse_url( $client_id );
-		$redirect = \wp_parse_url( $redirect_uri );
-
-		$valid = (
-			isset( $client['scheme'], $client['host'], $redirect['scheme'], $redirect['host'] )
-			&& $client['scheme'] === $redirect['scheme']
-			&& $client['host'] === $redirect['host']
-			&& ( isset( $client['port'] ) ? $client['port'] : null ) === ( isset( $redirect['port'] ) ? $redirect['port'] : null )
-		);
+		$valid = same_origin( $client_id, $redirect_uri );
 
 		if ( ! $valid ) {
 			$valid = in_array( $redirect_uri, self::get_client_redirect_uris( $client_id ), true );

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -10,6 +10,7 @@ namespace IndieAuth\Rest;
 use IndieAuth\Token\User as Token_User;
 use IndieAuth\OAuth_Response;
 use IndieAuth\Client_Taxonomy;
+use IndieAuth\Client_Discovery;
 use function IndieAuth\indieauth_validate_client_identifier;
 use function IndieAuth\indieauth_validate_user_identifier;
 use function IndieAuth\rest_is_valid_url;
@@ -339,6 +340,10 @@ class Authorization_Controller extends \WP_REST_Controller {
 				return new OAuth_Response( 'parameter_absent', sprintf( \__( 'Missing Parameter: %1$s', 'indieauth' ), $require ), 400 );
 			}
 		}
+
+		if ( ! self::verify_redirect_uri( $params['client_id'], $params['redirect_uri'] ) ) {
+			return new OAuth_Response( 'invalid_request', \__( 'The redirect_uri does not match the client_id and is not published by the client', 'indieauth' ), 400 );
+		}
 		$url  = \wp_login_url( $params['redirect_uri'], true );
 		$args = array_filter(
 			array(
@@ -367,6 +372,67 @@ class Authorization_Controller extends \WP_REST_Controller {
 		$url = add_query_params_to_url( $args, $url );
 
 		return new \WP_REST_Response( array( 'url' => $url ), 302, array( 'Location' => $url ) );
+	}
+
+	/**
+	 * Get the redirect URIs published by a client.
+	 *
+	 * @param string $client_id The client identifier URL.
+	 * @return array The published redirect URIs.
+	 */
+	public static function get_client_redirect_uris( $client_id ) {
+		/**
+		 * Short-circuit client redirect URI discovery.
+		 *
+		 * Return an array of redirect URIs to skip fetching the client information
+		 * document, for example to serve them from a cache or a static registration.
+		 *
+		 * @param array|null $redirect_uris The redirect URIs or null to discover them.
+		 * @param string     $client_id     The client identifier URL.
+		 */
+		$redirect_uris = \apply_filters( 'pre_indieauth_client_redirect_uris', null, $client_id );
+		if ( null !== $redirect_uris ) {
+			return (array) $redirect_uris;
+		}
+
+		$discovery = new Client_Discovery( $client_id );
+		return $discovery->get_redirect_uris();
+	}
+
+	/**
+	 * Verify that a redirect_uri belongs to the client.
+	 *
+	 * If the URL scheme, host or port of the redirect_uri differ from the
+	 * client_id, the redirect_uri has to match one of the redirect URLs
+	 * published by the client.
+	 *
+	 * @param string $client_id    The client identifier URL.
+	 * @param string $redirect_uri The redirect URI to verify.
+	 * @return bool Whether the redirect URI is valid for this client.
+	 */
+	public static function verify_redirect_uri( $client_id, $redirect_uri ) {
+		$client   = \wp_parse_url( $client_id );
+		$redirect = \wp_parse_url( $redirect_uri );
+
+		$valid = (
+			isset( $client['scheme'], $client['host'], $redirect['scheme'], $redirect['host'] )
+			&& $client['scheme'] === $redirect['scheme']
+			&& $client['host'] === $redirect['host']
+			&& ( isset( $client['port'] ) ? $client['port'] : null ) === ( isset( $redirect['port'] ) ? $redirect['port'] : null )
+		);
+
+		if ( ! $valid ) {
+			$valid = in_array( $redirect_uri, self::get_client_redirect_uris( $client_id ), true );
+		}
+
+		/**
+		 * Filter the result of the redirect URI verification.
+		 *
+		 * @param bool   $valid        Whether the redirect URI was verified.
+		 * @param string $redirect_uri The redirect URI.
+		 * @param string $client_id    The client identifier URL.
+		 */
+		return \apply_filters( 'indieauth_verify_redirect_uri', $valid, $redirect_uri, $client_id );
 	}
 
 	/**
@@ -564,6 +630,11 @@ class Authorization_Controller extends \WP_REST_Controller {
 		$scope         = isset( $_POST['scope'] ) ? $_POST['scope'] : array();
 		$code_challenge  = isset( $_POST['code_challenge'] ) ? \wp_unslash( $_POST['code_challenge'] ) : null;
 		$code_challenge_method  = isset( $_POST['code_challenge_method'] ) ? \wp_unslash( $_POST['code_challenge_method'] ) : null;
+
+		// The consent form can be reached without passing through the REST endpoint, so verify the redirect_uri here as well.
+		if ( empty( $redirect_uri ) || ! self::verify_redirect_uri( $client_id, $redirect_uri ) ) {
+			\wp_die( \esc_html__( 'The redirect_uri does not match the client_id and is not published by the client.', 'indieauth' ) );
+		}
 
 		// Do not allow the post scope as deprecated.
 		// For compatibility, instead update the offering to the more limited but functionally identical create/update.

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -20,6 +20,8 @@ use function IndieAuth\pkce_verifier;
 use function IndieAuth\add_query_params_to_url;
 use function IndieAuth\get_url_from_user;
 use function IndieAuth\same_origin;
+use function IndieAuth\is_loopback_url;
+use function IndieAuth\deprecation_notice;
 use function IndieAuth\add_deprecation_headers;
 
 /**
@@ -309,9 +311,9 @@ class Authorization_Controller extends \WP_REST_Controller {
 		$raw_params = $request->get_query_params();
 		$deprecated = ! isset( $raw_params['response_type'] ) || 'id' === $params['response_type'];
 		if ( $deprecated ) {
-			\_doing_it_wrong(
+			deprecation_notice(
 				'IndieAuth\Rest\Authorization_Controller::get',
-				\esc_html__( 'Omitting response_type or using response_type=id was removed from the IndieAuth specification. Clients must send response_type=code.', 'indieauth' ),
+				\__( 'Omitting response_type or using response_type=id was removed from the IndieAuth specification. Clients must send response_type=code.', 'indieauth' ),
 				'indieauth 4.7.0'
 			);
 			$params['response_type'] = 'code';
@@ -407,7 +409,13 @@ class Authorization_Controller extends \WP_REST_Controller {
 
 		$discovery     = new Client_Discovery( $client_id );
 		$redirect_uris = $discovery->get_redirect_uris();
-		\set_transient( $cache_key, $redirect_uris, 5 * MINUTE_IN_SECONDS );
+
+		// Only cache an answer the client actually gave. A failed fetch is not
+		// "published nothing", and caching it would lock a working client out
+		// for the life of the transient over one network blip.
+		if ( $discovery->is_discovered() ) {
+			\set_transient( $cache_key, $redirect_uris, 5 * MINUTE_IN_SECONDS );
+		}
 
 		return $redirect_uris;
 	}
@@ -425,6 +433,13 @@ class Authorization_Controller extends \WP_REST_Controller {
 	 */
 	public static function verify_redirect_uri( $client_id, $redirect_uri ) {
 		$valid = same_origin( $client_id, $redirect_uri );
+
+		// Native apps listen on an ephemeral loopback port and cannot publish
+		// anything at their client_id, so any loopback port is accepted for a
+		// loopback client. RFC 8252 section 7.3.
+		if ( ! $valid && is_loopback_url( $client_id ) && is_loopback_url( $redirect_uri ) ) {
+			$valid = true;
+		}
 
 		if ( ! $valid ) {
 			$valid = in_array( $redirect_uri, self::get_client_redirect_uris( $client_id ), true );

--- a/includes/rest/class-introspection-controller.php
+++ b/includes/rest/class-introspection-controller.php
@@ -49,10 +49,29 @@ class Introspection_Controller extends \WP_REST_Controller {
 	/**
 	 * Get supported authentication methods for introspection.
 	 *
+	 * The endpoint MUST require some form of authorization, so the default is a
+	 * Bearer access token issued by this site. Filtering this to `none` restores
+	 * unauthenticated introspection.
+	 *
 	 * @return array Supported authentication methods.
 	 */
 	public function auth_methods_supported() {
-		return array_unique( \apply_filters( 'indieauth_introspection_auth_methods_supported', array( 'none' ) ) );
+		return array_unique( \apply_filters( 'indieauth_introspection_auth_methods_supported', array( 'Bearer' ) ) );
+	}
+
+	/**
+	 * Permission callback for the introspection endpoint.
+	 *
+	 * Any authentication that establishes a WordPress user is accepted: an
+	 * IndieAuth Bearer token, an application password, or a logged-in session.
+	 *
+	 * @return bool Whether the request is authorized.
+	 */
+	public function permission_callback() {
+		if ( in_array( 'none', $this->auth_methods_supported(), true ) ) {
+			return true;
+		}
+		return \is_user_logged_in();
 	}
 
 	/**
@@ -97,7 +116,7 @@ class Introspection_Controller extends \WP_REST_Controller {
 							'default' => 'all',
 						), // A hint about the type of the token submitted for revocation, options are access_token or refresh_token.
 					),
-					'permission_callback' => '__return_true',
+					'permission_callback' => array( $this, 'permission_callback' ),
 				),
 			)
 		);

--- a/includes/rest/class-introspection-controller.php
+++ b/includes/rest/class-introspection-controller.php
@@ -64,14 +64,53 @@ class Introspection_Controller extends \WP_REST_Controller {
 	 *
 	 * Any authentication that establishes a WordPress user is accepted: an
 	 * IndieAuth Bearer token, an application password, or a logged-in session.
+	 * Whether a token may then be read is decided per token, in `post()`.
 	 *
 	 * @return bool Whether the request is authorized.
 	 */
 	public function permission_callback() {
-		if ( in_array( 'none', $this->auth_methods_supported(), true ) ) {
+		/**
+		 * Allow unauthenticated token introspection.
+		 *
+		 * The endpoint requires authentication by default. This is separate from
+		 * `indieauth_introspection_auth_methods_supported`, which only says what
+		 * the server advertises in its metadata and must not decide access.
+		 *
+		 * @param bool $allow Whether to allow unauthenticated introspection.
+		 */
+		if ( \apply_filters( 'indieauth_allow_unauthenticated_introspection', false ) ) {
 			return true;
 		}
+
 		return \is_user_logged_in();
+	}
+
+	/**
+	 * Whether the current user may introspect a given token.
+	 *
+	 * A token says who authorized it, what it can do and when it expires, so it
+	 * is only readable by the user it belongs to, or by someone who can edit
+	 * that user.
+	 *
+	 * @param array $token The token being introspected.
+	 * @return bool Whether the token may be read.
+	 */
+	protected function can_introspect_token( $token ) {
+		$owner = isset( $token['user'] ) ? (int) $token['user'] : 0;
+
+		if ( $owner && \get_current_user_id() === $owner ) {
+			return true;
+		}
+
+		$allowed = $owner ? \current_user_can( 'edit_user', $owner ) : \current_user_can( 'edit_users' );
+
+		/**
+		 * Filter whether the current user may introspect a token.
+		 *
+		 * @param bool  $allowed Whether introspection is allowed.
+		 * @param array $token   The token being introspected.
+		 */
+		return \apply_filters( 'indieauth_can_introspect_token', $allowed, $token );
 	}
 
 	/**
@@ -131,6 +170,13 @@ class Introspection_Controller extends \WP_REST_Controller {
 	public function introspection( $request ) {
 		$params = $request->get_params();
 		$token  = $this->get_token( $params['token'], $params['token_type_hint'] );
+
+		// Someone else's token reads the same as one that does not exist, so a
+		// caller cannot use this endpoint to learn which token values are real.
+		if ( $token && ! $this->can_introspect_token( $token ) ) {
+			$token = false;
+		}
+
 		if ( $token ) {
 			$token['active'] = 'true';
 		} else {

--- a/includes/rest/class-token-controller.php
+++ b/includes/rest/class-token-controller.php
@@ -148,6 +148,11 @@ class Token_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response|OAuth_Response Response to return to the REST Server.
 	 */
 	public function get( $request ) {
+		\_doing_it_wrong(
+			'IndieAuth\Rest\Token_Controller::get',
+			\esc_html__( 'Token verification via a GET request to the token endpoint was removed from the IndieAuth specification. Use the introspection endpoint instead.', 'indieauth' ),
+			'indieauth 4.7.0'
+		);
 		$header = $request->get_header( 'Authorization' );
 		if ( ! $header && ! empty( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ) {
 			$header = \wp_unslash( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -169,7 +174,10 @@ class Token_Controller extends \WP_REST_Controller {
 			return new OAuth_Response( 'invalid_token', \__( 'Invalid access token', 'indieauth' ), 401 );
 		}
 		$token['active'] = 'true';
-		return \rest_ensure_response( $token );
+		$response        = \rest_ensure_response( $token );
+		$response->header( 'Deprecation', 'true' );
+		$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"' );
+		return $response;
 	}
 
 	/**
@@ -193,9 +201,17 @@ class Token_Controller extends \WP_REST_Controller {
 			switch ( $params['action'] ) {
 				// Revoke Token.
 				case 'revoke':
+					\_doing_it_wrong(
+						'IndieAuth\Rest\Token_Controller::revoke_action',
+						\esc_html__( 'Token revocation via action=revoke on the token endpoint was removed from the IndieAuth specification. Use the revocation endpoint instead.', 'indieauth' ),
+						'indieauth 4.7.0'
+					);
 					if ( isset( $params['token'] ) ) {
 						$this->delete_token( $params['token'] );
-						return \__( 'The Token Provided is No Longer Valid', 'indieauth' );
+						$response = \rest_ensure_response( \__( 'The Token Provided is No Longer Valid', 'indieauth' ) );
+						$response->header( 'Deprecation', 'true' );
+						$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"' );
+						return $response;
 					} else {
 						return new OAuth_Response( 'invalid_request', \__( 'Revoke is Missing Required Parameter token', 'indieauth' ), 400 );
 					}

--- a/includes/rest/class-token-controller.php
+++ b/includes/rest/class-token-controller.php
@@ -160,19 +160,21 @@ class Token_Controller extends \WP_REST_Controller {
 		}
 		$access_token = $this->get_token_from_bearer_header( $header );
 		if ( ! $access_token ) {
-			return new OAuth_Response(
-				'parameter_absent',
-				\__(
-					'Bearer Token Not Supplied or Server Misconfigured to Not Pass Token. Run diagnostic script in WordPress Admin
+			return add_deprecation_headers(
+				new OAuth_Response(
+					'parameter_absent',
+					\__(
+						'Bearer Token Not Supplied or Server Misconfigured to Not Pass Token. Run diagnostic script in WordPress Admin
 				IndieAuth Settings Page',
-					'indieauth'
-				),
-				400
+						'indieauth'
+					),
+					400
+				)
 			);
 		}
 		$token = $this->get_token( $access_token );
 		if ( ! $token ) {
-			return new OAuth_Response( 'invalid_token', \__( 'Invalid access token', 'indieauth' ), 401 );
+			return add_deprecation_headers( new OAuth_Response( 'invalid_token', \__( 'Invalid access token', 'indieauth' ), 401 ) );
 		}
 		$token['active'] = 'true';
 		return add_deprecation_headers( \rest_ensure_response( $token ) );
@@ -208,7 +210,7 @@ class Token_Controller extends \WP_REST_Controller {
 						$this->delete_token( $params['token'] );
 						return add_deprecation_headers( \rest_ensure_response( \__( 'The Token Provided is No Longer Valid', 'indieauth' ) ) );
 					} else {
-						return new OAuth_Response( 'invalid_request', \__( 'Revoke is Missing Required Parameter token', 'indieauth' ), 400 );
+						return add_deprecation_headers( new OAuth_Response( 'invalid_request', \__( 'Revoke is Missing Required Parameter token', 'indieauth' ), 400 ) );
 					}
 				default:
 					$resp = new OAuth_Response( 'unsupported_action', \__( 'Unsupported Action', 'indieauth' ), 400 );

--- a/includes/rest/class-token-controller.php
+++ b/includes/rest/class-token-controller.php
@@ -16,6 +16,7 @@ use function IndieAuth\get_user_by_identifier;
 use function IndieAuth\pkce_verifier;
 use function IndieAuth\indieauth_validate_client_identifier;
 use function IndieAuth\rest_is_valid_url;
+use function IndieAuth\add_deprecation_headers;
 
 /**
  * IndieAuth Token Controller class.
@@ -174,10 +175,7 @@ class Token_Controller extends \WP_REST_Controller {
 			return new OAuth_Response( 'invalid_token', \__( 'Invalid access token', 'indieauth' ), 401 );
 		}
 		$token['active'] = 'true';
-		$response        = \rest_ensure_response( $token );
-		$response->header( 'Deprecation', 'true' );
-		$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"' );
-		return $response;
+		return add_deprecation_headers( \rest_ensure_response( $token ) );
 	}
 
 	/**
@@ -208,10 +206,7 @@ class Token_Controller extends \WP_REST_Controller {
 					);
 					if ( isset( $params['token'] ) ) {
 						$this->delete_token( $params['token'] );
-						$response = \rest_ensure_response( \__( 'The Token Provided is No Longer Valid', 'indieauth' ) );
-						$response->header( 'Deprecation', 'true' );
-						$response->header( 'Link', '<https://github.com/indieweb/wordpress-indieauth/issues/294>; rel="deprecation"' );
-						return $response;
+						return add_deprecation_headers( \rest_ensure_response( \__( 'The Token Provided is No Longer Valid', 'indieauth' ) ) );
 					} else {
 						return new OAuth_Response( 'invalid_request', \__( 'Revoke is Missing Required Parameter token', 'indieauth' ), 400 );
 					}

--- a/includes/rest/class-token-controller.php
+++ b/includes/rest/class-token-controller.php
@@ -16,6 +16,7 @@ use function IndieAuth\get_user_by_identifier;
 use function IndieAuth\pkce_verifier;
 use function IndieAuth\indieauth_validate_client_identifier;
 use function IndieAuth\rest_is_valid_url;
+use function IndieAuth\deprecation_notice;
 use function IndieAuth\add_deprecation_headers;
 
 /**
@@ -149,11 +150,6 @@ class Token_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response|OAuth_Response Response to return to the REST Server.
 	 */
 	public function get( $request ) {
-		\_doing_it_wrong(
-			'IndieAuth\Rest\Token_Controller::get',
-			\esc_html__( 'Token verification via a GET request to the token endpoint was removed from the IndieAuth specification. Use the introspection endpoint instead.', 'indieauth' ),
-			'indieauth 4.7.0'
-		);
 		$header = $request->get_header( 'Authorization' );
 		if ( ! $header && ! empty( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ) ) {
 			$header = \wp_unslash( $_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -176,6 +172,13 @@ class Token_Controller extends \WP_REST_Controller {
 		if ( ! $token ) {
 			return add_deprecation_headers( new OAuth_Response( 'invalid_token', \__( 'Invalid access token', 'indieauth' ), 401 ) );
 		}
+		// Only once the caller proved it holds a valid token, so an anonymous
+		// requester cannot fill the log by looping on this endpoint.
+		deprecation_notice(
+			'IndieAuth\Rest\Token_Controller::get',
+			\__( 'Token verification via a GET request to the token endpoint was removed from the IndieAuth specification. Use the introspection endpoint instead.', 'indieauth' ),
+			'indieauth 4.7.0'
+		);
 		$token['active'] = 'true';
 		return add_deprecation_headers( \rest_ensure_response( $token ) );
 	}
@@ -201,12 +204,12 @@ class Token_Controller extends \WP_REST_Controller {
 			switch ( $params['action'] ) {
 				// Revoke Token.
 				case 'revoke':
-					\_doing_it_wrong(
-						'IndieAuth\Rest\Token_Controller::revoke_action',
-						\esc_html__( 'Token revocation via action=revoke on the token endpoint was removed from the IndieAuth specification. Use the revocation endpoint instead.', 'indieauth' ),
-						'indieauth 4.7.0'
-					);
 					if ( isset( $params['token'] ) ) {
+						deprecation_notice(
+							'IndieAuth\Rest\Token_Controller::revoke_action',
+							\__( 'Token revocation via action=revoke on the token endpoint was removed from the IndieAuth specification. Use the revocation endpoint instead.', 'indieauth' ),
+							'indieauth 4.7.0'
+						);
 						$this->delete_token( $params['token'] );
 						return add_deprecation_headers( \rest_ensure_response( \__( 'The Token Provided is No Longer Valid', 'indieauth' ) ) );
 					} else {

--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,10 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
 
+### Unreleased
+
+* Deprecate legacy endpoint behaviors removed from the IndieAuth specification: `response_type=id` (and omitted `response_type`), token verification via GET on the token endpoint, and token revocation via `action=revoke`. These still work but now send a `Deprecation` header and log a `_doing_it_wrong()` notice; use the introspection and revocation endpoints instead.
+
 ### 4.6.0
 
 * Add FedCM (Federated Credential Management) support

--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,9 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 ### Unreleased
 
 * Deprecate legacy endpoint behaviors removed from the IndieAuth specification: `response_type=id` (and omitted `response_type`), token verification via GET on the token endpoint, and token revocation via `action=revoke`. These still work but now send a `Deprecation` header and log a `_doing_it_wrong()` notice; use the introspection and revocation endpoints instead.
+* Verify the `redirect_uri` of authorization requests: if its scheme, host or port differ from the `client_id`, it must match one of the redirect URLs published by the client (client metadata `redirect_uris`, `rel="redirect_uri"` link tags, or `Link` headers), as required by the IndieAuth specification.
+* Require authorization for the token introspection endpoint, as required by the IndieAuth specification. Any authentication that establishes a WordPress user is accepted. Filter `indieauth_introspection_auth_methods_supported` to `none` to restore unauthenticated introspection.
+* Fix client information discovery for HTML clients, which failed with a fatal error since the namespacing refactor.
 
 ### 4.6.0
 

--- a/tests/phpunit/tests/includes/class-test-client-discovery.php
+++ b/tests/phpunit/tests/includes/class-test-client-discovery.php
@@ -168,4 +168,133 @@ class Test_Client_Discovery extends WP_UnitTestCase {
 		$this->assertEquals( array( 'https://other.example.net/redirect' ), $discovery->get_redirect_uris() );
 		$this->assertEquals( 'Example App', $discovery->get_name() );
 	}
+
+	/**
+	 * A redirect_uri in the document body must not register a redirect target.
+	 *
+	 * The mf2 parser collects rels from anywhere in the document. On a client_id
+	 * page that renders user content (a bio, a comment, a directory listing),
+	 * anyone who can post markup could otherwise nominate where an authorization
+	 * code gets delivered.
+	 */
+	public function test_ignores_redirect_uri_in_document_body() {
+		$this->mock_http(
+			array( 'content-type' => 'text/html' ),
+			'<html><head><title>Example App</title></head><body>'
+			. '<a rel="redirect_uri" href="https://evil.example.net/cb">hi</a>'
+			. '<link rel="redirect_uri" href="https://evil.example.net/cb2" />'
+			. '</body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertSame( array(), $discovery->get_redirect_uris() );
+	}
+
+	// A redirect_uri published in the head is the supported way to do it.
+	public function test_accepts_redirect_uri_from_head() {
+		$this->mock_http(
+			array( 'content-type' => 'text/html' ),
+			'<html><head><title>Example App</title>'
+			. '<link rel="redirect_uri" href="https://other.example.net/cb" />'
+			. '</head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertContains( 'https://other.example.net/cb', $discovery->get_redirect_uris() );
+	}
+
+	// A comma inside a quoted parameter does not separate two links.
+	public function test_link_header_comma_inside_quoted_parameter() {
+		$this->mock_http(
+			array(
+				'content-type' => 'text/html',
+				'link'         => '<https://other.example.net/cb>; title="Foo, Bar"; rel="redirect_uri"',
+			),
+			'<html><head><title>Example App</title></head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertContains( 'https://other.example.net/cb', $discovery->get_redirect_uris() );
+	}
+
+	/**
+	 * A rel must never be read off a neighbouring link.
+	 *
+	 * Two links in one header value: only the second declares redirect_uri, so
+	 * only the second may be accepted.
+	 */
+	public function test_link_header_does_not_borrow_a_neighbours_rel() {
+		$this->mock_http(
+			array(
+				'content-type' => 'text/html',
+				// A repeated Link header arrives as an array, and one element may
+				// itself hold several comma-separated links.
+				'link'         => array(
+					'<https://third.example.net/x>; rel="me"',
+					'<https://evil.example.net/cb>; type="text/html", <https://other.example.net/cb>; rel="redirect_uri"',
+				),
+			),
+			'<html><head><title>Example App</title></head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertSame( array( 'https://other.example.net/cb' ), $discovery->get_redirect_uris() );
+	}
+
+	// An empty body must not crash the parser.
+	public function test_empty_body_does_not_crash() {
+		$this->mock_http( array( 'content-type' => 'text/html' ), '' );
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertSame( array(), $discovery->get_redirect_uris() );
+		$this->assertFalse( $discovery->is_discovered() );
+	}
+
+	// A non-string entry in the published JSON must not raise a warning.
+	public function test_ignores_non_string_json_redirect_uris() {
+		$this->mock_http(
+			array( 'content-type' => 'application/json' ),
+			wp_json_encode(
+				array(
+					'client_id'     => 'https://app.example.com/id',
+					'redirect_uris' => array( array( 'https://a.example/cb' ), 'https://b.example/cb', 42 ),
+				)
+			)
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/id' );
+		$discovery->discover();
+
+		$this->assertSame( array( 'https://b.example/cb' ), $discovery->get_redirect_uris() );
+	}
+
+	// XHTML is still HTML for discovery purposes.
+	public function test_parses_xhtml_content_type() {
+		$this->mock_http(
+			array( 'content-type' => 'application/xhtml+xml' ),
+			'<html><head><link rel="redirect_uri" href="https://other.example.net/cb" /></head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertContains( 'https://other.example.net/cb', $discovery->get_redirect_uris() );
+	}
+
+	// A failed fetch is not the same answer as "published nothing".
+	public function test_failed_fetch_is_not_reported_as_discovered() {
+		$this->http_mock = function () {
+			return new WP_Error( 'http_request_failed', 'Connection timed out' );
+		};
+		add_filter( 'pre_http_request', $this->http_mock, 10, 3 );
+
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertFalse( $discovery->is_discovered() );
+		$this->assertSame( array(), $discovery->get_redirect_uris() );
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-client-discovery.php
+++ b/tests/phpunit/tests/includes/class-test-client-discovery.php
@@ -85,6 +85,55 @@ class Test_Client_Discovery extends WP_UnitTestCase {
 		$this->assertSame( array(), $discovery->get_redirect_uris() );
 	}
 
+	public function link_header_rel_provider() {
+		return array(
+			'single rel'            => array( '<https://other.example.net/cb>; rel="redirect_uri"' ),
+			'rel listed first'      => array( '<https://other.example.net/cb>; rel="redirect_uri me"' ),
+			'rel listed last'       => array( '<https://other.example.net/cb>; rel="me redirect_uri"' ),
+			'rel in the middle'     => array( '<https://other.example.net/cb>; rel="me redirect_uri author"' ),
+			'unquoted rel'          => array( '<https://other.example.net/cb>; rel=redirect_uri' ),
+			'uppercased rel'        => array( '<https://other.example.net/cb>; rel="ME REDIRECT_URI"' ),
+			'other params first'    => array( '<https://other.example.net/cb>; type="text/html"; rel="me redirect_uri"' ),
+		);
+	}
+
+	/**
+	 * A Link header rel is a space-separated list, so redirect_uri does not
+	 * have to be the only or the first type listed.
+	 *
+	 * @dataProvider link_header_rel_provider
+	 *
+	 * @param string $link The Link header the client publishes.
+	 */
+	public function test_extracts_redirect_uris_from_multi_token_rel( $link ) {
+		$this->mock_http(
+			array(
+				'content-type' => 'text/html',
+				'link'         => $link,
+			),
+			'<html><head><title>Example App</title></head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertContains( 'https://other.example.net/cb', $discovery->get_redirect_uris() );
+	}
+
+	// A rel that merely contains the string must not match.
+	public function test_ignores_link_header_with_unrelated_rel() {
+		$this->mock_http(
+			array(
+				'content-type' => 'text/html',
+				'link'         => '<https://other.example.net/cb>; rel="my_redirect_uris"',
+			),
+			'<html><head><title>Example App</title></head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+
+		$this->assertSame( array(), $discovery->get_redirect_uris() );
+	}
+
 	public function content_type_provider() {
 		return array(
 			'plain media type'    => array( 'application/json' ),

--- a/tests/phpunit/tests/includes/class-test-client-discovery.php
+++ b/tests/phpunit/tests/includes/class-test-client-discovery.php
@@ -1,0 +1,86 @@
+<?php
+
+use IndieAuth\Client_Discovery;
+
+class Test_Client_Discovery extends WP_UnitTestCase {
+
+	public function tear_down() {
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
+	public function mock_http( $headers, $body ) {
+		add_filter(
+			'pre_http_request',
+			function () use ( $headers, $body ) {
+				return array(
+					'headers'  => $headers,
+					'body'     => $body,
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	public function test_extracts_redirect_uris_from_json_metadata() {
+		$this->mock_http(
+			array( 'content-type' => 'application/json' ),
+			wp_json_encode(
+				array(
+					'client_id'     => 'https://app.example.com/id',
+					'client_name'   => 'Example App',
+					'redirect_uris' => array( 'https://other.example.net/redirect', 'https://app.example.com/callback' ),
+				)
+			)
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/id' );
+		$discovery->discover();
+		$this->assertEquals(
+			array( 'https://other.example.net/redirect', 'https://app.example.com/callback' ),
+			$discovery->get_redirect_uris()
+		);
+	}
+
+	public function test_extracts_redirect_uris_from_html_links() {
+		$this->mock_http(
+			array( 'content-type' => 'text/html' ),
+			'<html><head><title>Example App</title><link rel="redirect_uri" href="/callback" /><link rel="redirect_uri" href="https://other.example.net/redirect" /></head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+		$this->assertEquals(
+			array( 'https://app.example.com/callback', 'https://other.example.net/redirect' ),
+			$discovery->get_redirect_uris()
+		);
+	}
+
+	public function test_extracts_redirect_uris_from_link_headers() {
+		$this->mock_http(
+			array(
+				'content-type' => 'text/html',
+				'link'         => '<https://other.example.net/cb>; rel="redirect_uri"',
+			),
+			'<html><head><title>Example App</title></head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+		$this->assertContains( 'https://other.example.net/cb', $discovery->get_redirect_uris() );
+	}
+
+	public function test_returns_empty_redirect_uris_when_none_published() {
+		$this->mock_http(
+			array( 'content-type' => 'text/html' ),
+			'<html><head><title>Example App</title></head><body></body></html>'
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/' );
+		$discovery->discover();
+		$this->assertSame( array(), $discovery->get_redirect_uris() );
+	}
+}

--- a/tests/phpunit/tests/includes/class-test-client-discovery.php
+++ b/tests/phpunit/tests/includes/class-test-client-discovery.php
@@ -4,29 +4,30 @@ use IndieAuth\Client_Discovery;
 
 class Test_Client_Discovery extends WP_UnitTestCase {
 
+	protected $http_mock;
+
 	public function tear_down() {
-		remove_all_filters( 'pre_http_request' );
+		if ( $this->http_mock ) {
+			remove_filter( 'pre_http_request', $this->http_mock, 10 );
+			$this->http_mock = null;
+		}
 		parent::tear_down();
 	}
 
 	public function mock_http( $headers, $body ) {
-		add_filter(
-			'pre_http_request',
-			function () use ( $headers, $body ) {
-				return array(
-					'headers'  => $headers,
-					'body'     => $body,
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'cookies'  => array(),
-					'filename' => null,
-				);
-			},
-			10,
-			3
-		);
+		$this->http_mock = function () use ( $headers, $body ) {
+			return array(
+				'headers'  => $headers,
+				'body'     => $body,
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $this->http_mock, 10, 3 );
 	}
 
 	public function test_extracts_redirect_uris_from_json_metadata() {
@@ -82,5 +83,40 @@ class Test_Client_Discovery extends WP_UnitTestCase {
 		$discovery = new Client_Discovery( 'https://app.example.com/' );
 		$discovery->discover();
 		$this->assertSame( array(), $discovery->get_redirect_uris() );
+	}
+
+	public function content_type_provider() {
+		return array(
+			'plain media type'    => array( 'application/json' ),
+			'with charset'        => array( 'application/json; charset=utf-8' ),
+			'with spacing'        => array( 'application/json ;charset=UTF-8' ),
+			'uppercased'          => array( 'Application/JSON; charset=utf-8' ),
+		);
+	}
+
+	/**
+	 * Most servers send parameters along with the media type, so the header
+	 * cannot be compared to "application/json" as-is.
+	 *
+	 * @dataProvider content_type_provider
+	 *
+	 * @param string $content_type The Content-Type header the client sends.
+	 */
+	public function test_parses_json_metadata_regardless_of_content_type_parameters( $content_type ) {
+		$this->mock_http(
+			array( 'content-type' => $content_type ),
+			wp_json_encode(
+				array(
+					'client_id'     => 'https://app.example.com/id',
+					'client_name'   => 'Example App',
+					'redirect_uris' => array( 'https://other.example.net/redirect' ),
+				)
+			)
+		);
+		$discovery = new Client_Discovery( 'https://app.example.com/id' );
+		$discovery->discover();
+
+		$this->assertEquals( array( 'https://other.example.net/redirect' ), $discovery->get_redirect_uris() );
+		$this->assertEquals( 'Example App', $discovery->get_name() );
 	}
 }

--- a/tests/phpunit/tests/includes/class-test-client-discovery.php
+++ b/tests/phpunit/tests/includes/class-test-client-discovery.php
@@ -297,4 +297,51 @@ class Test_Client_Discovery extends WP_UnitTestCase {
 		$this->assertFalse( $discovery->is_discovered() );
 		$this->assertSame( array(), $discovery->get_redirect_uris() );
 	}
+
+	public function no_fetch_host_provider() {
+		return array(
+			'ipv4 loopback'     => array( 'http://127.0.0.1:8080/' ),
+			'ipv4 loopback alt' => array( 'http://127.0.0.53/' ),
+			'ipv6 loopback'     => array( 'http://[::1]:8080/' ),
+			'localhost'         => array( 'http://localhost:8080/' ),
+			'uppercase host'    => array( 'http://LOCALHOST:8080/' ),
+			'public ip literal' => array( 'https://93.184.216.34/' ),
+		);
+	}
+
+	/**
+	 * Hosts that must never be fetched.
+	 *
+	 * A bare IP address serves no client information document, and the request
+	 * would be blocked or fail anyway. The old guard did the opposite of what its
+	 * comment said and fetched loopback addresses.
+	 *
+	 * @dataProvider no_fetch_host_provider
+	 *
+	 * @param string $client_id The client identifier.
+	 */
+	public function test_does_not_fetch_ip_or_localhost_client_ids( $client_id ) {
+		$fetched         = false;
+		$this->http_mock = function () use ( &$fetched ) {
+			$fetched = true;
+			return array(
+				'headers'  => array( 'content-type' => 'text/html' ),
+				'body'     => '<html><head><link rel="redirect_uri" href="https://evil.example.net/cb" /></head><body></body></html>',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $this->http_mock, 10, 3 );
+
+		$discovery = new Client_Discovery( $client_id );
+		$discovery->discover();
+
+		$this->assertFalse( $fetched, 'No request should be made for ' . $client_id );
+		$this->assertSame( array(), $discovery->get_redirect_uris() );
+		$this->assertFalse( $discovery->is_discovered() );
+	}
 }

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -125,4 +125,30 @@ class Test_Functions extends WP_UnitTestCase {
 		}
 	}
 
+	// Schemes and hostnames are case-insensitive, so equivalent origins must match.
+	public function test_same_origin_ignores_case() {
+		$this->assertTrue( IndieAuth\same_origin( 'https://example.com/a', 'HTTPS://Example.com/b' ) );
+		$this->assertTrue( IndieAuth\same_origin( 'HTTPS://EXAMPLE.COM', 'https://example.com' ) );
+
+		// The default port still has to be resolved from the uppercased scheme.
+		$this->assertTrue( IndieAuth\same_origin( 'HTTPS://Example.com', 'https://example.com:443' ) );
+		$this->assertFalse( IndieAuth\same_origin( 'HTTPS://Example.com', 'https://example.com:8443' ) );
+
+		// Paths are irrelevant, everything else must still differ.
+		$this->assertFalse( IndieAuth\same_origin( 'https://example.com', 'http://example.com' ) );
+		$this->assertFalse( IndieAuth\same_origin( 'https://example.com', 'https://evil.example.net' ) );
+	}
+
+	// The deprecation link is added next to an existing Link header, not on top of it.
+	public function test_add_deprecation_headers_keeps_existing_link() {
+		$response = new WP_REST_Response();
+		$response->header( 'Link', '<https://example.com/>; rel="canonical"' );
+
+		$headers = IndieAuth\add_deprecation_headers( $response )->get_headers();
+
+		$this->assertEquals( 'true', $headers['Deprecation'] );
+		$this->assertStringContainsString( 'rel="canonical"', $headers['Link'] );
+		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
+	}
+
 }

--- a/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
@@ -118,6 +118,60 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'Deprecation', $response->get_headers() );
 	}
 
+	/**
+	 * A redirect_uri on a different host than the client_id must be rejected
+	 * when the client does not publish it as one of its redirect URLs.
+	 */
+	public function test_rejects_cross_host_redirect_uri_not_published_by_client() {
+		$response = $this->create_get(
+			array(
+				'response_type'         => 'code',
+				'client_id'             => 'https://app.example.com',
+				'redirect_uri'          => 'https://evil.example.net/redirect',
+				'state'                 => '12345',
+				'code_challenge'        => 'OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo',
+				'code_challenge_method' => 'S256',
+			)
+		);
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'invalid_request', $data['error'], wp_json_encode( $data ) );
+	}
+
+	/**
+	 * A redirect_uri on a different host than the client_id must be accepted
+	 * when the client publishes it as one of its redirect URLs.
+	 */
+	public function test_allows_cross_host_redirect_uri_published_by_client() {
+		add_filter(
+			'pre_indieauth_client_redirect_uris',
+			function () {
+				return array( 'https://other.example.net/redirect' );
+			}
+		);
+		$response = $this->create_get(
+			array(
+				'response_type'         => 'code',
+				'client_id'             => 'https://app.example.com',
+				'redirect_uri'          => 'https://other.example.net/redirect',
+				'state'                 => '12345',
+				'code_challenge'        => 'OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo',
+				'code_challenge_method' => 'S256',
+			)
+		);
+		remove_all_filters( 'pre_indieauth_client_redirect_uris' );
+		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+	}
+
+	// Verifies the same scheme/host/port comparison directly.
+	public function test_verify_redirect_uri_same_origin() {
+		$controller = new IndieAuth\Rest\Authorization_Controller();
+		$this->assertTrue( $controller::verify_redirect_uri( 'https://app.example.com', 'https://app.example.com/callback' ) );
+		$this->assertFalse( $controller::verify_redirect_uri( 'https://app.example.com', 'http://app.example.com/callback' ) );
+		$this->assertFalse( $controller::verify_redirect_uri( 'https://app.example.com', 'https://app.example.com:8443/callback' ) );
+		$this->assertFalse( $controller::verify_redirect_uri( 'https://app.example.com', 'https://evil.example.net/callback' ) );
+	}
+
 	// Check For an Invalid Grant Type.
 	public function test_invalid_grant_type() {
 		$code = $this->set_auth_code();

--- a/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
@@ -60,42 +60,39 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Omitting response_type was only valid before IndieAuth 1.1 and must send deprecation signals.
+	 * Data provider for legacy response_type values.
 	 *
-	 * @expectedIncorrectUsage IndieAuth\Rest\Authorization_Controller::get
+	 * @return array[] The response_type to send, or null to omit the parameter.
 	 */
-	public function test_missing_response_type_sends_deprecation_signals() {
-		$response = $this->create_get(
-			array(
-				'client_id'             => 'https://app.example.com',
-				'redirect_uri'          => 'https://app.example.com/redirect',
-				'state'                 => '12345',
-				'code_challenge'        => 'OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo',
-				'code_challenge_method' => 'S256',
-			)
+	public function legacy_response_type_provider() {
+		return array(
+			'omitted response_type (pre IndieAuth 1.1)' => array( null ),
+			'removed response_type=id flow'             => array( 'id' ),
 		);
-		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
-		$headers = $response->get_headers();
-		$this->assertArrayHasKey( 'Deprecation', $headers );
-		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
 	}
 
 	/**
-	 * The response_type=id flow was removed from the IndieAuth specification and must send deprecation signals.
+	 * Legacy response_type requests must still work but send deprecation signals.
 	 *
+	 * @dataProvider legacy_response_type_provider
 	 * @expectedIncorrectUsage IndieAuth\Rest\Authorization_Controller::get
+	 *
+	 * @param string|null $response_type The response_type to send, or null to omit it.
 	 */
-	public function test_response_type_id_sends_deprecation_signals() {
-		$response = $this->create_get(
-			array(
-				'response_type'         => 'id',
-				'client_id'             => 'https://app.example.com',
-				'redirect_uri'          => 'https://app.example.com/redirect',
-				'state'                 => '12345',
-				'code_challenge'        => 'OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo',
-				'code_challenge_method' => 'S256',
-			)
+	public function test_legacy_response_type_sends_deprecation_signals( $response_type ) {
+		$params = array(
+			'client_id'             => 'https://app.example.com',
+			'redirect_uri'          => 'https://app.example.com/redirect',
+			'state'                 => '12345',
+			'code_challenge'        => 'OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo',
+			'code_challenge_method' => 'S256',
 		);
+		if ( null !== $response_type ) {
+			$params['response_type'] = $response_type;
+		}
+
+		$response = $this->create_get( $params );
+
 		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 		$headers = $response->get_headers();
 		$this->assertArrayHasKey( 'Deprecation', $headers );

--- a/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
@@ -159,6 +159,25 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 	}
 
+	/**
+	 * A native app on loopback may use any port.
+	 *
+	 * It listens on an ephemeral port it cannot know in advance and cannot
+	 * publish metadata at localhost, so the port is not part of its identity.
+	 * RFC 8252 section 7.3.
+	 */
+	public function test_verify_redirect_uri_allows_any_loopback_port() {
+		$controller = new IndieAuth\Rest\Authorization_Controller();
+
+		$this->assertTrue( $controller::verify_redirect_uri( 'http://127.0.0.1:8080/', 'http://127.0.0.1:53821/callback' ) );
+		$this->assertTrue( $controller::verify_redirect_uri( 'http://localhost:8080/', 'http://localhost:53821/callback' ) );
+		$this->assertTrue( $controller::verify_redirect_uri( 'http://[::1]:8080/', 'http://[::1]:53821/cb' ) );
+
+		// A loopback client still may not redirect off the loopback interface.
+		$this->assertFalse( $controller::verify_redirect_uri( 'http://127.0.0.1:8080/', 'https://evil.example.net/cb' ) );
+		$this->assertFalse( $controller::verify_redirect_uri( 'https://app.example.com', 'http://127.0.0.1:53821/cb' ) );
+	}
+
 	// Verifies the same scheme/host/port comparison directly.
 	public function test_verify_redirect_uri_same_origin() {
 		$controller = new IndieAuth\Rest\Authorization_Controller();

--- a/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
@@ -52,6 +52,72 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 	}
 
 
+	// Authorization Request via GET.
+	public function create_get( $params = array() ) {
+		$request = new WP_REST_Request( 'GET', '/indieauth/1.0/auth' );
+		$request->set_query_params( $params );
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Omitting response_type was only valid before IndieAuth 1.1 and must send deprecation signals.
+	 *
+	 * @expectedIncorrectUsage IndieAuth\Rest\Authorization_Controller::get
+	 */
+	public function test_missing_response_type_sends_deprecation_signals() {
+		$response = $this->create_get(
+			array(
+				'client_id'             => 'https://app.example.com',
+				'redirect_uri'          => 'https://app.example.com/redirect',
+				'state'                 => '12345',
+				'code_challenge'        => 'OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo',
+				'code_challenge_method' => 'S256',
+			)
+		);
+		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
+	}
+
+	/**
+	 * The response_type=id flow was removed from the IndieAuth specification and must send deprecation signals.
+	 *
+	 * @expectedIncorrectUsage IndieAuth\Rest\Authorization_Controller::get
+	 */
+	public function test_response_type_id_sends_deprecation_signals() {
+		$response = $this->create_get(
+			array(
+				'response_type'         => 'id',
+				'client_id'             => 'https://app.example.com',
+				'redirect_uri'          => 'https://app.example.com/redirect',
+				'state'                 => '12345',
+				'code_challenge'        => 'OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo',
+				'code_challenge_method' => 'S256',
+			)
+		);
+		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
+	}
+
+	// A spec-conforming request must not carry deprecation signals.
+	public function test_response_type_code_sends_no_deprecation_signals() {
+		$response = $this->create_get(
+			array(
+				'response_type'         => 'code',
+				'client_id'             => 'https://app.example.com',
+				'redirect_uri'          => 'https://app.example.com/redirect',
+				'state'                 => '12345',
+				'code_challenge'        => 'OfYAxt8zU2dAPDWQxTAUIteRzMsoj9QBdMIVEDOErUo',
+				'code_challenge_method' => 'S256',
+			)
+		);
+		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$this->assertArrayNotHasKey( 'Deprecation', $response->get_headers() );
+	}
+
 	// Check For an Invalid Grant Type.
 	public function test_invalid_grant_type() {
 		$code = $this->set_auth_code();

--- a/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
@@ -96,6 +96,7 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 		$headers = $response->get_headers();
 		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertArrayHasKey( 'Link', $headers );
 		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
 	}
 
@@ -140,12 +141,10 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 	 * when the client publishes it as one of its redirect URLs.
 	 */
 	public function test_allows_cross_host_redirect_uri_published_by_client() {
-		add_filter(
-			'pre_indieauth_client_redirect_uris',
-			function () {
-				return array( 'https://other.example.net/redirect' );
-			}
-		);
+		$published_uris = function () {
+			return array( 'https://other.example.net/redirect' );
+		};
+		add_filter( 'pre_indieauth_client_redirect_uris', $published_uris );
 		$response = $this->create_get(
 			array(
 				'response_type'         => 'code',
@@ -156,7 +155,7 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 				'code_challenge_method' => 'S256',
 			)
 		);
-		remove_all_filters( 'pre_indieauth_client_redirect_uris' );
+		remove_filter( 'pre_indieauth_client_redirect_uris', $published_uris );
 		$this->assertEquals( 302, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 	}
 

--- a/tests/phpunit/tests/includes/rest/class-test-introspection-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-introspection-controller.php
@@ -128,19 +128,17 @@ class Test_Introspection_Controller extends WP_UnitTestCase {
 
 	// Unauthenticated introspection can be re-enabled by filtering the supported auth methods to none.
 	public function test_token_introspection_unauthenticated_when_none_allowed() {
-		add_filter(
-			'indieauth_introspection_auth_methods_supported',
-			function () {
-				return array( 'none' );
-			}
-		);
+		$allow_none = function () {
+			return array( 'none' );
+		};
+		add_filter( 'indieauth_introspection_auth_methods_supported', $allow_none );
 		$token    = self::set_access_token();
 		$response = $this->create_form( 'POST',
 				array(
 					'token' => $token
 				)
 			);
-		remove_all_filters( 'indieauth_introspection_auth_methods_supported' );
+		remove_filter( 'indieauth_introspection_auth_methods_supported', $allow_none );
 		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-introspection-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-introspection-controller.php
@@ -126,19 +126,76 @@ class Test_Introspection_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 401, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 	}
 
-	// Unauthenticated introspection can be re-enabled by filtering the supported auth methods to none.
-	public function test_token_introspection_unauthenticated_when_none_allowed() {
-		$allow_none = function () {
-			return array( 'none' );
-		};
-		add_filter( 'indieauth_introspection_auth_methods_supported', $allow_none );
+	// Unauthenticated introspection can be re-enabled with the dedicated filter.
+	public function test_token_introspection_unauthenticated_when_explicitly_allowed() {
+		$allow = '__return_true';
+		add_filter( 'indieauth_allow_unauthenticated_introspection', $allow );
 		$token    = self::set_access_token();
 		$response = $this->create_form( 'POST',
 				array(
 					'token' => $token
 				)
 			);
-		remove_filter( 'indieauth_introspection_auth_methods_supported', $allow_none );
+		remove_filter( 'indieauth_allow_unauthenticated_introspection', $allow );
 		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+	}
+
+	/**
+	 * Advertising 'none' in the metadata must not open the endpoint.
+	 *
+	 * That filter says what the server advertises. Letting it decide access
+	 * means a site documenting its capabilities silently exposes every token.
+	 */
+	public function test_metadata_filter_does_not_grant_access() {
+		$advertise_none = function () {
+			return array( 'none' );
+		};
+		add_filter( 'indieauth_introspection_auth_methods_supported', $advertise_none );
+		$token    = self::set_access_token();
+		$response = $this->create_form( 'POST',
+				array(
+					'token' => $token
+				)
+			);
+		remove_filter( 'indieauth_introspection_auth_methods_supported', $advertise_none );
+		$this->assertEquals( 401, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+	}
+
+	/**
+	 * A logged-in user must not be able to read another user's token.
+	 *
+	 * The response is the same as for a token that does not exist, so the
+	 * endpoint cannot be used to find out which token values are real.
+	 */
+	public function test_token_introspection_hides_another_users_token() {
+		$token = self::set_access_token();
+
+		wp_set_current_user( self::$subscriber_id );
+		$response = $this->create_form( 'POST',
+				array(
+					'token' => $token
+				)
+			);
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertFalse( $data['active'] );
+		$this->assertArrayNotHasKey( 'client_id', $data );
+	}
+
+	// The owner can still read their own token.
+	public function test_token_introspection_allows_the_owner() {
+		$token = self::set_access_token();
+
+		wp_set_current_user( self::$author_id );
+		$response = $this->create_form( 'POST',
+				array(
+					'token' => $token
+				)
+			);
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'true', $data['active'] );
 	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-introspection-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-introspection-controller.php
@@ -102,8 +102,9 @@ class Test_Introspection_Controller extends WP_UnitTestCase {
 	// Sets a token and verifies it using Access Token Introspection
 	public function test_token_introspection() {
 		$token   = self::set_access_token();
+		wp_set_current_user( self::$author_id );
 		$response = $this->create_form( 'POST',
-				array( 
+				array(
 					'token' => $token
 				)
 			);
@@ -112,5 +113,34 @@ class Test_Introspection_Controller extends WP_UnitTestCase {
 		unset( $response_token['user'] );
 		unset( $response_token['active'] );
 		$this->assertEquals( static::$test_token, $response_token );
+	}
+
+	// The introspection endpoint MUST require some form of authorization.
+	public function test_token_introspection_requires_authorization() {
+		$token    = self::set_access_token();
+		$response = $this->create_form( 'POST',
+				array(
+					'token' => $token
+				)
+			);
+		$this->assertEquals( 401, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+	}
+
+	// Unauthenticated introspection can be re-enabled by filtering the supported auth methods to none.
+	public function test_token_introspection_unauthenticated_when_none_allowed() {
+		add_filter(
+			'indieauth_introspection_auth_methods_supported',
+			function () {
+				return array( 'none' );
+			}
+		);
+		$token    = self::set_access_token();
+		$response = $this->create_form( 'POST',
+				array(
+					'token' => $token
+				)
+			);
+		remove_all_filters( 'indieauth_introspection_auth_methods_supported' );
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-token-controller.php
@@ -256,7 +256,11 @@ class Test_Token_Controller extends WP_UnitTestCase {
 	}
 
 
-	// Sets a token and verifies it using Access Token Verification
+	/**
+	 * Sets a token and verifies it using Access Token Verification.
+	 *
+	 * @expectedIncorrectUsage IndieAuth\Rest\Token_Controller::get
+	 */
 	public function test_token_verification() {
 		$token   = self::set_access_token();
 		$response = $this->create_form( 
@@ -270,6 +274,26 @@ class Test_Token_Controller extends WP_UnitTestCase {
 		unset( $response_token['user'] );
 		unset( $response_token['active'] );
 		$this->assertEquals( static::$test_token, $response_token );
+	}
+
+	/**
+	 * Token verification via GET is no longer part of the spec and must send deprecation signals.
+	 *
+	 * @expectedIncorrectUsage IndieAuth\Rest\Token_Controller::get
+	 */
+	public function test_token_verification_sends_deprecation_signals() {
+		$token    = self::set_access_token();
+		$response = $this->create_form(
+				'GET',
+				array(),
+				array(
+					'Authorization' => 'Bearer ' . $token
+				)
+			);
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
 	}
 
 	// To Make Sure that Revokation Works, Test the Helper Function First.
@@ -296,7 +320,31 @@ class Test_Token_Controller extends WP_UnitTestCase {
 
 
 
-	// Sets a token, revokes it, then verifies it is not there.
+	/**
+	 * Token revocation via action=revoke is no longer part of the spec and must send deprecation signals.
+	 *
+	 * @expectedIncorrectUsage IndieAuth\Rest\Token_Controller::revoke_action
+	 */
+	public function test_token_revocation_action_sends_deprecation_signals() {
+		$token    = self::set_access_token();
+		$response = $this->create_form( 'POST',
+			array(
+				'action' => 'revoke',
+				'token'  => $token,
+			)
+		);
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
+		$this->assertFalse( self::get_access_token( $token ) );
+	}
+
+	/**
+	 * Sets a token, revokes it, then verifies it is not there.
+	 *
+	 * @expectedIncorrectUsage IndieAuth\Rest\Token_Controller::revoke_action
+	 */
 	public function test_token_revokation() {
 		$token   = self::set_access_token();
 		$response = $this->create_form( 'POST', 

--- a/tests/phpunit/tests/includes/rest/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-token-controller.php
@@ -293,6 +293,22 @@ class Test_Token_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 		$headers = $response->get_headers();
 		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertArrayHasKey( 'Link', $headers );
+		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
+	}
+
+	/**
+	 * The deprecation signals belong on the error responses too, not only on success.
+	 *
+	 * @expectedIncorrectUsage IndieAuth\Rest\Token_Controller::get
+	 */
+	public function test_token_verification_sends_deprecation_signals_on_error() {
+		$response = $this->create_form( 'GET' );
+
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertArrayHasKey( 'Link', $headers );
 		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
 	}
 
@@ -336,8 +352,28 @@ class Test_Token_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 		$headers = $response->get_headers();
 		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertArrayHasKey( 'Link', $headers );
 		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
 		$this->assertFalse( self::get_access_token( $token ) );
+	}
+
+	/**
+	 * A revoke call without a token is still a deprecated call and must say so.
+	 *
+	 * @expectedIncorrectUsage IndieAuth\Rest\Token_Controller::revoke_action
+	 */
+	public function test_token_revocation_action_sends_deprecation_signals_on_error() {
+		$response = $this->create_form( 'POST',
+			array(
+				'action' => 'revoke',
+			)
+		);
+
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$headers = $response->get_headers();
+		$this->assertArrayHasKey( 'Deprecation', $headers );
+		$this->assertArrayHasKey( 'Link', $headers );
+		$this->assertStringContainsString( 'rel="deprecation"', $headers['Link'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-token-controller.php
@@ -298,9 +298,10 @@ class Test_Token_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The deprecation signals belong on the error responses too, not only on success.
+	 * The deprecation headers belong on the error responses too, not only on success.
 	 *
-	 * @expectedIncorrectUsage IndieAuth\Rest\Token_Controller::get
+	 * The _doing_it_wrong() notice is deliberately not emitted here: this path is
+	 * reachable without any credential, so emitting would let anyone fill the log.
 	 */
 	public function test_token_verification_sends_deprecation_signals_on_error() {
 		$response = $this->create_form( 'GET' );
@@ -360,7 +361,7 @@ class Test_Token_Controller extends WP_UnitTestCase {
 	/**
 	 * A revoke call without a token is still a deprecated call and must say so.
 	 *
-	 * @expectedIncorrectUsage IndieAuth\Rest\Token_Controller::revoke_action
+	 * Headers only, for the same reason as the token verification error path.
 	 */
 	public function test_token_revocation_action_sends_deprecation_signals_on_error() {
 		$response = $this->create_form( 'POST',


### PR DESCRIPTION
Closes #294.

## Audit result

Reviewed the code against the current IndieAuth living spec. Already implemented: `iss` parameter, metadata endpoint, introspection + revocation + userinfo endpoints, refresh tokens, optional `me`, JSON client metadata with h-app fallback. Non-PKCE clients are already rejected outright (stricter than spec). Revocation correctly advertises `none` auth per spec.

## Deprecations (legacy behaviors removed from the spec — still work, now warn)

| Legacy behavior | Replacement |
| --- | --- |
| `response_type=id` / omitted `response_type` | `response_type=code` |
| Token verification via GET on the token endpoint | Introspection endpoint |
| Token revocation via `action=revoke` | Revocation endpoint |

Each emits a `_doing_it_wrong()` notice (logged with `WP_DEBUG`, hookable via `doing_it_wrong_run`) and sends `Deprecation: true` + `Link: <…>; rel="deprecation"` headers. Behavior is otherwise unchanged; custom actions via `indieauth_token_action_handler` are untouched.

## New spec requirements implemented

- **`redirect_uri` verification**: when scheme/host/port differ from `client_id`, the `redirect_uri` must match a redirect URL published by the client (client metadata `redirect_uris`, `rel="redirect_uri"` link tags, or `Link` headers). Enforced at the REST authorization endpoint and the consent form handler. Filters: `pre_indieauth_client_redirect_uris` (short-circuit/cache), `indieauth_verify_redirect_uri` (override).
- **Introspection authorization**: the spec says the endpoint "MUST require some form of authorization". Default now requires an authenticated WordPress user (IndieAuth bearer token, application password, or session) and advertises `Bearer`; filter `indieauth_introspection_auth_methods_supported` to `none` to restore the old behavior. ⚠️ Breaking for unauthenticated introspection consumers.

## Bug fixes (found by the new Client_Discovery tests)

- `Mf2\parse()` inside `namespace IndieAuth` resolved to `IndieAuth\Mf2\parse()` — fatal for every HTML client since the namespacing refactor.
- The `DOMDocument` fallback passed HTML to the constructor (which takes an XML version string) instead of `loadHTML()`, and crashed on missing titles/icons.

## Testing

TDD throughout — every test was watched failing first. 81 tests / 210 assertions pass on PHP 7.4 and 8.3 (wp-env); phpcs clean.