### PR TITLE
Fix fatal error from undefined function __e()

### DIFF
--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -8,8 +8,8 @@ login_header(
 );
 $user_website = esc_url( get_url_from_user( $current_user->ID ) );
 if ( ! $user_website ) {
-	esc_html_e( 'The application cannot sign you in as WordPress cannot determine the current user', 'indieauth' );
-	login_footer();
+	\esc_html_e( 'The application cannot sign you in as WordPress cannot determine the current user', 'indieauth' );
+	\login_footer();
 	exit;
 }
 

--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -8,7 +8,8 @@ login_header(
 );
 $user_website = esc_url( get_url_from_user( $current_user->ID ) );
 if ( ! $user_website ) {
-	__e( 'The application cannot sign you in as WordPress cannot determine the current user', 'indieauth' );
+	esc_html_e( 'The application cannot sign you in as WordPress cannot determine the current user', 'indieauth' );
+	login_footer();
 	exit;
 }
 


### PR DESCRIPTION
## Summary

Fixes #313

`templates/indieauth-authenticate-form.php` called `__e()` on its error path — a function that does not exist in WordPress (typo of `esc_html_e()`, introduced in d04401a). Whenever the authorization form was rendered and `get_url_from_user()` returned no URL for the current user (e.g. the reporter's logged-out scenario), the page died with:

```
PHP Fatal error: Uncaught Error: Call to undefined function __e()
```

## Changes

- Replace `__e()` with `esc_html_e()` so the intended error message is actually displayed.
- Call `login_footer()` before `exit` so the login page HTML is properly closed, matching the other templates.

## Testing

- `php -l` and `phpcs` pass on the template.
- Verified no other `__e(` calls exist in the codebase.