### PR TITLE
Call the function directly as the global variable is not set in this context

### DIFF
--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -6,7 +6,7 @@ login_header(
 	'',
 	$login_errors
 );
-$user_website = esc_url( get_url_from_user( $current_user->ID ) );
+$user_website = esc_url( get_url_from_user( wp_get_current_user()?->ID ) );
 if ( ! $user_website ) {
 	__e( 'The application cannot sign you in as WordPress cannot determine the current user', 'indieauth' );
 	exit;


### PR DESCRIPTION
This is a pull request into the branch for #313 since they happen in the same file at the same place.

`$current_user` isn't set globally in the `wp-login.php` but the function can return it just fine.