### PR TITLE
Bump version to 4.7.0

### DIFF
--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 4.6.0
+ * Version: 4.7.0
  * Requires at least: 6.2
  * Requires PHP: 7.4
  * Requires CP: 2.1
@@ -19,7 +19,7 @@
 
 namespace IndieAuth;
 
-\define( 'INDIEAUTH_PLUGIN_VERSION', '4.5.5' );
+\define( 'INDIEAUTH_PLUGIN_VERSION', '4.7.0' );
 \define( 'INDIEAUTH_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'INDIEAUTH_PLUGIN_BASENAME', \plugin_basename( __FILE__ ) );
 \define( 'INDIEAUTH_PLUGIN_FILE', INDIEAUTH_PLUGIN_DIR . \basename( __FILE__ ) );

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 - Donate link: https://opencollective.com/indieweb
 - Tags: IndieAuth, IndieWeb, login, oauth
 - Tested up to: 7.0
-- Stable tag: 4.6.0
+- Stable tag: 4.7.0
 - Requires PHP: 7.4
 - License: MIT
 - License URI: https://opensource.org/licenses/MIT
@@ -188,6 +188,11 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 ## Changelog
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
+
+### 4.7.0
+
+* Fix fatal error on the authorization form when the current user cannot be determined
+* Modernize codebase with namespaces, an autoloader and a new folder structure (all global functions keep working)
 
 ### 4.6.0
 

--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,7 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 ### 4.7.0
 
 * Fix fatal error on the authorization form when the current user cannot be determined
+* Fix user detection on the authorization form by calling `wp_get_current_user()` instead of relying on the global variable
 * Modernize codebase with namespaces, an autoloader and a new folder structure (all global functions keep working)
 
 ### 4.6.0

--- a/templates/indieauth-authenticate-form.php
+++ b/templates/indieauth-authenticate-form.php
@@ -6,7 +6,8 @@ login_header(
 	'',
 	$login_errors
 );
-$user_website = esc_url( get_url_from_user( wp_get_current_user()?->ID ) );
+$current_user = wp_get_current_user();
+$user_website = esc_url( get_url_from_user( $current_user->ID ) );
 if ( ! $user_website ) {
 	\esc_html_e( 'The application cannot sign you in as WordPress cannot determine the current user', 'indieauth' );
 	\login_footer();


### PR DESCRIPTION
## Summary

Prepare the 4.7.0 release:

- Bump the plugin version to **4.7.0** in `indieauth.php` and the stable tag in `readme.md`
- Sync `INDIEAUTH_PLUGIN_VERSION`, which was still set to `4.5.5` (missed in the 4.6.0 bump)
- Add the 4.7.0 changelog entries
- Fix PHP 7.4 compatibility: the nullsafe operator (`?->`) introduced in #317 is PHP 8.0 syntax and causes a parse error on PHP 7.4. Assign a local `$current_user` from `wp_get_current_user()` instead, which also fixes the remaining usages of the unset global in the template.

## Changelog

* Fix fatal error on the authorization form when the current user cannot be determined (#314)
* Fix user detection on the authorization form by calling `wp_get_current_user()` instead of relying on the global variable (#317)
* Modernize codebase with namespaces, an autoloader and a new folder structure (#306)

## Release steps

After merging, tag `trunk` as `4.7.0` and push the tag — the deploy workflow will publish to WordPress.org.