### PR TITLE
Restore pre-4.7.0 global class names as backward-compat aliases

### DIFF
--- a/includes/compat.php
+++ b/includes/compat.php
@@ -51,9 +51,13 @@ const COMPAT_CLASS_MAP = array(
 
 \spl_autoload_register(
 	function ( $class_name ) {
-		if ( isset( COMPAT_CLASS_MAP[ $class_name ] ) ) {
-			\class_alias( COMPAT_CLASS_MAP[ $class_name ], $class_name );
+		if ( ! isset( COMPAT_CLASS_MAP[ $class_name ] ) ) {
+			return;
 		}
+
+		\_deprecated_class( $class_name, '4.7.0', COMPAT_CLASS_MAP[ $class_name ] );
+
+		\class_alias( COMPAT_CLASS_MAP[ $class_name ], $class_name );
 	}
 );
 

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -3,8 +3,8 @@
  * Backward compatibility aliases for pre-4.7.0 class names.
  *
  * Version 4.7.0 moved all classes into the `IndieAuth` namespace. Third-party
- * plugins (e.g. Micropub) check for the old global class names, so they are
- * kept available as aliases.
+ * plugins (e.g. Micropub) check for old global class names, so compatible
+ * replacements are kept available as aliases.
  *
  * @package IndieAuth
  */
@@ -14,39 +14,33 @@ namespace IndieAuth;
 /**
  * Map of pre-4.7.0 global class names to their namespaced replacements.
  *
- * The abstract `IndieAuth_Endpoint` class is the only pre-4.7.0 class without
- * an alias; its functionality moved to the `IndieAuth\Rest\Token_Management`
- * trait, which a class alias cannot represent.
+ * `IndieAuth_Endpoint` cannot be aliased because its functionality moved to a
+ * trait. The authorization, introspection, metadata, revocation, ticket, token,
+ * and userinfo endpoint classes are also excluded: their legacy `get_endpoint()`
+ * methods were static, while the replacement controller methods are not.
  */
 const COMPAT_CLASS_MAP = array(
-	'External_Token_Page'              => Ticket\External_Token_Page::class,
-	'External_Token_Table'             => WP_Admin\External_Token_List_Table::class,
-	'External_User_Token'              => Ticket\External_User_Token::class,
-	'IndieAuth_Admin'                  => WP_Admin\Admin::class,
-	'IndieAuth_Authorization_Endpoint' => Rest\Authorization_Controller::class,
-	'IndieAuth_Authorize'              => Authorize::class,
-	'IndieAuth_Client'                 => Client::class,
-	'IndieAuth_Client_Discovery'       => Client_Discovery::class,
-	'IndieAuth_Client_Taxonomy'        => Client_Taxonomy::class,
-	'IndieAuth_Debug'                  => Debug::class,
-	'IndieAuth_FedCM_Endpoint'         => Rest\FedCM_Controller::class,
-	'IndieAuth_Introspection_Endpoint' => Rest\Introspection_Controller::class,
-	'IndieAuth_Metadata_Endpoint'      => Rest\Metadata_Controller::class,
-	'IndieAuth_Plugin'                 => IndieAuth::class,
-	'IndieAuth_Revocation_Endpoint'    => Rest\Revocation_Controller::class,
-	'IndieAuth_Scope'                  => Scope\Scope::class,
-	'IndieAuth_Scopes'                 => Scopes::class,
-	'IndieAuth_Ticket_Endpoint'        => Rest\Ticket_Controller::class,
-	'IndieAuth_Token_Endpoint'         => Rest\Token_Controller::class,
-	'IndieAuth_Token_UI'               => WP_Admin\Token_UI::class,
-	'IndieAuth_Userinfo_Endpoint'      => Rest\Userinfo_Controller::class,
-	'IndieAuth_WebIdentity'            => WebIdentity::class,
-	'Token_Generic'                    => Token\Generic::class,
-	'Token_List_Table'                 => WP_Admin\Token_List_Table::class,
-	'Token_Transient'                  => Token\Transient::class,
-	'Token_User'                       => Token\User::class,
-	'WP_OAuth_Response'                => OAuth_Response::class,
-	'Web_Signin'                       => Web_Signin::class,
+	'External_Token_Page'        => Ticket\External_Token_Page::class,
+	'External_Token_Table'       => WP_Admin\External_Token_List_Table::class,
+	'External_User_Token'        => Ticket\External_User_Token::class,
+	'IndieAuth_Admin'            => WP_Admin\Admin::class,
+	'IndieAuth_Authorize'        => Authorize::class,
+	'IndieAuth_Client'           => Client::class,
+	'IndieAuth_Client_Discovery' => Client_Discovery::class,
+	'IndieAuth_Client_Taxonomy'  => Client_Taxonomy::class,
+	'IndieAuth_Debug'            => Debug::class,
+	'IndieAuth_FedCM_Endpoint'   => Rest\FedCM_Controller::class,
+	'IndieAuth_Plugin'           => IndieAuth::class,
+	'IndieAuth_Scope'            => Scope\Scope::class,
+	'IndieAuth_Scopes'           => Scopes::class,
+	'IndieAuth_Token_UI'         => WP_Admin\Token_UI::class,
+	'IndieAuth_WebIdentity'      => WebIdentity::class,
+	'Token_Generic'              => Token\Generic::class,
+	'Token_List_Table'           => WP_Admin\Token_List_Table::class,
+	'Token_Transient'            => Token\Transient::class,
+	'Token_User'                 => Token\User::class,
+	'WP_OAuth_Response'          => OAuth_Response::class,
+	'Web_Signin'                 => Web_Signin::class,
 );
 
 \spl_autoload_register(

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -67,6 +67,10 @@ const COMPAT_CLASS_MAP = array(
 /*
  * Micropub gates its whole initialization on `class_exists( 'IndieAuth_Plugin' )`,
  * and other plugins may check with autoloading disabled, so this alias is
- * registered eagerly instead of through the autoloader above.
+ * registered eagerly instead of through the autoloader above. Guarded, because
+ * sites may have defined the class themselves as a workaround for the 4.7.0
+ * breakage, and `class_alias()` warns when the name is already taken.
  */
-\class_alias( IndieAuth::class, 'IndieAuth_Plugin' );
+if ( ! \class_exists( 'IndieAuth_Plugin', false ) ) {
+	\class_alias( IndieAuth::class, 'IndieAuth_Plugin' );
+}

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Backward compatibility aliases for pre-4.7.0 class names.
+ *
+ * Version 4.7.0 moved all classes into the `IndieAuth` namespace. Third-party
+ * plugins (e.g. Micropub) check for the old global class names, so they are
+ * kept available as aliases.
+ *
+ * @package IndieAuth
+ */
+
+namespace IndieAuth;
+
+/**
+ * Map of pre-4.7.0 global class names to their namespaced replacements.
+ *
+ * The abstract `IndieAuth_Endpoint` class is the only pre-4.7.0 class without
+ * an alias; its functionality moved to the `IndieAuth\Rest\Token_Management`
+ * trait, which a class alias cannot represent.
+ */
+const COMPAT_CLASS_MAP = array(
+	'External_Token_Page'              => Ticket\External_Token_Page::class,
+	'External_Token_Table'             => WP_Admin\External_Token_List_Table::class,
+	'External_User_Token'              => Ticket\External_User_Token::class,
+	'IndieAuth_Admin'                  => WP_Admin\Admin::class,
+	'IndieAuth_Authorization_Endpoint' => Rest\Authorization_Controller::class,
+	'IndieAuth_Authorize'              => Authorize::class,
+	'IndieAuth_Client'                 => Client::class,
+	'IndieAuth_Client_Discovery'       => Client_Discovery::class,
+	'IndieAuth_Client_Taxonomy'        => Client_Taxonomy::class,
+	'IndieAuth_Debug'                  => Debug::class,
+	'IndieAuth_FedCM_Endpoint'         => Rest\FedCM_Controller::class,
+	'IndieAuth_Introspection_Endpoint' => Rest\Introspection_Controller::class,
+	'IndieAuth_Metadata_Endpoint'      => Rest\Metadata_Controller::class,
+	'IndieAuth_Plugin'                 => IndieAuth::class,
+	'IndieAuth_Revocation_Endpoint'    => Rest\Revocation_Controller::class,
+	'IndieAuth_Scope'                  => Scope\Scope::class,
+	'IndieAuth_Scopes'                 => Scopes::class,
+	'IndieAuth_Ticket_Endpoint'        => Rest\Ticket_Controller::class,
+	'IndieAuth_Token_Endpoint'         => Rest\Token_Controller::class,
+	'IndieAuth_Token_UI'               => WP_Admin\Token_UI::class,
+	'IndieAuth_Userinfo_Endpoint'      => Rest\Userinfo_Controller::class,
+	'IndieAuth_WebIdentity'            => WebIdentity::class,
+	'Token_Generic'                    => Token\Generic::class,
+	'Token_List_Table'                 => WP_Admin\Token_List_Table::class,
+	'Token_Transient'                  => Token\Transient::class,
+	'Token_User'                       => Token\User::class,
+	'WP_OAuth_Response'                => OAuth_Response::class,
+	'Web_Signin'                       => Web_Signin::class,
+);
+
+\spl_autoload_register(
+	function ( $class_name ) {
+		if ( isset( COMPAT_CLASS_MAP[ $class_name ] ) ) {
+			\class_alias( COMPAT_CLASS_MAP[ $class_name ], $class_name );
+		}
+	}
+);
+
+/*
+ * Micropub gates its whole initialization on `class_exists( 'IndieAuth_Plugin' )`,
+ * and other plugins may check with autoloading disabled, so this alias is
+ * registered eagerly instead of through the autoloader above.
+ */
+\class_alias( IndieAuth::class, 'IndieAuth_Plugin' );

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -55,7 +55,10 @@ const COMPAT_CLASS_MAP = array(
 			return;
 		}
 
-		\_deprecated_class( $class_name, '4.7.0', COMPAT_CLASS_MAP[ $class_name ] );
+		// `_deprecated_class()` requires WordPress 6.4.
+		if ( \function_exists( '_deprecated_class' ) ) {
+			\_deprecated_class( $class_name, '4.7.0', COMPAT_CLASS_MAP[ $class_name ] );
+		}
 
 		\class_alias( COMPAT_CLASS_MAP[ $class_name ], $class_name );
 	}

--- a/indieauth.php
+++ b/indieauth.php
@@ -3,7 +3,7 @@
  * Plugin Name: IndieAuth
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
- * Version: 4.7.0
+ * Version: 4.7.1
  * Requires at least: 6.2
  * Requires PHP: 7.4
  * Requires CP: 2.1
@@ -19,7 +19,7 @@
 
 namespace IndieAuth;
 
-\define( 'INDIEAUTH_PLUGIN_VERSION', '4.7.0' );
+\define( 'INDIEAUTH_PLUGIN_VERSION', '4.7.1' );
 \define( 'INDIEAUTH_PLUGIN_DIR', \plugin_dir_path( __FILE__ ) );
 \define( 'INDIEAUTH_PLUGIN_BASENAME', \plugin_basename( __FILE__ ) );
 \define( 'INDIEAUTH_PLUGIN_FILE', INDIEAUTH_PLUGIN_DIR . \basename( __FILE__ ) );

--- a/indieauth.php
+++ b/indieauth.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
  * Version: 4.7.0
- * Requires at least: 6.4
+ * Requires at least: 6.2
  * Requires PHP: 7.4
  * Requires CP: 2.1
  * Author: IndieWeb WordPress Outreach Club

--- a/indieauth.php
+++ b/indieauth.php
@@ -36,6 +36,9 @@ require_once __DIR__ . '/includes/functions-api.php';
 
 Autoloader::register_path( __NAMESPACE__, __DIR__ . '/includes' );
 
+// Backward compatibility aliases for pre-4.7.0 class names.
+require_once __DIR__ . '/includes/compat.php';
+
 // Initialize the plugin.
 $indieauth = IndieAuth::get_instance();
 $indieauth->init();

--- a/indieauth.php
+++ b/indieauth.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://github.com/indieweb/wordpress-indieauth/
  * Description: IndieAuth is a way to allow users to use their own domain to sign into other websites and services
  * Version: 4.7.0
- * Requires at least: 6.2
+ * Requires at least: 6.4
  * Requires PHP: 7.4
  * Requires CP: 2.1
  * Author: IndieWeb WordPress Outreach Club

--- a/readme.md
+++ b/readme.md
@@ -192,6 +192,8 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 ### 4.7.1
 
 * Restore the pre-4.7.0 global class names as aliases of their namespaced replacements, fixing plugins like Micropub that check for `IndieAuth_Plugin` before initializing (#319). The abstract `IndieAuth_Endpoint` class is the only exception, as it was replaced by a trait.
+* Trigger a deprecation notice when one of the old class names is used, except for `IndieAuth_Plugin`, which plugins use for feature detection
+* Raise the minimum required WordPress version to 6.4
 
 ### 4.7.0
 

--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,6 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 
 * Restore the pre-4.7.0 global class names as aliases of their namespaced replacements, fixing plugins like Micropub that check for `IndieAuth_Plugin` before initializing (#319). The abstract `IndieAuth_Endpoint` class is the only exception, as it was replaced by a trait.
 * Trigger a deprecation notice when one of the old class names is used, except for `IndieAuth_Plugin`, which plugins use for feature detection
-* Raise the minimum required WordPress version to 6.4
 
 ### 4.7.0
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 - Donate link: https://opencollective.com/indieweb
 - Tags: IndieAuth, IndieWeb, login, oauth
 - Tested up to: 7.0
-- Stable tag: 4.7.0
+- Stable tag: 4.7.1
 - Requires PHP: 7.4
 - License: MIT
 - License URI: https://opensource.org/licenses/MIT

--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,10 @@ In version 2.0, we added an IndieAuth endpoint to this plugin, which previously 
 
 Project and support maintained on github at [indieweb/wordpress-indieauth](https://github.com/indieweb/wordpress-indieauth).
 
+### 4.7.1
+
+* Restore the pre-4.7.0 global class names as aliases of their namespaced replacements, fixing plugins like Micropub that check for `IndieAuth_Plugin` before initializing (#319). The abstract `IndieAuth_Endpoint` class is the only exception, as it was replaced by a trait.
+
 ### 4.7.0
 
 * Fix fatal error on the authorization form when the current user cannot be determined

--- a/readme.md
+++ b/readme.md
@@ -191,8 +191,8 @@ Project and support maintained on github at [indieweb/wordpress-indieauth](https
 
 ### 4.7.1
 
-* Restore the pre-4.7.0 global class names as aliases of their namespaced replacements, fixing plugins like Micropub that check for `IndieAuth_Plugin` before initializing (#319). The abstract `IndieAuth_Endpoint` class is the only exception, as it was replaced by a trait.
-* Trigger a deprecation notice when one of the old class names is used, except for `IndieAuth_Plugin`, which plugins use for feature detection
+* Restore compatible pre-4.7.0 global class names as aliases of their namespaced replacements, fixing plugins like Micropub that check for `IndieAuth_Plugin` before initializing (#319). The abstract `IndieAuth_Endpoint` and endpoint classes whose legacy static API is not preserved are intentionally excluded.
+* Trigger a deprecation notice when an aliased legacy class name is used, except for `IndieAuth_Plugin`, which plugins use for feature detection
 
 ### 4.7.0
 

--- a/tests/phpunit/tests/includes/class-test-compat.php
+++ b/tests/phpunit/tests/includes/class-test-compat.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Tests for the backward-compatibility class aliases for pre-4.7.0 class names.
+ *
+ * @package IndieAuth
+ */
+class Test_Compat extends WP_UnitTestCase {
+
+	/**
+	 * The IndieAuth_Plugin alias must exist without triggering the autoloader,
+	 * so that `class_exists( 'IndieAuth_Plugin', false )` checks also work.
+	 */
+	public function test_indieauth_plugin_alias_is_registered_eagerly() {
+		$this->assertTrue( class_exists( 'IndieAuth_Plugin', false ) );
+	}
+
+	/**
+	 * Map of pre-4.7.0 global class names to their namespaced replacements.
+	 *
+	 * @return array
+	 */
+	public function legacy_class_provider() {
+		return array(
+			array( 'External_Token_Page', \IndieAuth\Ticket\External_Token_Page::class ),
+			array( 'External_Token_Table', \IndieAuth\WP_Admin\External_Token_List_Table::class ),
+			array( 'External_User_Token', \IndieAuth\Ticket\External_User_Token::class ),
+			array( 'IndieAuth_Admin', \IndieAuth\WP_Admin\Admin::class ),
+			array( 'IndieAuth_Authorization_Endpoint', \IndieAuth\Rest\Authorization_Controller::class ),
+			array( 'IndieAuth_Authorize', \IndieAuth\Authorize::class ),
+			array( 'IndieAuth_Client', \IndieAuth\Client::class ),
+			array( 'IndieAuth_Client_Discovery', \IndieAuth\Client_Discovery::class ),
+			array( 'IndieAuth_Client_Taxonomy', \IndieAuth\Client_Taxonomy::class ),
+			array( 'IndieAuth_Debug', \IndieAuth\Debug::class ),
+			array( 'IndieAuth_FedCM_Endpoint', \IndieAuth\Rest\FedCM_Controller::class ),
+			array( 'IndieAuth_Introspection_Endpoint', \IndieAuth\Rest\Introspection_Controller::class ),
+			array( 'IndieAuth_Metadata_Endpoint', \IndieAuth\Rest\Metadata_Controller::class ),
+			array( 'IndieAuth_Plugin', \IndieAuth\IndieAuth::class ),
+			array( 'IndieAuth_Revocation_Endpoint', \IndieAuth\Rest\Revocation_Controller::class ),
+			array( 'IndieAuth_Scope', \IndieAuth\Scope\Scope::class ),
+			array( 'IndieAuth_Scopes', \IndieAuth\Scopes::class ),
+			array( 'IndieAuth_Ticket_Endpoint', \IndieAuth\Rest\Ticket_Controller::class ),
+			array( 'IndieAuth_Token_Endpoint', \IndieAuth\Rest\Token_Controller::class ),
+			array( 'IndieAuth_Token_UI', \IndieAuth\WP_Admin\Token_UI::class ),
+			array( 'IndieAuth_Userinfo_Endpoint', \IndieAuth\Rest\Userinfo_Controller::class ),
+			array( 'IndieAuth_WebIdentity', \IndieAuth\WebIdentity::class ),
+			array( 'Token_Generic', \IndieAuth\Token\Generic::class ),
+			array( 'Token_List_Table', \IndieAuth\WP_Admin\Token_List_Table::class ),
+			array( 'Token_Transient', \IndieAuth\Token\Transient::class ),
+			array( 'Token_User', \IndieAuth\Token\User::class ),
+			array( 'WP_OAuth_Response', \IndieAuth\OAuth_Response::class ),
+			array( 'Web_Signin', \IndieAuth\Web_Signin::class ),
+		);
+	}
+
+	/**
+	 * Every legacy class name must resolve, via autoloading, to its namespaced replacement.
+	 *
+	 * @dataProvider legacy_class_provider
+	 *
+	 * @param string $legacy  Pre-4.7.0 global class name.
+	 * @param string $current Namespaced replacement class.
+	 */
+	public function test_legacy_class_alias( $legacy, $current ) {
+		$this->assertTrue( class_exists( $legacy ), "Legacy class {$legacy} does not exist." );
+
+		$reflection = new ReflectionClass( $legacy );
+		$this->assertSame( $current, $reflection->getName(), "Legacy class {$legacy} is not an alias of {$current}." );
+	}
+
+	/**
+	 * The Micropub plugin gates its whole initialization on this check.
+	 *
+	 * @see https://github.com/indieweb/wordpress-indieauth/issues/319
+	 */
+	public function test_micropub_indieauth_detection() {
+		$this->assertTrue( \class_exists( 'IndieAuth_Plugin' ) );
+	}
+}

--- a/tests/phpunit/tests/includes/class-test-compat.php
+++ b/tests/phpunit/tests/includes/class-test-compat.php
@@ -28,23 +28,16 @@ class Test_Compat extends WP_UnitTestCase {
 			array( 'External_Token_Table', \IndieAuth\WP_Admin\External_Token_List_Table::class ),
 			array( 'External_User_Token', \IndieAuth\Ticket\External_User_Token::class ),
 			array( 'IndieAuth_Admin', \IndieAuth\WP_Admin\Admin::class ),
-			array( 'IndieAuth_Authorization_Endpoint', \IndieAuth\Rest\Authorization_Controller::class ),
 			array( 'IndieAuth_Authorize', \IndieAuth\Authorize::class ),
 			array( 'IndieAuth_Client', \IndieAuth\Client::class ),
 			array( 'IndieAuth_Client_Discovery', \IndieAuth\Client_Discovery::class ),
 			array( 'IndieAuth_Client_Taxonomy', \IndieAuth\Client_Taxonomy::class ),
 			array( 'IndieAuth_Debug', \IndieAuth\Debug::class ),
 			array( 'IndieAuth_FedCM_Endpoint', \IndieAuth\Rest\FedCM_Controller::class ),
-			array( 'IndieAuth_Introspection_Endpoint', \IndieAuth\Rest\Introspection_Controller::class ),
-			array( 'IndieAuth_Metadata_Endpoint', \IndieAuth\Rest\Metadata_Controller::class ),
 			array( 'IndieAuth_Plugin', \IndieAuth\IndieAuth::class ),
-			array( 'IndieAuth_Revocation_Endpoint', \IndieAuth\Rest\Revocation_Controller::class ),
 			array( 'IndieAuth_Scope', \IndieAuth\Scope\Scope::class ),
 			array( 'IndieAuth_Scopes', \IndieAuth\Scopes::class ),
-			array( 'IndieAuth_Ticket_Endpoint', \IndieAuth\Rest\Ticket_Controller::class ),
-			array( 'IndieAuth_Token_Endpoint', \IndieAuth\Rest\Token_Controller::class ),
 			array( 'IndieAuth_Token_UI', \IndieAuth\WP_Admin\Token_UI::class ),
-			array( 'IndieAuth_Userinfo_Endpoint', \IndieAuth\Rest\Userinfo_Controller::class ),
 			array( 'IndieAuth_WebIdentity', \IndieAuth\WebIdentity::class ),
 			array( 'Token_Generic', \IndieAuth\Token\Generic::class ),
 			array( 'Token_List_Table', \IndieAuth\WP_Admin\Token_List_Table::class ),
@@ -93,6 +86,35 @@ class Test_Compat extends WP_UnitTestCase {
 		}
 
 		$this->assertSame( $expected, \IndieAuth\COMPAT_CLASS_MAP );
+	}
+
+	/**
+	 * Endpoint classes whose legacy static API is not preserved by the new
+	 * controllers must not be exposed as misleading aliases.
+	 *
+	 * @return array
+	 */
+	public function incompatible_endpoint_class_provider() {
+		return array(
+			array( 'IndieAuth_Authorization_Endpoint' ),
+			array( 'IndieAuth_Introspection_Endpoint' ),
+			array( 'IndieAuth_Metadata_Endpoint' ),
+			array( 'IndieAuth_Revocation_Endpoint' ),
+			array( 'IndieAuth_Ticket_Endpoint' ),
+			array( 'IndieAuth_Token_Endpoint' ),
+			array( 'IndieAuth_Userinfo_Endpoint' ),
+		);
+	}
+
+	/**
+	 * Ensure incompatible endpoint controllers are not registered as aliases.
+	 *
+	 * @dataProvider incompatible_endpoint_class_provider
+	 *
+	 * @param string $legacy Pre-4.7.0 endpoint class name.
+	 */
+	public function test_incompatible_endpoint_class_is_not_aliased( $legacy ) {
+		$this->assertFalse( class_exists( $legacy ), "Incompatible endpoint class {$legacy} must not be aliased." );
 	}
 
 }

--- a/tests/phpunit/tests/includes/class-test-compat.php
+++ b/tests/phpunit/tests/includes/class-test-compat.php
@@ -64,9 +64,10 @@ class Test_Compat extends WP_UnitTestCase {
 		/*
 		 * Lazily aliased classes must trigger a deprecation notice on first use.
 		 * `IndieAuth_Plugin` is aliased eagerly and stays notice-free, because
-		 * plugins like Micropub use it for feature detection.
+		 * plugins like Micropub use it for feature detection. ClassicPress does
+		 * not have `_deprecated_class()`, so no notice is triggered there.
 		 */
-		if ( ! class_exists( $legacy, false ) ) {
+		if ( ! class_exists( $legacy, false ) && function_exists( '_deprecated_class' ) ) {
 			$this->setExpectedDeprecated( $legacy );
 		}
 

--- a/tests/phpunit/tests/includes/class-test-compat.php
+++ b/tests/phpunit/tests/includes/class-test-compat.php
@@ -9,6 +9,9 @@ class Test_Compat extends WP_UnitTestCase {
 	/**
 	 * The IndieAuth_Plugin alias must exist without triggering the autoloader,
 	 * so that `class_exists( 'IndieAuth_Plugin', false )` checks also work.
+	 * The Micropub plugin gates its whole initialization on this class.
+	 *
+	 * @see https://github.com/indieweb/wordpress-indieauth/issues/319
 	 */
 	public function test_indieauth_plugin_alias_is_registered_eagerly() {
 		$this->assertTrue( class_exists( 'IndieAuth_Plugin', false ) );
@@ -92,12 +95,4 @@ class Test_Compat extends WP_UnitTestCase {
 		$this->assertSame( $expected, \IndieAuth\COMPAT_CLASS_MAP );
 	}
 
-	/**
-	 * The Micropub plugin gates its whole initialization on this check.
-	 *
-	 * @see https://github.com/indieweb/wordpress-indieauth/issues/319
-	 */
-	public function test_micropub_indieauth_detection() {
-		$this->assertTrue( \class_exists( 'IndieAuth_Plugin' ) );
-	}
 }

--- a/tests/phpunit/tests/includes/class-test-compat.php
+++ b/tests/phpunit/tests/includes/class-test-compat.php
@@ -61,6 +61,15 @@ class Test_Compat extends WP_UnitTestCase {
 	 * @param string $current Namespaced replacement class.
 	 */
 	public function test_legacy_class_alias( $legacy, $current ) {
+		/*
+		 * Lazily aliased classes must trigger a deprecation notice on first use.
+		 * `IndieAuth_Plugin` is aliased eagerly and stays notice-free, because
+		 * plugins like Micropub use it for feature detection.
+		 */
+		if ( ! class_exists( $legacy, false ) ) {
+			$this->setExpectedDeprecated( $legacy );
+		}
+
 		$this->assertTrue( class_exists( $legacy ), "Legacy class {$legacy} does not exist." );
 
 		$reflection = new ReflectionClass( $legacy );

--- a/tests/phpunit/tests/includes/class-test-compat.php
+++ b/tests/phpunit/tests/includes/class-test-compat.php
@@ -78,6 +78,21 @@ class Test_Compat extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The data provider intentionally duplicates the map as an independent pin
+	 * of the pre-4.7.0 public surface: removing an alias from production must
+	 * fail here. This assertion covers the other direction, so an alias added
+	 * to production cannot silently miss test coverage.
+	 */
+	public function test_compat_map_matches_legacy_class_provider() {
+		$expected = array();
+		foreach ( $this->legacy_class_provider() as $row ) {
+			$expected[ $row[0] ] = $row[1];
+		}
+
+		$this->assertSame( $expected, \IndieAuth\COMPAT_CLASS_MAP );
+	}
+
+	/**
 	 * The Micropub plugin gates its whole initialization on this check.
 	 *
 	 * @see https://github.com/indieweb/wordpress-indieauth/issues/319


### PR DESCRIPTION
## Problem

The 4.7.0 namespace refactoring (#306) removed all global classes without backward-compat aliases. Third-party plugins that check for the old names broke — most notably Micropub, which gates its whole initialization on `class_exists( 'IndieAuth_Plugin' )` and therefore never registers its REST routes under 4.7.0 (`rest_no_route` 404).

Fixes #319

## Solution

New `includes/compat.php` registers the old global class names as aliases of their namespaced replacements:

- `IndieAuth_Plugin` is aliased **eagerly** and notice-free, so `class_exists( 'IndieAuth_Plugin', false )` checks work and feature detection doesn't spam debug logs.
- The remaining 20 classes are aliased **lazily** via `spl_autoload_register()`; first use triggers `_deprecated_class()` (guarded by `function_exists()`, since the plugin supports WP 6.2 and `_deprecated_class()` needs 6.4) pointing to the namespaced replacement.
- Eight pre-4.7.0 classes are intentionally **not** aliased: the abstract `IndieAuth_Endpoint`, whose functionality moved to the `IndieAuth\Rest\Token_Management` trait (a class alias cannot represent a trait), and the seven `*_Endpoint` classes (authorization, introspection, metadata, revocation, ticket, token, userinfo), whose legacy `get_endpoint()` API was static while the replacement controller methods are not — an alias would not restore the old calling convention.

## Verification

- New `Test_Compat` suite asserts every legacy name resolves to its namespaced replacement, that lazy aliases trigger the expected deprecation, and that the excluded endpoint classes stay unaliased (30 tests, written first and watched fail).
- Full suite passes (97 tests, 247 assertions); phpcs clean.
- Reproduced #319 end-to-end in wp-env with Micropub 2.5.1: stock 4.7.0 → `GET /?rest_route=/micropub/1.0/endpoint` returns **404 `rest_no_route`**; with this patch → **403** (route registered, auth required), matching 4.6.0 behavior. Eager/lazy alias semantics, `IndieAuth_Client_Taxonomy::get_client()` callability and `Token_User` instantiation verified at runtime via `wp eval`.

Companion change for WebFinger: pfefferle/wordpress-webfinger#58
