### PR TITLE
Fix FedCM authentication, scope consent, and code-binding issues

### DIFF
--- a/includes/class-indieauth.php
+++ b/includes/class-indieauth.php
@@ -209,6 +209,7 @@ class IndieAuth {
 
 		// FedCM Controller hooks.
 		\add_action( 'rest_api_init', array( $this->fedcm, 'register_routes' ) );
+		\add_filter( 'rest_authentication_errors', array( $this->fedcm, 'rest_authentication_errors' ) );
 		\add_filter( 'indieauth_metadata', array( $this->fedcm, 'metadata' ) );
 		\add_filter( 'rest_index_indieauth_endpoints', array( $this->fedcm, 'rest_index' ) );
 		\add_action( 'set_logged_in_cookie', array( $this->fedcm, 'set_login_status_logged_in' ) );

--- a/includes/class-indieauth.php
+++ b/includes/class-indieauth.php
@@ -210,6 +210,7 @@ class IndieAuth {
 		// FedCM Controller hooks.
 		\add_action( 'rest_api_init', array( $this->fedcm, 'register_routes' ) );
 		\add_filter( 'rest_authentication_errors', array( $this->fedcm, 'rest_authentication_errors' ) );
+		\add_filter( 'rest_pre_dispatch', array( $this->fedcm, 'rest_pre_dispatch' ), 10, 3 );
 		\add_filter( 'indieauth_metadata', array( $this->fedcm, 'metadata' ) );
 		\add_filter( 'rest_index_indieauth_endpoints', array( $this->fedcm, 'rest_index' ) );
 		\add_action( 'set_logged_in_cookie', array( $this->fedcm, 'set_login_status_logged_in' ) );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -387,6 +387,39 @@ if ( ! function_exists( 'IndieAuth\build_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'IndieAuth\code_binding_failure' ) ) {
+	/**
+	 * Check an authorization code against the parameters it was issued for.
+	 *
+	 * The authorization endpoint and the token endpoint both redeem the same
+	 * codes, so they must agree exactly on what counts as a match. This is the
+	 * one place that decides it.
+	 *
+	 * URLs are compared with same_url(), because a caller is not lying about its
+	 * identity by omitting a trailing slash, and a failure here destroys the code.
+	 *
+	 * @param array $token  The stored authorization code data.
+	 * @param array $params The parameters supplied at redemption.
+	 * @return string|null The name of the parameter that failed, or null if the code is bound correctly.
+	 */
+	function code_binding_failure( $token, $params ) {
+		$bound = array( 'client_id' );
+
+		// FedCM codes are issued without a redirect_uri; every other code is bound to one.
+		if ( empty( $token['fedcm'] ) ) {
+			$bound[] = 'redirect_uri';
+		}
+
+		foreach ( $bound as $key ) {
+			if ( ! isset( $params[ $key ], $token[ $key ] ) || ! same_url( $token[ $key ], $params[ $key ] ) ) {
+				return $key;
+			}
+		}
+
+		return null;
+	}
+}
+
 if ( ! function_exists( 'IndieAuth\normalize_url' ) ) {
 	/**
 	 * Normalize a URL by adding slash if no path and converting hostname to lowercase.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -421,6 +421,61 @@ if ( ! function_exists( 'IndieAuth\normalize_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'IndieAuth\same_url' ) ) {
+	/**
+	 * Compare two URLs, ignoring differences that do not change what they point at.
+	 *
+	 * Used to bind an authorization code to the client_id and redirect_uri it was
+	 * issued for. A client that registers "https://app.example.com" and redeems
+	 * with "https://app.example.com/" means the same URL, and the binding check
+	 * must not destroy the code over that.
+	 *
+	 * @param string $url1 First URL.
+	 * @param string $url2 Second URL.
+	 * @return bool True if both URLs are equivalent.
+	 */
+	function same_url( $url1, $url2 ) {
+		if ( ! is_string( $url1 ) || ! is_string( $url2 ) ) {
+			return false;
+		}
+
+		if ( $url1 === $url2 ) {
+			return true;
+		}
+
+		$defaults  = array(
+			'http'  => 80,
+			'https' => 443,
+		);
+		$canonical = array();
+
+		foreach ( array( $url1, $url2 ) as $url ) {
+			$parts = \wp_parse_url( $url );
+			if ( ! is_array( $parts ) || ! isset( $parts['scheme'], $parts['host'] ) ) {
+				return false;
+			}
+
+			// Scheme and host are case-insensitive.
+			$parts['scheme'] = strtolower( $parts['scheme'] );
+			$parts['host']   = strtolower( $parts['host'] );
+
+			// No path means the root path.
+			if ( empty( $parts['path'] ) ) {
+				$parts['path'] = '/';
+			}
+
+			// An explicit default port is the same as none.
+			if ( isset( $parts['port'], $defaults[ $parts['scheme'] ] ) && (int) $parts['port'] === $defaults[ $parts['scheme'] ] ) {
+				unset( $parts['port'] );
+			}
+
+			$canonical[] = build_url( $parts );
+		}
+
+		return $canonical[0] === $canonical[1];
+	}
+}
+
 /**
  * Get Scope.
  *

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -421,11 +421,12 @@ class Authorization_Controller extends \WP_REST_Controller {
 		$code          = $params['code'];
 		$code_verifier = isset( $params['code_verifier'] ) ? $params['code_verifier'] : null;
 		$token         = $this->get_code( $code );
-		$scopes        = isset( $token['scope'] ) ? array_filter( explode( ' ', $token['scope'] ) ) : array();
 
 		if ( ! $token ) {
 			return new OAuth_Response( 'invalid_grant', \__( 'Invalid authorization code', 'indieauth' ), 400 );
 		}
+
+		$scopes = isset( $token['scope'] ) ? array_filter( explode( ' ', $token['scope'] ) ) : array();
 
 		$bound_params = array( 'client_id' );
 		if ( empty( $token['fedcm'] ) ) {

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -409,7 +409,8 @@ class Authorization_Controller extends \WP_REST_Controller {
 	 * @return array|OAuth_Response Response to return to the REST Server.
 	 */
 	public function authorization_code( $params ) {
-		$required = array( 'redirect_uri', 'client_id', 'code', 'grant_type' );
+		// redirect_uri is required conditionally below; FedCM codes are issued without one.
+		$required = array( 'client_id', 'code', 'grant_type' );
 		foreach ( $required as $require ) {
 			if ( ! isset( $params[ $require ] ) ) {
 				// translators: Name of missing parameter.
@@ -419,13 +420,22 @@ class Authorization_Controller extends \WP_REST_Controller {
 
 		$code          = $params['code'];
 		$code_verifier = isset( $params['code_verifier'] ) ? $params['code_verifier'] : null;
-		$params        = \wp_array_slice_assoc( $params, array( 'client_id', 'redirect_uri' ) );
 		$token         = $this->get_code( $code );
 		$scopes        = isset( $token['scope'] ) ? array_filter( explode( ' ', $token['scope'] ) ) : array();
 
 		if ( ! $token ) {
 			return new OAuth_Response( 'invalid_grant', \__( 'Invalid authorization code', 'indieauth' ), 400 );
 		}
+
+		$bound_params = array( 'client_id' );
+		if ( empty( $token['fedcm'] ) ) {
+			if ( ! isset( $params['redirect_uri'] ) ) {
+				// translators: Name of missing parameter.
+				return new OAuth_Response( 'parameter_absent', sprintf( \__( 'Missing Parameter: %1$s', 'indieauth' ), 'redirect_uri' ), 400 );
+			}
+			$bound_params[] = 'redirect_uri';
+		}
+		$params = \wp_array_slice_assoc( $params, $bound_params );
 		$user = \get_user_by( 'id', $token['user'] );
 		if ( $token['exp'] <= time() ) {
 			$this->delete_code( $code, $token['user'] );

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -18,6 +18,7 @@ use function IndieAuth\indieauth_get_user;
 use function IndieAuth\pkce_verifier;
 use function IndieAuth\add_query_params_to_url;
 use function IndieAuth\get_url_from_user;
+use function IndieAuth\same_url;
 
 /**
  * IndieAuth Authorization Controller class.
@@ -468,6 +469,11 @@ class Authorization_Controller extends \WP_REST_Controller {
 
 			return $return;
 		}
+
+		// The token endpoint destroys a code that fails this same binding check.
+		// This endpoint accepts the same codes, so it has to do the same, or the
+		// code could simply be probed here instead.
+		$this->delete_code( $code, $token['user'] );
 		return new OAuth_Response( 'invalid_grant', \__( 'There was an error verifying the authorization code. Check that the client_id and redirect_uri match the original request.', 'indieauth' ), 400 );
 	}
 

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -19,6 +19,7 @@ use function IndieAuth\pkce_verifier;
 use function IndieAuth\add_query_params_to_url;
 use function IndieAuth\get_url_from_user;
 use function IndieAuth\same_url;
+use function IndieAuth\code_binding_failure;
 
 /**
  * IndieAuth Authorization Controller class.
@@ -458,7 +459,9 @@ class Authorization_Controller extends \WP_REST_Controller {
 			unset( $token['code_challenge_method'] );
 		}
 
-		if ( array() === array_diff_assoc( $params, $token ) ) {
+		// Same check as the token endpoint, from the same function, so the two
+		// endpoints can never drift apart on what a valid redemption looks like.
+		if ( null === code_binding_failure( $token, $params ) ) {
 			$this->delete_code( $code, $token['user'] );
 
 			$return = array( 'me' => $token['me'] );

--- a/includes/rest/class-authorization-controller.php
+++ b/includes/rest/class-authorization-controller.php
@@ -436,7 +436,7 @@ class Authorization_Controller extends \WP_REST_Controller {
 			$bound_params[] = 'redirect_uri';
 		}
 		$params = \wp_array_slice_assoc( $params, $bound_params );
-		$user = \get_user_by( 'id', $token['user'] );
+		$user   = \get_user_by( 'id', $token['user'] );
 		if ( $token['exp'] <= time() ) {
 			$this->delete_code( $code, $token['user'] );
 			return new OAuth_Response( 'invalid_grant', \__( 'The authorization code expired', 'indieauth' ), 400 );

--- a/includes/rest/class-fedcm-controller.php
+++ b/includes/rest/class-fedcm-controller.php
@@ -306,6 +306,35 @@ class FedCM_Controller extends \WP_REST_Controller {
 	}
 
 	/**
+	 * Exempt FedCM requests from the REST cookie nonce check.
+	 *
+	 * The browser's FedCM machinery sends the auth cookie but cannot include a
+	 * REST nonce, so `rest_cookie_check_errors()` would treat the request as
+	 * unauthenticated. `Sec-` prefixed headers are forbidden for cross-site
+	 * JavaScript, so requiring `Sec-Fetch-Dest: webidentity` rules out CSRF.
+	 *
+	 * @param \WP_Error|null|true $result Current authentication result.
+	 * @return \WP_Error|null|true True for FedCM requests to FedCM routes, unchanged otherwise.
+	 */
+	public function rest_authentication_errors( $result ) {
+		if ( null !== $result ) {
+			return $result;
+		}
+
+		if ( ! isset( $_SERVER['HTTP_SEC_FETCH_DEST'] ) || 'webidentity' !== $_SERVER['HTTP_SEC_FETCH_DEST'] ) {
+			return $result;
+		}
+
+		// Only exempt this plugin's FedCM routes.
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? \sanitize_text_field( \wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		if ( false === strpos( $request_uri, $this->namespace . '/' . $this->rest_base . '/' ) ) {
+			return $result;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Validate Origin header matches client_id scheme, hostname, and port.
 	 *
 	 * Per FedCM spec, the full origin (scheme + host + port) must match.
@@ -329,10 +358,8 @@ class FedCM_Controller extends \WP_REST_Controller {
 
 		$origin_scheme    = isset( $origin_parts['scheme'] ) ? $origin_parts['scheme'] : null;
 		$origin_host      = isset( $origin_parts['host'] ) ? $origin_parts['host'] : null;
-		$origin_port      = isset( $origin_parts['port'] ) ? (int) $origin_parts['port'] : null;
 		$client_id_scheme = isset( $client_id_parts['scheme'] ) ? $client_id_parts['scheme'] : null;
 		$client_id_host   = isset( $client_id_parts['host'] ) ? $client_id_parts['host'] : null;
-		$client_id_port   = isset( $client_id_parts['port'] ) ? (int) $client_id_parts['port'] : null;
 
 		if ( null === $origin_scheme || null === $origin_host || null === $client_id_scheme || null === $client_id_host ) {
 			return false;
@@ -343,12 +370,32 @@ class FedCM_Controller extends \WP_REST_Controller {
 			return false;
 		}
 
-		// Port must match (null means default port for scheme).
+		// Port must match; a missing port means the default port for the scheme.
+		$defaults       = array(
+			'http'  => 80,
+			'https' => 443,
+		);
+		$default_port   = isset( $defaults[ $origin_scheme ] ) ? $defaults[ $origin_scheme ] : null;
+		$origin_port    = isset( $origin_parts['port'] ) ? (int) $origin_parts['port'] : $default_port;
+		$client_id_port = isset( $client_id_parts['port'] ) ? (int) $client_id_parts['port'] : $default_port;
+
 		return $origin_port === $client_id_port;
 	}
 
 	/**
-	 * Add CORS headers for FedCM responses.
+	 * Add public CORS headers for endpoints that serve no user data.
+	 *
+	 * @param \WP_REST_Response $response The response object.
+	 * @return \WP_REST_Response Modified response.
+	 */
+	private function add_public_cors_headers( $response ) {
+		$response->header( 'Access-Control-Allow-Origin', '*' );
+
+		return $response;
+	}
+
+	/**
+	 * Add credentialed CORS headers for FedCM responses.
 	 *
 	 * @param \WP_REST_Response $response The response object.
 	 * @param \WP_REST_Request  $request  The request object.
@@ -392,7 +439,7 @@ class FedCM_Controller extends \WP_REST_Controller {
 		$response = new \WP_REST_Response( $config, 200 );
 
 		// Config endpoint must be accessible cross-origin per FedCM spec.
-		return $this->add_cors_headers( $response, $request );
+		return $this->add_public_cors_headers( $response );
 	}
 
 	/**
@@ -500,7 +547,27 @@ class FedCM_Controller extends \WP_REST_Controller {
 			array()
 		);
 
-		return $this->add_cors_headers( $response, $request );
+		return $this->add_public_cors_headers( $response );
+	}
+
+	/**
+	 * Build an ID assertion error response per the FedCM Error API.
+	 *
+	 * @see https://fedidcg.github.io/FedCM/#idp-api-error-response
+	 *
+	 * @param string $code   One of the error codes defined by the FedCM specification.
+	 * @param int    $status HTTP status code.
+	 * @return \WP_REST_Response The error response.
+	 */
+	private function assertion_error( $code, $status ) {
+		return new \WP_REST_Response(
+			array(
+				'error' => array(
+					'code' => $code,
+				),
+			),
+			$status
+		);
 	}
 
 	/**
@@ -514,10 +581,7 @@ class FedCM_Controller extends \WP_REST_Controller {
 	public function assertion( $request ) {
 		// Validate FedCM request header.
 		if ( ! $this->is_valid_fedcm_request( $request ) ) {
-			return new \WP_REST_Response(
-				array( 'error' => 'Missing or invalid Sec-Fetch-Dest header' ),
-				400
-			);
+			return $this->assertion_error( 'invalid_request', 400 );
 		}
 
 		$client_id  = $request->get_param( 'client_id' );
@@ -527,18 +591,12 @@ class FedCM_Controller extends \WP_REST_Controller {
 
 		// Validate origin.
 		if ( ! $this->validate_origin( $request, $client_id ) ) {
-			return new \WP_REST_Response(
-				array( 'error' => 'Origin mismatch' ),
-				403
-			);
+			return $this->assertion_error( 'unauthorized_client', 403 );
 		}
 
 		// Check if user is logged in.
 		if ( ! \is_user_logged_in() ) {
-			return new \WP_REST_Response(
-				array( 'error' => 'Not logged in' ),
-				401
-			);
+			return $this->assertion_error( 'access_denied', 401 );
 		}
 
 		$user = \wp_get_current_user();
@@ -546,10 +604,7 @@ class FedCM_Controller extends \WP_REST_Controller {
 
 		// Verify account_id matches the current user.
 		if ( normalize_url( $account_id ) !== normalize_url( $me ) ) {
-			return new \WP_REST_Response(
-				array( 'error' => 'Account mismatch' ),
-				403
-			);
+			return $this->assertion_error( 'access_denied', 403 );
 		}
 
 		// Parse PKCE params (already validated by validate_params callback).
@@ -566,11 +621,21 @@ class FedCM_Controller extends \WP_REST_Controller {
 		// Determine scope - default to 'profile' for FedCM.
 		$scope = 'profile';
 		if ( is_array( $params ) && isset( $params['scope'] ) ) {
-			$scope = \sanitize_text_field( $params['scope'] );
+			// The FedCM browser UI never displays scopes, so only identity
+			// scopes may be granted without a real consent screen.
+			$requested = array_filter( explode( ' ', \sanitize_text_field( $params['scope'] ) ) );
+			$granted   = array_values( array_intersect( $requested, array( 'profile', 'email' ) ) );
+			if ( $granted ) {
+				$scope = implode( ' ', $granted );
+			}
 		}
 
 		/**
 		 * Filter the scope used for FedCM-issued authorization codes.
+		 *
+		 * Scopes requested by the client are clamped to 'profile' and 'email'
+		 * before this filter runs, because the FedCM flow has no consent
+		 * screen where a user could review other scopes.
 		 *
 		 * @param string           $scope   The scope to be stored with the authorization code.
 		 * @param \WP_REST_Request $request The REST request object.
@@ -581,14 +646,13 @@ class FedCM_Controller extends \WP_REST_Controller {
 		$token = array(
 			'response_type'         => 'code',
 			'client_id'             => $client_id,
-			'redirect_uri'          => 'urn:ietf:wg:oauth:2.0:oob', // FedCM doesn't redirect; use OOB constant.
 			'scope'                 => $scope,
 			'me'                    => $me,
 			'code_challenge'        => $code_challenge,
 			'code_challenge_method' => $code_challenge_method,
 			'user'                  => $user->ID,
 			'uuid'                  => $uuid,
-			'fedcm'                 => true, // Mark as FedCM-issued code.
+			'fedcm'                 => true, // Mark as FedCM-issued code; these are not bound to a redirect_uri.
 		);
 
 		if ( $nonce ) {

--- a/includes/rest/class-fedcm-controller.php
+++ b/includes/rest/class-fedcm-controller.php
@@ -386,10 +386,11 @@ class FedCM_Controller extends \WP_REST_Controller {
 			return false;
 		}
 
-		$origin_scheme    = isset( $origin_parts['scheme'] ) ? $origin_parts['scheme'] : null;
-		$origin_host      = isset( $origin_parts['host'] ) ? $origin_parts['host'] : null;
-		$client_id_scheme = isset( $client_id_parts['scheme'] ) ? $client_id_parts['scheme'] : null;
-		$client_id_host   = isset( $client_id_parts['host'] ) ? $client_id_parts['host'] : null;
+		// Schemes and hosts are case-insensitive.
+		$origin_scheme    = isset( $origin_parts['scheme'] ) ? strtolower( $origin_parts['scheme'] ) : null;
+		$origin_host      = isset( $origin_parts['host'] ) ? strtolower( $origin_parts['host'] ) : null;
+		$client_id_scheme = isset( $client_id_parts['scheme'] ) ? strtolower( $client_id_parts['scheme'] ) : null;
+		$client_id_host   = isset( $client_id_parts['host'] ) ? strtolower( $client_id_parts['host'] ) : null;
 
 		if ( null === $origin_scheme || null === $origin_host || null === $client_id_scheme || null === $client_id_host ) {
 			return false;

--- a/includes/rest/class-fedcm-controller.php
+++ b/includes/rest/class-fedcm-controller.php
@@ -313,25 +313,55 @@ class FedCM_Controller extends \WP_REST_Controller {
 	 * unauthenticated. `Sec-` prefixed headers are forbidden for cross-site
 	 * JavaScript, so requiring `Sec-Fetch-Dest: webidentity` rules out CSRF.
 	 *
+	 * The exemption is deliberately narrow: it only applies to a request that
+	 * is actually cookie-authenticated and that the REST server dispatched to
+	 * one of this plugin's FedCM routes. Everything else falls through to the
+	 * normal REST authentication pipeline.
+	 *
 	 * @param \WP_Error|null|true $result Current authentication result.
-	 * @return \WP_Error|null|true True for FedCM requests to FedCM routes, unchanged otherwise.
+	 * @return \WP_Error|null|true True for cookie-authenticated FedCM requests to FedCM routes, unchanged otherwise.
 	 */
 	public function rest_authentication_errors( $result ) {
+		global $wp_rest_auth_cookie;
+
 		if ( null !== $result ) {
 			return $result;
 		}
 
-		if ( ! isset( $_SERVER['HTTP_SEC_FETCH_DEST'] ) || 'webidentity' !== $_SERVER['HTTP_SEC_FETCH_DEST'] ) {
+		if ( ! isset( $_SERVER['HTTP_SEC_FETCH_DEST'] ) || 'webidentity' !== \sanitize_text_field( \wp_unslash( $_SERVER['HTTP_SEC_FETCH_DEST'] ) ) ) {
 			return $result;
 		}
 
-		// Only exempt this plugin's FedCM routes.
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? \sanitize_text_field( \wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		if ( false === strpos( $request_uri, $this->namespace . '/' . $this->rest_base . '/' ) ) {
+		// Match the route the REST server dispatched, not the raw request URI,
+		// so an unrelated route cannot carry the FedCM path in its query string.
+		if ( ! $this->is_fedcm_route() ) {
+			return $result;
+		}
+
+		// There is only a nonce-less user to preserve when the request really is
+		// cookie-authenticated. `is_user_logged_in()` resolves the current user,
+		// which is what populates `$wp_rest_auth_cookie`.
+		if ( ! \is_user_logged_in() || true !== $wp_rest_auth_cookie ) {
 			return $result;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check whether the REST server is serving one of this plugin's FedCM routes.
+	 *
+	 * @return bool True if the dispatched route belongs to the FedCM namespace.
+	 */
+	private function is_fedcm_route() {
+		if ( empty( $GLOBALS['wp']->query_vars['rest_route'] ) ) {
+			return false;
+		}
+
+		$route  = '/' . ltrim( $GLOBALS['wp']->query_vars['rest_route'], '/' );
+		$prefix = '/' . $this->namespace . '/' . $this->rest_base . '/';
+
+		return 0 === strpos( $route, $prefix );
 	}
 
 	/**

--- a/includes/rest/class-fedcm-controller.php
+++ b/includes/rest/class-fedcm-controller.php
@@ -318,8 +318,12 @@ class FedCM_Controller extends \WP_REST_Controller {
 	 * one of this plugin's FedCM routes. Everything else falls through to the
 	 * normal REST authentication pipeline.
 	 *
+	 * Core's nonce check is removed rather than answering `true`, because `true`
+	 * would end the whole filter chain and silently skip any other plugin's REST
+	 * authentication policy, not just the nonce check.
+	 *
 	 * @param \WP_Error|null|true $result Current authentication result.
-	 * @return \WP_Error|null|true True for cookie-authenticated FedCM requests to FedCM routes, unchanged otherwise.
+	 * @return \WP_Error|null|true The result, unchanged.
 	 */
 	public function rest_authentication_errors( $result ) {
 		global $wp_rest_auth_cookie;
@@ -345,7 +349,12 @@ class FedCM_Controller extends \WP_REST_Controller {
 			return $result;
 		}
 
-		return true;
+		// Only core's nonce check gets skipped. Everything else on this filter
+		// still runs, and the request is left unauthenticated so far as this
+		// callback is concerned.
+		\remove_filter( 'rest_authentication_errors', 'rest_cookie_check_errors', 100 );
+
+		return $result;
 	}
 
 	/**
@@ -411,6 +420,30 @@ class FedCM_Controller extends \WP_REST_Controller {
 		$client_id_port = isset( $client_id_parts['port'] ) ? (int) $client_id_parts['port'] : $default_port;
 
 		return $origin_port === $client_id_port;
+	}
+
+	/**
+	 * Let the FedCM routes send their own CORS headers.
+	 *
+	 * Core's `rest_send_cors_headers()` runs on `rest_pre_serve_request`, which
+	 * fires after the response's own headers have gone out, and it echoes the
+	 * request Origin with `Access-Control-Allow-Credentials: true`. That would
+	 * overwrite whatever these endpoints set, so it is taken out of the way for
+	 * FedCM routes only. Removing it here affects just the request being served.
+	 *
+	 * @param mixed            $result  Response to replace the requested version with.
+	 * @param \WP_REST_Server  $server  Server instance.
+	 * @param \WP_REST_Request $request Request used to generate the response.
+	 * @return mixed The result, unchanged.
+	 */
+	public function rest_pre_dispatch( $result, $server, $request ) {
+		$prefix = '/' . $this->namespace . '/' . $this->rest_base . '/';
+
+		if ( 0 === strpos( $request->get_route(), $prefix ) ) {
+			\remove_filter( 'rest_pre_serve_request', 'rest_send_cors_headers' );
+		}
+
+		return $result;
 	}
 
 	/**
@@ -586,12 +619,13 @@ class FedCM_Controller extends \WP_REST_Controller {
 	 *
 	 * @see https://fedidcg.github.io/FedCM/#idp-api-error-response
 	 *
-	 * @param string $code   One of the error codes defined by the FedCM specification.
-	 * @param int    $status HTTP status code.
+	 * @param string           $code    One of the error codes defined by the FedCM specification.
+	 * @param int              $status  HTTP status code.
+	 * @param \WP_REST_Request $request The request object.
 	 * @return \WP_REST_Response The error response.
 	 */
-	private function assertion_error( $code, $status ) {
-		return new \WP_REST_Response(
+	private function assertion_error( $code, $status, $request ) {
+		$response = new \WP_REST_Response(
 			array(
 				'error' => array(
 					'code' => $code,
@@ -599,6 +633,9 @@ class FedCM_Controller extends \WP_REST_Controller {
 			),
 			$status
 		);
+
+		// The browser drops the body without these, so the error never surfaces.
+		return $this->add_cors_headers( $response, $request );
 	}
 
 	/**
@@ -612,7 +649,7 @@ class FedCM_Controller extends \WP_REST_Controller {
 	public function assertion( $request ) {
 		// Validate FedCM request header.
 		if ( ! $this->is_valid_fedcm_request( $request ) ) {
-			return $this->assertion_error( 'invalid_request', 400 );
+			return $this->assertion_error( 'invalid_request', 400, $request );
 		}
 
 		$client_id  = $request->get_param( 'client_id' );
@@ -622,12 +659,12 @@ class FedCM_Controller extends \WP_REST_Controller {
 
 		// Validate origin.
 		if ( ! $this->validate_origin( $request, $client_id ) ) {
-			return $this->assertion_error( 'unauthorized_client', 403 );
+			return $this->assertion_error( 'unauthorized_client', 403, $request );
 		}
 
 		// Check if user is logged in.
 		if ( ! \is_user_logged_in() ) {
-			return $this->assertion_error( 'access_denied', 401 );
+			return $this->assertion_error( 'access_denied', 401, $request );
 		}
 
 		$user = \wp_get_current_user();
@@ -635,7 +672,7 @@ class FedCM_Controller extends \WP_REST_Controller {
 
 		// Verify account_id matches the current user.
 		if ( normalize_url( $account_id ) !== normalize_url( $me ) ) {
-			return $this->assertion_error( 'access_denied', 403 );
+			return $this->assertion_error( 'access_denied', 403, $request );
 		}
 
 		// Parse PKCE params (already validated by validate_params callback).
@@ -649,7 +686,7 @@ class FedCM_Controller extends \WP_REST_Controller {
 		// Generate authorization code.
 		$uuid = \wp_generate_uuid4();
 
-		// Determine scope - default to 'profile' for FedCM.
+		// Determine scope - default to 'profile' when the client does not ask.
 		$scope = 'profile';
 		if ( is_array( $params ) && isset( $params['scope'] ) ) {
 			// The FedCM browser UI never displays scopes, so only identity
@@ -657,9 +694,11 @@ class FedCM_Controller extends \WP_REST_Controller {
 			$requested = array_filter( explode( ' ', \sanitize_text_field( $params['scope'] ) ) );
 			// array_intersect() keeps every occurrence, so a repeated scope has to be dropped.
 			$granted = array_values( array_unique( array_intersect( $requested, array( 'profile', 'email' ) ) ) );
-			if ( $granted ) {
-				$scope = implode( ' ', $granted );
-			}
+
+			// Whatever the client asked for, it only gets what survived the clamp.
+			// An empty result means no access token at all, rather than a
+			// profile token the client never requested.
+			$scope = implode( ' ', $granted );
 		}
 
 		/**

--- a/includes/rest/class-fedcm-controller.php
+++ b/includes/rest/class-fedcm-controller.php
@@ -283,8 +283,13 @@ class FedCM_Controller extends \WP_REST_Controller {
 			return new \WP_Error( 'invalid_params', \__( 'Invalid params format', 'indieauth' ) );
 		}
 
-		if ( empty( $value['code_challenge'] ) || empty( $value['code_challenge_method'] ) ) {
-			return new \WP_Error( 'invalid_params', \__( 'PKCE parameters required', 'indieauth' ) );
+		// Both have to be non-empty strings. A non-scalar passes empty() but
+		// sanitizes to an empty string later, and the code would then be stored
+		// without a PKCE binding at all.
+		foreach ( array( 'code_challenge', 'code_challenge_method' ) as $key ) {
+			if ( ! isset( $value[ $key ] ) || ! is_string( $value[ $key ] ) || '' === trim( $value[ $key ] ) ) {
+				return new \WP_Error( 'invalid_params', \__( 'PKCE parameters required', 'indieauth' ) );
+			}
 		}
 
 		if ( 'S256' !== $value['code_challenge_method'] ) {
@@ -682,6 +687,14 @@ class FedCM_Controller extends \WP_REST_Controller {
 
 		$code_challenge        = \sanitize_text_field( $params['code_challenge'] );
 		$code_challenge_method = \sanitize_text_field( $params['code_challenge_method'] );
+
+		// The stored code is run through array_filter() below, which drops empty
+		// values. A challenge that sanitized to nothing would therefore be stored
+		// as no challenge at all, and the token endpoint skips PKCE verification
+		// when the code carries none.
+		if ( '' === $code_challenge || '' === $code_challenge_method ) {
+			return $this->assertion_error( 'invalid_request', 400, $request );
+		}
 
 		// Generate authorization code.
 		$uuid = \wp_generate_uuid4();

--- a/includes/rest/class-fedcm-controller.php
+++ b/includes/rest/class-fedcm-controller.php
@@ -655,7 +655,8 @@ class FedCM_Controller extends \WP_REST_Controller {
 			// The FedCM browser UI never displays scopes, so only identity
 			// scopes may be granted without a real consent screen.
 			$requested = array_filter( explode( ' ', \sanitize_text_field( $params['scope'] ) ) );
-			$granted   = array_values( array_intersect( $requested, array( 'profile', 'email' ) ) );
+			// array_intersect() keeps every occurrence, so a repeated scope has to be dropped.
+			$granted = array_values( array_unique( array_intersect( $requested, array( 'profile', 'email' ) ) ) );
 			if ( $granted ) {
 				$scope = implode( ' ', $granted );
 			}

--- a/includes/rest/class-token-controller.php
+++ b/includes/rest/class-token-controller.php
@@ -384,9 +384,16 @@ class Token_Controller extends \WP_REST_Controller {
 			return new OAuth_Response( 'invalid_grant', \__( 'The client_id does not match the authorization request', 'indieauth' ), 400 );
 		}
 		// FedCM codes are issued without a redirect_uri; every other code is bound to one.
-		if ( empty( $return['fedcm'] ) && ( ! isset( $args['redirect_uri'] ) || ! isset( $return['redirect_uri'] ) || $return['redirect_uri'] !== $args['redirect_uri'] ) ) {
-			$codes->destroy( $args['code'] );
-			return new OAuth_Response( 'invalid_grant', \__( 'The redirect_uri does not match the authorization request', 'indieauth' ), 400 );
+		if ( empty( $return['fedcm'] ) ) {
+			// A missing parameter is a client mistake, not a sign the code leaked,
+			// so it stays usable for a retry.
+			if ( ! isset( $args['redirect_uri'] ) ) {
+				return new OAuth_Response( 'invalid_request', \__( 'The request is missing the redirect_uri parameter', 'indieauth' ), 400 );
+			}
+			if ( ! isset( $return['redirect_uri'] ) || $return['redirect_uri'] !== $args['redirect_uri'] ) {
+				$codes->destroy( $args['code'] );
+				return new OAuth_Response( 'invalid_grant', \__( 'The redirect_uri does not match the authorization request', 'indieauth' ), 400 );
+			}
 		}
 		if ( isset( $return['code_challenge'] ) ) {
 			if ( ! isset( $args['code_verifier'] ) ) {

--- a/includes/rest/class-token-controller.php
+++ b/includes/rest/class-token-controller.php
@@ -16,6 +16,7 @@ use function IndieAuth\get_user_by_identifier;
 use function IndieAuth\pkce_verifier;
 use function IndieAuth\indieauth_validate_client_identifier;
 use function IndieAuth\rest_is_valid_url;
+use function IndieAuth\same_url;
 
 /**
  * IndieAuth Token Controller class.
@@ -379,18 +380,16 @@ class Token_Controller extends \WP_REST_Controller {
 		if ( ! $return ) {
 			return new OAuth_Response( 'invalid_code', \__( 'Invalid authorization code', 'indieauth' ), 401 );
 		}
-		if ( ! isset( $args['client_id'] ) || ! isset( $return['client_id'] ) || $return['client_id'] !== $args['client_id'] ) {
+		if ( ! isset( $args['client_id'] ) || ! isset( $return['client_id'] ) || ! same_url( $return['client_id'], $args['client_id'] ) ) {
 			$codes->destroy( $args['code'] );
 			return new OAuth_Response( 'invalid_grant', \__( 'The client_id does not match the authorization request', 'indieauth' ), 400 );
 		}
-		// FedCM codes are issued without a redirect_uri; every other code is bound to one.
+		// FedCM codes are issued without a redirect_uri; every other code is bound
+		// to one. A code that fails the binding is destroyed either way, including
+		// when the parameter is absent: answering differently would tell an
+		// attacker holding a stolen code that it is still live, without spending it.
 		if ( empty( $return['fedcm'] ) ) {
-			// A missing parameter is a client mistake, not a sign the code leaked,
-			// so it stays usable for a retry.
-			if ( ! isset( $args['redirect_uri'] ) ) {
-				return new OAuth_Response( 'invalid_request', \__( 'The request is missing the redirect_uri parameter', 'indieauth' ), 400 );
-			}
-			if ( ! isset( $return['redirect_uri'] ) || $return['redirect_uri'] !== $args['redirect_uri'] ) {
+			if ( ! isset( $args['redirect_uri'] ) || ! isset( $return['redirect_uri'] ) || ! same_url( $return['redirect_uri'], $args['redirect_uri'] ) ) {
 				$codes->destroy( $args['code'] );
 				return new OAuth_Response( 'invalid_grant', \__( 'The redirect_uri does not match the authorization request', 'indieauth' ), 400 );
 			}

--- a/includes/rest/class-token-controller.php
+++ b/includes/rest/class-token-controller.php
@@ -257,14 +257,15 @@ class Token_Controller extends \WP_REST_Controller {
 	 * @return \WP_REST_Response|OAuth_Response Token response or error.
 	 */
 	public function authorization_code( $params ) {
-		$diff = array_diff( array( 'code', 'client_id', 'redirect_uri' ), array_keys( $params ) );
+		// redirect_uri is validated against the stored code, which knows whether one was used.
+		$diff = array_diff( array( 'code', 'client_id' ), array_keys( $params ) );
 		if ( ! empty( $diff ) ) {
 			return new OAuth_Response( 'invalid_request', \__( 'The request is missing one or more required parameters', 'indieauth' ), 400 );
 		}
 		$args     = array_filter(
 			array(
 				'code'          => $params['code'],
-				'redirect_uri'  => $params['redirect_uri'],
+				'redirect_uri'  => isset( $params['redirect_uri'] ) ? $params['redirect_uri'] : null,
 				'client_id'     => $params['client_id'],
 				'code_verifier' => isset( $params['code_verifier'] ) ? $params['code_verifier'] : null,
 			)
@@ -377,6 +378,15 @@ class Token_Controller extends \WP_REST_Controller {
 		$return = $codes->get( $args['code'] );
 		if ( ! $return ) {
 			return new OAuth_Response( 'invalid_code', \__( 'Invalid authorization code', 'indieauth' ), 401 );
+		}
+		if ( ! isset( $args['client_id'] ) || ! isset( $return['client_id'] ) || $return['client_id'] !== $args['client_id'] ) {
+			$codes->destroy( $args['code'] );
+			return new OAuth_Response( 'invalid_grant', \__( 'The client_id does not match the authorization request', 'indieauth' ), 400 );
+		}
+		// FedCM codes are issued without a redirect_uri; every other code is bound to one.
+		if ( empty( $return['fedcm'] ) && ( ! isset( $args['redirect_uri'] ) || ! isset( $return['redirect_uri'] ) || $return['redirect_uri'] !== $args['redirect_uri'] ) ) {
+			$codes->destroy( $args['code'] );
+			return new OAuth_Response( 'invalid_grant', \__( 'The redirect_uri does not match the authorization request', 'indieauth' ), 400 );
 		}
 		if ( isset( $return['code_challenge'] ) ) {
 			if ( ! isset( $args['code_verifier'] ) ) {

--- a/includes/rest/class-token-controller.php
+++ b/includes/rest/class-token-controller.php
@@ -17,6 +17,7 @@ use function IndieAuth\pkce_verifier;
 use function IndieAuth\indieauth_validate_client_identifier;
 use function IndieAuth\rest_is_valid_url;
 use function IndieAuth\same_url;
+use function IndieAuth\code_binding_failure;
 
 /**
  * IndieAuth Token Controller class.
@@ -380,19 +381,21 @@ class Token_Controller extends \WP_REST_Controller {
 		if ( ! $return ) {
 			return new OAuth_Response( 'invalid_code', \__( 'Invalid authorization code', 'indieauth' ), 401 );
 		}
-		if ( ! isset( $args['client_id'] ) || ! isset( $return['client_id'] ) || ! same_url( $return['client_id'], $args['client_id'] ) ) {
+		// A code that fails its binding is destroyed, including when the parameter
+		// is simply absent: answering differently would tell an attacker holding a
+		// stolen code that it is still live, without spending it.
+		$failed = code_binding_failure( $return, $args );
+		if ( null !== $failed ) {
 			$codes->destroy( $args['code'] );
-			return new OAuth_Response( 'invalid_grant', \__( 'The client_id does not match the authorization request', 'indieauth' ), 400 );
-		}
-		// FedCM codes are issued without a redirect_uri; every other code is bound
-		// to one. A code that fails the binding is destroyed either way, including
-		// when the parameter is absent: answering differently would tell an
-		// attacker holding a stolen code that it is still live, without spending it.
-		if ( empty( $return['fedcm'] ) ) {
-			if ( ! isset( $args['redirect_uri'] ) || ! isset( $return['redirect_uri'] ) || ! same_url( $return['redirect_uri'], $args['redirect_uri'] ) ) {
-				$codes->destroy( $args['code'] );
-				return new OAuth_Response( 'invalid_grant', \__( 'The redirect_uri does not match the authorization request', 'indieauth' ), 400 );
-			}
+			return new OAuth_Response(
+				'invalid_grant',
+				sprintf(
+					// translators: Name of the parameter that did not match.
+					\__( 'The %s does not match the authorization request', 'indieauth' ),
+					$failed
+				),
+				400
+			);
 		}
 		if ( isset( $return['code_challenge'] ) ) {
 			if ( ! isset( $args['code_verifier'] ) ) {

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -125,4 +125,42 @@ class Test_Functions extends WP_UnitTestCase {
 		}
 	}
 
+
+	public function code_binding_provider() {
+		$stored = array(
+			'client_id'    => 'https://app.example.com',
+			'redirect_uri' => 'https://app.example.com/redirect',
+		);
+
+		return array(
+			'exact match'                => array( $stored, array( 'client_id' => 'https://app.example.com', 'redirect_uri' => 'https://app.example.com/redirect' ), null ),
+			'client_id trailing slash'   => array( $stored, array( 'client_id' => 'https://app.example.com/', 'redirect_uri' => 'https://app.example.com/redirect' ), null ),
+			'client_id case'             => array( $stored, array( 'client_id' => 'HTTPS://App.Example.com', 'redirect_uri' => 'https://app.example.com/redirect' ), null ),
+			'explicit default port'      => array( $stored, array( 'client_id' => 'https://app.example.com:443', 'redirect_uri' => 'https://app.example.com/redirect' ), null ),
+			'client_id mismatch'         => array( $stored, array( 'client_id' => 'https://evil.example.com', 'redirect_uri' => 'https://app.example.com/redirect' ), 'client_id' ),
+			'redirect_uri mismatch'      => array( $stored, array( 'client_id' => 'https://app.example.com', 'redirect_uri' => 'https://evil.example.com/cb' ), 'redirect_uri' ),
+			'client_id absent'           => array( $stored, array( 'redirect_uri' => 'https://app.example.com/redirect' ), 'client_id' ),
+			'redirect_uri absent'        => array( $stored, array( 'client_id' => 'https://app.example.com' ), 'redirect_uri' ),
+			'different path is no match' => array( $stored, array( 'client_id' => 'https://app.example.com', 'redirect_uri' => 'https://app.example.com/other' ), 'redirect_uri' ),
+			'fedcm needs no redirect'    => array( array( 'client_id' => 'https://app.example.com', 'fedcm' => true ), array( 'client_id' => 'https://app.example.com' ), null ),
+			'fedcm still binds client'   => array( array( 'client_id' => 'https://app.example.com', 'fedcm' => true ), array( 'client_id' => 'https://evil.example.com' ), 'client_id' ),
+		);
+	}
+
+	/**
+	 * The one place that decides whether a code was redeemed correctly.
+	 *
+	 * Both the authorization endpoint and the token endpoint call this, so it is
+	 * tested directly rather than only through either of them.
+	 *
+	 * @dataProvider code_binding_provider
+	 *
+	 * @param array       $token    The stored code data.
+	 * @param array       $params   The redemption parameters.
+	 * @param string|null $expected The parameter expected to fail, or null.
+	 */
+	public function test_code_binding_failure( $token, $params, $expected ) {
+		$this->assertSame( $expected, IndieAuth\code_binding_failure( $token, $params ) );
+	}
+
 }

--- a/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
@@ -212,4 +212,29 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 	 	$code_verifier  = "a612878371009ghja1d388e2e98b6ae8221ac31aca31959e59512c59f5";
 		$this->assertFalse( pkce_verifier( $code_challenge, $code_verifier, 'S256' ) );
 	}
+	/**
+	 * This endpoint must destroy a code on a binding failure too.
+	 *
+	 * It accepts the same codes as the token endpoint. If only that one
+	 * revoked, an attacker could simply probe client_id and redirect_uri here
+	 * instead, without ever spending the code.
+	 */
+	public function test_auth_code_destroyed_on_binding_failure() {
+		$code     = $this->set_auth_code();
+		$response = $this->create_form(
+			'POST',
+			array(
+				'grant_type'   => 'authorization_code',
+				'code'         => $code,
+				'client_id'    => 'https://evil.example.com',
+				'redirect_uri' => 'https://app.example.com/redirect',
+			)
+		);
+
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'invalid_grant', $data['error'], wp_json_encode( $data ) );
+		$this->assertFalse( $this->get_auth_code( $code ) );
+	}
+
 }

--- a/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
@@ -213,6 +213,28 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 		$this->assertFalse( pkce_verifier( $code_challenge, $code_verifier, 'S256' ) );
 	}
 	/**
+	 * An equivalent client_id must not burn the code at this endpoint either.
+	 *
+	 * The token endpoint compares these as URLs. This endpoint destroys the code
+	 * on a mismatch, so comparing as raw strings would mean a trailing slash
+	 * costs the user a restart of the whole flow.
+	 */
+	public function test_auth_code_redemption_tolerates_equivalent_client_id() {
+		$code     = $this->set_auth_code();
+		$response = $this->create_form(
+			'POST',
+			array(
+				'grant_type'   => 'authorization_code',
+				'code'         => $code,
+				'client_id'    => 'https://app.example.com/',
+				'redirect_uri' => 'https://app.example.com/redirect',
+			)
+		);
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+	}
+
+	/**
 	 * This endpoint must destroy a code on a binding failure too.
 	 *
 	 * It accepts the same codes as the token endpoint. If only that one

--- a/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-authorization-controller.php
@@ -91,6 +91,35 @@ class Test_Authorization_Controller extends WP_UnitTestCase {
 		);
 	}
 
+	// FedCM codes are issued without a redirect, so redemption works without redirect_uri.
+	public function test_fedcm_auth_code_redemption_without_redirect_uri() {
+		$tokens = new Token_User( '_indieauth_code_' );
+		$tokens->set_user( self::$author_id );
+		$code = $tokens->set(
+			array(
+				'client_id' => 'https://app.example.com/',
+				'scope'     => 'profile',
+				'me'        => get_author_posts_url( static::$author_id ),
+				'user'      => static::$author_id,
+				'fedcm'     => true,
+			),
+			600
+		);
+
+		$response = $this->create_form(
+			'POST',
+			array(
+				'grant_type' => 'authorization_code',
+				'code'       => $code,
+				'client_id'  => 'https://app.example.com/',
+			)
+		);
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertArrayNotHasKey( 'access_token', $data );
+		$this->assertEquals( get_author_posts_url( static::$author_id ), $data['me'] );
+	}
+
 	// Tests to Make Sure the Auth Endpoint Does Not Return a Token
 	public function test_auth_code_redemption_with_scope() {
 		static::$test_auth_code['scope'] = 'create update';

--- a/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
@@ -15,9 +15,13 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	protected static $author_id;
 	protected static $author_url;
 
+	protected $original_request_uri;
+
 	public function set_up() {
 		global $wp_rest_server;
 		parent::set_up();
+
+		$this->original_request_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
 
 		$wp_rest_server = new Spy_REST_Server();
 		do_action( 'rest_api_init', $wp_rest_server );
@@ -59,6 +63,9 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		global $wp_rewrite;
 		$wp_rewrite->set_permalink_structure( '' );
 		$wp_rewrite->flush_rules();
+		unset( $GLOBALS['wp_rest_auth_cookie'] );
+		unset( $_SERVER['HTTP_SEC_FETCH_DEST'] );
+		$_SERVER['REQUEST_URI'] = $this->original_request_uri;
 		parent::tear_down();
 	}
 
@@ -105,6 +112,45 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Send an assertion request with valid PKCE parameters and FedCM headers.
+	 *
+	 * @param array  $body_overrides   Overrides merged into the request body.
+	 * @param array  $params_overrides Overrides merged into the JSON params field.
+	 * @param string $origin           Origin header value.
+	 * @return WP_REST_Response
+	 */
+	public function assertion_request( $body_overrides = array(), $params_overrides = array(), $origin = 'https://app.example.com' ) {
+		$code_verifier = 'a6128783714cfda1d388e2e98b6ae8221ac31aca31959e59512c59f5';
+
+		$params = wp_json_encode(
+			array_merge(
+				array(
+					'code_challenge'        => base64_urlencode( hash( 'sha256', $code_verifier, true ) ),
+					'code_challenge_method' => 'S256',
+				),
+				$params_overrides
+			)
+		);
+
+		return $this->create_request(
+			'POST',
+			'assertion',
+			array_merge(
+				array(
+					'client_id'  => 'https://app.example.com/',
+					'account_id' => self::$author_url,
+					'params'     => $params,
+				),
+				$body_overrides
+			),
+			array(
+				'Sec-Fetch-Dest' => 'webidentity',
+				'Origin'         => $origin,
+			)
+		);
+	}
+
+	/**
 	 * Test config endpoint returns valid configuration.
 	 */
 	public function test_config_endpoint_returns_valid_config() {
@@ -123,6 +169,38 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$this->assertStringStartsWith( 'http', $data['accounts_endpoint'] );
 		$this->assertStringStartsWith( 'http', $data['client_metadata_endpoint'] );
 		$this->assertStringStartsWith( 'http', $data['id_assertion_endpoint'] );
+	}
+
+	/**
+	 * Test config endpoint sends public CORS headers without credentials.
+	 */
+	public function test_config_endpoint_uses_public_cors() {
+		$response = $this->create_request(
+			'GET',
+			'config.json',
+			array(),
+			array( 'Origin' => 'https://app.example.com' )
+		);
+
+		$headers = $response->get_headers();
+		$this->assertEquals( '*', $headers['Access-Control-Allow-Origin'] );
+		$this->assertArrayNotHasKey( 'Access-Control-Allow-Credentials', $headers );
+	}
+
+	/**
+	 * Test client_metadata endpoint sends public CORS headers without credentials.
+	 */
+	public function test_client_metadata_endpoint_uses_public_cors() {
+		$response = $this->create_request(
+			'GET',
+			'client_metadata',
+			array( 'client_id' => 'https://unknown-client.example.com/' ),
+			array( 'Origin' => 'https://app.example.com' )
+		);
+
+		$headers = $response->get_headers();
+		$this->assertEquals( '*', $headers['Access-Control-Allow-Origin'] );
+		$this->assertArrayNotHasKey( 'Access-Control-Allow-Credentials', $headers );
 	}
 
 	/**
@@ -225,7 +303,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
 		$data = $response->get_data();
-		$this->assertEquals( 'Missing or invalid Sec-Fetch-Dest header', $data['error'] );
+		$this->assertEquals( 'invalid_request', $data['error']['code'] );
 	}
 
 	/**
@@ -258,7 +336,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 403, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
 		$data = $response->get_data();
-		$this->assertEquals( 'Origin mismatch', $data['error'] );
+		$this->assertEquals( 'unauthorized_client', $data['error']['code'] );
 	}
 
 	/**
@@ -291,7 +369,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 403, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
 		$data = $response->get_data();
-		$this->assertEquals( 'Origin mismatch', $data['error'] );
+		$this->assertEquals( 'unauthorized_client', $data['error']['code'] );
 	}
 
 	/**
@@ -324,7 +402,21 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 403, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
 		$data = $response->get_data();
-		$this->assertEquals( 'Origin mismatch', $data['error'] );
+		$this->assertEquals( 'unauthorized_client', $data['error']['code'] );
+	}
+
+	/**
+	 * Test assertion endpoint treats an explicit default port as equal to no port.
+	 *
+	 * Browsers omit default ports from the Origin header, so a client_id
+	 * registered as https://app.example.com:443/ must still match.
+	 */
+	public function test_assertion_endpoint_accepts_explicit_default_port() {
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->assertion_request( array( 'client_id' => 'https://app.example.com:443/' ) );
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 	}
 
 	/**
@@ -357,7 +449,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 401, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
 		$data = $response->get_data();
-		$this->assertEquals( 'Not logged in', $data['error'] );
+		$this->assertEquals( 'access_denied', $data['error']['code'] );
 	}
 
 	/**
@@ -451,29 +543,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	public function test_assertion_endpoint_issues_authorization_code() {
 		wp_set_current_user( self::$author_id );
 
-		$code_verifier  = 'a6128783714cfda1d388e2e98b6ae8221ac31aca31959e59512c59f5';
-		$code_challenge = base64_urlencode( hash( 'sha256', $code_verifier, true ) );
-
-		$params = wp_json_encode(
-			array(
-				'code_challenge'        => $code_challenge,
-				'code_challenge_method' => 'S256',
-			)
-		);
-
-		$response = $this->create_request(
-			'POST',
-			'assertion',
-			array(
-				'client_id'  => 'https://app.example.com/',
-				'account_id' => self::$author_url,
-				'params'     => $params,
-			),
-			array(
-				'Sec-Fetch-Dest' => 'webidentity',
-				'Origin'         => 'https://app.example.com',
-			)
-		);
+		$response = $this->assertion_request();
 
 		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
@@ -516,7 +586,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 403, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
 		$data = $response->get_data();
-		$this->assertEquals( 'Account mismatch', $data['error'] );
+		$this->assertEquals( 'access_denied', $data['error']['code'] );
 	}
 
 	/**
@@ -525,30 +595,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	public function test_assertion_endpoint_stores_nonce() {
 		wp_set_current_user( self::$author_id );
 
-		$code_verifier  = 'a6128783714cfda1d388e2e98b6ae8221ac31aca31959e59512c59f5';
-		$code_challenge = base64_urlencode( hash( 'sha256', $code_verifier, true ) );
-
-		$params = wp_json_encode(
-			array(
-				'code_challenge'        => $code_challenge,
-				'code_challenge_method' => 'S256',
-			)
-		);
-
-		$response = $this->create_request(
-			'POST',
-			'assertion',
-			array(
-				'client_id'  => 'https://app.example.com/',
-				'account_id' => self::$author_url,
-				'params'     => $params,
-				'nonce'      => 'test-nonce-12345',
-			),
-			array(
-				'Sec-Fetch-Dest' => 'webidentity',
-				'Origin'         => 'https://app.example.com',
-			)
-		);
+		$response = $this->assertion_request( array( 'nonce' => 'test-nonce-12345' ) );
 
 		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
@@ -564,34 +611,78 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test assertion endpoint clamps RP-requested scopes to identity scopes.
+	 *
+	 * The FedCM browser UI never displays scopes, so scopes beyond
+	 * profile/email must not be granted without a real consent screen.
+	 */
+	public function test_assertion_endpoint_clamps_scope_to_identity_scopes() {
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->assertion_request( array(), array( 'scope' => 'create update profile email' ) );
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+
+		$data       = $response->get_data();
+		$token_data = json_decode( $data['token'], true );
+
+		$tokens    = new Token_User( '_indieauth_code_' );
+		$code_data = $tokens->get( $token_data['code'] );
+
+		$this->assertEquals( 'profile email', $code_data['scope'] );
+	}
+
+	/**
+	 * Data provider for the REST nonce exemption checks.
+	 *
+	 * @return array[] Sec-Fetch-Dest header (null to omit), request URI, whether the cookie user is kept.
+	 */
+	public function rest_nonce_exemption_provider() {
+		return array(
+			'FedCM request to a FedCM route is exempt'    => array( 'webidentity', '/wp-json/indieauth/1.0/fedcm/accounts', true ),
+			'request without FedCM header is not exempt'  => array( null, '/wp-json/wp/v2/posts', false ),
+			'FedCM header on another route is not exempt' => array( 'webidentity', '/wp-json/wp/v2/posts', false ),
+		);
+	}
+
+	/**
+	 * Test which cookie-authenticated requests without a nonce keep their user.
+	 *
+	 * The browser's FedCM machinery cannot send a REST nonce, so FedCM
+	 * requests to FedCM routes are exempt from the nonce check; everything
+	 * else must stay unauthenticated.
+	 *
+	 * @dataProvider rest_nonce_exemption_provider
+	 *
+	 * @param string|null $sec_fetch_dest Sec-Fetch-Dest header value, or null to omit the header.
+	 * @param string      $request_uri    The request URI.
+	 * @param bool        $exempt         Whether the cookie-authenticated user should be kept.
+	 */
+	public function test_rest_nonce_exemption( $sec_fetch_dest, $request_uri, $exempt ) {
+		wp_set_current_user( self::$author_id );
+
+		// Simulate a cookie-authenticated request without a nonce.
+		$GLOBALS['wp_rest_auth_cookie'] = true;
+		if ( null === $sec_fetch_dest ) {
+			unset( $_SERVER['HTTP_SEC_FETCH_DEST'] );
+		} else {
+			$_SERVER['HTTP_SEC_FETCH_DEST'] = $sec_fetch_dest;
+		}
+		$_SERVER['REQUEST_URI'] = $request_uri;
+
+		$result = apply_filters( 'rest_authentication_errors', null );
+
+		$this->assertTrue( $result );
+		$this->assertEquals( $exempt ? self::$author_id : 0, get_current_user_id() );
+	}
+
+	/**
 	 * Test that FedCM-issued codes are marked as such.
 	 */
 	public function test_assertion_endpoint_marks_code_as_fedcm() {
 		wp_set_current_user( self::$author_id );
 
-		$code_verifier  = 'a6128783714cfda1d388e2e98b6ae8221ac31aca31959e59512c59f5';
-		$code_challenge = base64_urlencode( hash( 'sha256', $code_verifier, true ) );
-
-		$params = wp_json_encode(
-			array(
-				'code_challenge'        => $code_challenge,
-				'code_challenge_method' => 'S256',
-			)
-		);
-
-		$response = $this->create_request(
-			'POST',
-			'assertion',
-			array(
-				'client_id'  => 'https://app.example.com/',
-				'account_id' => self::$author_url,
-				'params'     => $params,
-			),
-			array(
-				'Sec-Fetch-Dest' => 'webidentity',
-				'Origin'         => 'https://app.example.com',
-			)
-		);
+		$response = $this->assertion_request();
 
 		$this->assertEquals( 200, $response->get_status() );
 

--- a/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
@@ -636,7 +636,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	/**
 	 * Data provider for the REST nonce exemption checks.
 	 *
-	 * @return array[] Sec-Fetch-Dest header (null to omit), request URI, whether the cookie user is kept.
+	 * @return array[] Sec-Fetch-Dest header (null to omit), dispatched route, whether a valid auth cookie was sent, whether the cookie user is kept.
 	 */
 	public function rest_nonce_exemption_provider() {
 		return array(

--- a/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
@@ -407,6 +407,25 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test assertion endpoint matches the origin case-insensitively.
+	 *
+	 * Browsers send a lowercased Origin, but a client can register a client_id
+	 * with any casing. Schemes and hosts are case-insensitive, so the two still
+	 * have to be treated as the same origin.
+	 */
+	public function test_assertion_endpoint_matches_origin_case_insensitively() {
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->assertion_request(
+			array( 'client_id' => 'HTTPS://App.Example.com/' ),
+			array(),
+			'https://app.example.com'
+		);
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+	}
+
+	/**
 	 * Test assertion endpoint treats an explicit default port as equal to no port.
 	 *
 	 * Browsers omit default ports from the Origin header, so a client_id

--- a/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
@@ -844,4 +844,91 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'fedcm', $code_data );
 		$this->assertTrue( $code_data['fedcm'] );
 	}
+
+	public function unusable_code_challenge_provider() {
+		return array(
+			'array'         => array( array( 'abc' ) ),
+			'nested array'  => array( array( 'a' => 'b' ) ),
+			'boolean true'  => array( true ),
+			'whitespace'    => array( '   ' ),
+		);
+	}
+
+	/**
+	 * A code_challenge that cannot be used must be rejected at the assertion.
+	 *
+	 * `empty()` accepts a non-empty array, `sanitize_text_field()` turns it into
+	 * an empty string, and `array_filter()` then drops the key entirely. The
+	 * stored code would carry no challenge, and the token endpoint only verifies
+	 * PKCE when the code has one, so the binding would be gone with no error
+	 * anywhere along the way.
+	 *
+	 * @dataProvider unusable_code_challenge_provider
+	 *
+	 * @param mixed $code_challenge The code_challenge an RP sends.
+	 */
+	public function test_assertion_endpoint_rejects_unusable_code_challenge( $code_challenge ) {
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->create_request(
+			'POST',
+			'assertion',
+			array(
+				'client_id'  => 'https://app.example.com/',
+				'account_id' => self::$author_url,
+				'params'     => array(
+					'code_challenge'        => $code_challenge,
+					'code_challenge_method' => 'S256',
+				),
+			),
+			array(
+				'Sec-Fetch-Dest' => 'webidentity',
+				'Origin'         => 'https://app.example.com',
+			)
+		);
+
+		$this->assertNotEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+	}
+
+	/**
+	 * No FedCM code may ever be stored without its PKCE challenge.
+	 *
+	 * This is the property that matters: the token endpoint skips PKCE
+	 * verification for a code that has no challenge, so a code stored without
+	 * one is redeemable by anyone who obtains it.
+	 */
+	public function test_assertion_endpoint_never_stores_a_code_without_a_challenge() {
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->create_request(
+			'POST',
+			'assertion',
+			array(
+				'client_id'  => 'https://app.example.com/',
+				'account_id' => self::$author_url,
+				'params'     => array(
+					'code_challenge'        => array( 'abc' ),
+					'code_challenge_method' => 'S256',
+				),
+			),
+			array(
+				'Sec-Fetch-Dest' => 'webidentity',
+				'Origin'         => 'https://app.example.com',
+			)
+		);
+
+		$data = $response->get_data();
+		if ( ! isset( $data['token'] ) ) {
+			// Rejected outright, which is the expected outcome.
+			$this->assertNotEquals( 200, $response->get_status() );
+			return;
+		}
+
+		$token_data = json_decode( $data['token'], true );
+		$tokens     = new Token_User( '_indieauth_code_' );
+		$code_data  = $tokens->get( $token_data['code'] );
+
+		$this->assertArrayHasKey( 'code_challenge', $code_data, 'Code was stored with no PKCE challenge.' );
+		$this->assertNotEmpty( $code_data['code_challenge'] );
+	}
 }

--- a/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
@@ -64,6 +64,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 		$wp_rewrite->set_permalink_structure( '' );
 		$wp_rewrite->flush_rules();
 		unset( $GLOBALS['wp_rest_auth_cookie'] );
+		unset( $GLOBALS['wp']->query_vars['rest_route'] );
 		unset( $_SERVER['HTTP_SEC_FETCH_DEST'] );
 		$_SERVER['REQUEST_URI'] = $this->original_request_uri;
 		parent::tear_down();
@@ -639,9 +640,10 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	 */
 	public function rest_nonce_exemption_provider() {
 		return array(
-			'FedCM request to a FedCM route is exempt'    => array( 'webidentity', '/wp-json/indieauth/1.0/fedcm/accounts', true ),
-			'request without FedCM header is not exempt'  => array( null, '/wp-json/wp/v2/posts', false ),
-			'FedCM header on another route is not exempt' => array( 'webidentity', '/wp-json/wp/v2/posts', false ),
+			'FedCM request to a FedCM route is exempt'     => array( 'webidentity', '/indieauth/1.0/fedcm/accounts', true, true ),
+			'request without FedCM header is not exempt'   => array( null, '/wp/v2/posts', true, false ),
+			'FedCM header on another route is not exempt'  => array( 'webidentity', '/wp/v2/posts', true, false ),
+			'FedCM path in a query string is not exempt'   => array( 'webidentity', '/wp/v2/posts?s=/indieauth/1.0/fedcm/accounts', true, false ),
 		);
 	}
 
@@ -655,25 +657,54 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	 * @dataProvider rest_nonce_exemption_provider
 	 *
 	 * @param string|null $sec_fetch_dest Sec-Fetch-Dest header value, or null to omit the header.
-	 * @param string      $request_uri    The request URI.
+	 * @param string      $rest_route     The route the REST server dispatched.
+	 * @param bool        $auth_cookie    Whether the request carried a valid auth cookie.
 	 * @param bool        $exempt         Whether the cookie-authenticated user should be kept.
 	 */
-	public function test_rest_nonce_exemption( $sec_fetch_dest, $request_uri, $exempt ) {
+	public function test_rest_nonce_exemption( $sec_fetch_dest, $rest_route, $auth_cookie, $exempt ) {
 		wp_set_current_user( self::$author_id );
 
-		// Simulate a cookie-authenticated request without a nonce.
-		$GLOBALS['wp_rest_auth_cookie'] = true;
+		// Simulate a request without a nonce.
+		if ( $auth_cookie ) {
+			$GLOBALS['wp_rest_auth_cookie'] = true;
+		}
 		if ( null === $sec_fetch_dest ) {
 			unset( $_SERVER['HTTP_SEC_FETCH_DEST'] );
 		} else {
 			$_SERVER['HTTP_SEC_FETCH_DEST'] = $sec_fetch_dest;
 		}
-		$_SERVER['REQUEST_URI'] = $request_uri;
+		$GLOBALS['wp']->query_vars['rest_route'] = $rest_route;
 
 		$result = apply_filters( 'rest_authentication_errors', null );
 
 		$this->assertTrue( $result );
 		$this->assertEquals( $exempt ? self::$author_id : 0, get_current_user_id() );
+	}
+
+	/**
+	 * Test that a FedCM request without a valid auth cookie is not exempted.
+	 *
+	 * The exemption exists to keep a cookie-authenticated user that cannot send
+	 * a nonce. With no cookie there is nothing to preserve, so the request has
+	 * to fall through to the normal REST authentication pipeline.
+	 */
+	public function test_rest_nonce_exemption_requires_auth_cookie() {
+		$controller = new IndieAuth\Rest\FedCM_Controller();
+
+		wp_set_current_user( self::$author_id );
+		$_SERVER['HTTP_SEC_FETCH_DEST']          = 'webidentity';
+		$GLOBALS['wp']->query_vars['rest_route'] = '/indieauth/1.0/fedcm/accounts';
+
+		// No valid auth cookie was collected for this request.
+		unset( $GLOBALS['wp_rest_auth_cookie'] );
+		$this->assertNull( $controller->rest_authentication_errors( null ) );
+
+		// A cookie that failed validation must not qualify either.
+		$GLOBALS['wp_rest_auth_cookie'] = 'bad_hash';
+		$this->assertNull( $controller->rest_authentication_errors( null ) );
+
+		$GLOBALS['wp_rest_auth_cookie'] = true;
+		$this->assertTrue( $controller->rest_authentication_errors( null ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
@@ -653,6 +653,28 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the stored scope is canonical when a scope is requested twice.
+	 *
+	 * A repeated scope grants nothing extra, so it must not end up in the
+	 * stored scope string either.
+	 */
+	public function test_assertion_endpoint_stores_each_scope_once() {
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->assertion_request( array(), array( 'scope' => 'profile email profile' ) );
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+
+		$data       = $response->get_data();
+		$token_data = json_decode( $data['token'], true );
+
+		$tokens    = new Token_User( '_indieauth_code_' );
+		$code_data = $tokens->get( $token_data['code'] );
+
+		$this->assertEquals( 'profile email', $code_data['scope'] );
+	}
+
+	/**
 	 * Data provider for the REST nonce exemption checks.
 	 *
 	 * @return array[] Sec-Fetch-Dest header (null to omit), dispatched route, whether a valid auth cookie was sent, whether the cookie user is kept.

--- a/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-fedcm-controller.php
@@ -653,6 +653,51 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An explicit empty scope must not turn into a profile access token.
+	 *
+	 * A client that asks for nothing gets an identity response, the same as
+	 * before the clamp existed. Falling back to 'profile' would hand out a
+	 * bearer token the client never requested.
+	 */
+	public function test_assertion_endpoint_grants_no_scope_when_none_requested() {
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->assertion_request( array(), array( 'scope' => '' ) );
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+
+		$data       = $response->get_data();
+		$token_data = json_decode( $data['token'], true );
+
+		$tokens    = new Token_User( '_indieauth_code_' );
+		$code_data = $tokens->get( $token_data['code'] );
+
+		$this->assertArrayNotHasKey( 'scope', $code_data );
+	}
+
+	/**
+	 * A request for only non-identity scopes must not become a profile token.
+	 *
+	 * The clamp cannot grant 'create', and quietly substituting 'profile'
+	 * hands the client authority it did not ask for.
+	 */
+	public function test_assertion_endpoint_grants_no_scope_when_none_survive_the_clamp() {
+		wp_set_current_user( self::$author_id );
+
+		$response = $this->assertion_request( array(), array( 'scope' => 'create update' ) );
+
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+
+		$data       = $response->get_data();
+		$token_data = json_decode( $data['token'], true );
+
+		$tokens    = new Token_User( '_indieauth_code_' );
+		$code_data = $tokens->get( $token_data['code'] );
+
+		$this->assertArrayNotHasKey( 'scope', $code_data );
+	}
+
+	/**
 	 * Test the stored scope is canonical when a scope is requested twice.
 	 *
 	 * A repeated scope grants nothing extra, so it must not end up in the
@@ -718,7 +763,7 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 
 		$result = apply_filters( 'rest_authentication_errors', null );
 
-		$this->assertTrue( $result );
+		$this->assertNotWPError( $result );
 		$this->assertEquals( $exempt ? self::$author_id : 0, get_current_user_id() );
 	}
 
@@ -738,14 +783,45 @@ class Test_FedCM_Controller extends WP_UnitTestCase {
 
 		// No valid auth cookie was collected for this request.
 		unset( $GLOBALS['wp_rest_auth_cookie'] );
-		$this->assertNull( $controller->rest_authentication_errors( null ) );
+		$controller->rest_authentication_errors( null );
+		$this->assertNotFalse( has_filter( 'rest_authentication_errors', 'rest_cookie_check_errors' ) );
 
 		// A cookie that failed validation must not qualify either.
 		$GLOBALS['wp_rest_auth_cookie'] = 'bad_hash';
-		$this->assertNull( $controller->rest_authentication_errors( null ) );
+		$controller->rest_authentication_errors( null );
+		$this->assertNotFalse( has_filter( 'rest_authentication_errors', 'rest_cookie_check_errors' ) );
 
 		$GLOBALS['wp_rest_auth_cookie'] = true;
-		$this->assertTrue( $controller->rest_authentication_errors( null ) );
+		$controller->rest_authentication_errors( null );
+		$this->assertFalse( has_filter( 'rest_authentication_errors', 'rest_cookie_check_errors' ) );
+	}
+
+	/**
+	 * The exemption must not end the filter chain for other plugins.
+	 *
+	 * Returning true from rest_authentication_errors stops every later callback,
+	 * which would silently skip a REST hardening plugin's policy on FedCM routes.
+	 */
+	public function test_rest_nonce_exemption_leaves_other_auth_filters_running() {
+		$controller = new IndieAuth\Rest\FedCM_Controller();
+
+		wp_set_current_user( self::$author_id );
+		$_SERVER['HTTP_SEC_FETCH_DEST']          = 'webidentity';
+		$GLOBALS['wp']->query_vars['rest_route'] = '/indieauth/1.0/fedcm/accounts';
+		$GLOBALS['wp_rest_auth_cookie']          = true;
+
+		$denied = new WP_Error( 'rest_forbidden', 'Blocked by policy.' );
+		$deny   = function () use ( $denied ) {
+			return $denied;
+		};
+		add_filter( 'rest_authentication_errors', $deny, 20 );
+
+		$result = apply_filters( 'rest_authentication_errors', null );
+
+		remove_filter( 'rest_authentication_errors', $deny, 20 );
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'rest_forbidden', $result->get_error_code() );
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/rest/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-token-controller.php
@@ -191,6 +191,58 @@ class Test_Token_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 'invalid_grant', $data['error'], wp_json_encode( $data ) );
 	}
 
+	/**
+	 * A missing redirect_uri is a client mistake, not a leaked code.
+	 *
+	 * It has to come back as invalid_request, and the code must survive so the
+	 * client can retry once it sends the parameter.
+	 */
+	public function test_auth_code_survives_missing_redirect_uri() {
+		$code     = $this->set_auth_code();
+		$response = $this->create_form(
+			'POST',
+			array(
+				'grant_type' => 'authorization_code',
+				'code'       => $code,
+				'client_id'  => 'https://app.example.com',
+			)
+		);
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'invalid_request', $data['error'], wp_json_encode( $data ) );
+
+		// The code is still there, and redeeming it properly works.
+		$this->assertNotFalse( $this->get_auth_code( $code ) );
+		$retry = $this->create_form(
+			'POST',
+			array(
+				'grant_type'   => 'authorization_code',
+				'code'         => $code,
+				'client_id'    => 'https://app.example.com',
+				'redirect_uri' => 'https://app.example.com/redirect',
+			)
+		);
+		$this->assertEquals( 200, $retry->get_status(), 'Response: ' . wp_json_encode( $retry ) );
+	}
+
+	// An actual mismatch may mean the code leaked, so the code is destroyed.
+	public function test_auth_code_destroyed_on_redirect_uri_mismatch() {
+		$code     = $this->set_auth_code();
+		$response = $this->create_form(
+			'POST',
+			array(
+				'grant_type'   => 'authorization_code',
+				'code'         => $code,
+				'client_id'    => 'https://app.example.com',
+				'redirect_uri' => 'https://evil.example.com/redirect',
+			)
+		);
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'invalid_grant', $data['error'], wp_json_encode( $data ) );
+		$this->assertFalse( $this->get_auth_code( $code ) );
+	}
+
 	// FedCM codes are issued without a redirect, so redemption works without redirect_uri.
 	public function test_fedcm_auth_code_redemption_without_redirect_uri() {
 		$code_verifier  = 'a6128783714cfda1d388e2e98b6ae8221ac31aca31959e59512c59f5';

--- a/tests/phpunit/tests/includes/rest/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-token-controller.php
@@ -192,12 +192,14 @@ class Test_Token_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A missing redirect_uri is a client mistake, not a leaked code.
+	 * A missing redirect_uri must destroy the code, like any other binding failure.
 	 *
-	 * It has to come back as invalid_request, and the code must survive so the
-	 * client can retry once it sends the parameter.
+	 * Answering differently for a live code than for a dead one, without
+	 * spending the code, would let anyone holding a stolen code confirm it is
+	 * still redeemable and keep probing. client_id is the client's public URL,
+	 * so that probe costs an attacker nothing.
 	 */
-	public function test_auth_code_survives_missing_redirect_uri() {
+	public function test_auth_code_destroyed_when_redirect_uri_missing() {
 		$code     = $this->set_auth_code();
 		$response = $this->create_form(
 			'POST',
@@ -209,20 +211,56 @@ class Test_Token_Controller extends WP_UnitTestCase {
 		);
 		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 		$data = $response->get_data();
-		$this->assertEquals( 'invalid_request', $data['error'], wp_json_encode( $data ) );
+		$this->assertEquals( 'invalid_grant', $data['error'], wp_json_encode( $data ) );
+		$this->assertFalse( $this->get_auth_code( $code ) );
+	}
 
-		// The code is still there, and redeeming it properly works.
-		$this->assertNotFalse( $this->get_auth_code( $code ) );
-		$retry = $this->create_form(
+	/**
+	 * The probe must not be repeatable.
+	 *
+	 * A single request can still tell a live code from one that never existed,
+	 * the same as any other binding failure. What matters is that the attempt
+	 * spends the code, so an attacker cannot poll a set of harvested codes and
+	 * keep the live ones intact for later.
+	 */
+	public function test_missing_redirect_uri_probe_is_not_repeatable() {
+		$code = $this->set_auth_code();
+
+		$probe = function ( $candidate ) {
+			return $this->create_form(
+				'POST',
+				array(
+					'grant_type' => 'authorization_code',
+					'code'       => $candidate,
+					'client_id'  => 'https://app.example.com',
+				)
+			);
+		};
+
+		$probe( $code );
+
+		// The code is gone, so a second probe looks like one for a code that
+		// was never issued.
+		$second      = $probe( $code );
+		$nonexistent = $probe( 'a-code-that-was-never-issued' );
+
+		$this->assertEquals( $nonexistent->get_status(), $second->get_status() );
+		$this->assertEquals( $nonexistent->get_data()['error'], $second->get_data()['error'] );
+	}
+
+	// A cosmetic client_id difference is the same URL and must still redeem.
+	public function test_auth_code_redemption_tolerates_equivalent_client_id() {
+		$code     = $this->set_auth_code();
+		$response = $this->create_form(
 			'POST',
 			array(
 				'grant_type'   => 'authorization_code',
 				'code'         => $code,
-				'client_id'    => 'https://app.example.com',
+				'client_id'    => 'https://app.example.com/',
 				'redirect_uri' => 'https://app.example.com/redirect',
 			)
 		);
-		$this->assertEquals( 200, $retry->get_status(), 'Response: ' . wp_json_encode( $retry ) );
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 	}
 
 	// An actual mismatch may mean the code leaked, so the code is destroyed.

--- a/tests/phpunit/tests/includes/rest/class-test-token-controller.php
+++ b/tests/phpunit/tests/includes/rest/class-test-token-controller.php
@@ -157,6 +157,75 @@ class Test_Token_Controller extends WP_UnitTestCase {
 		);
 	}
 
+	// Redemption must fail when the client_id does not match the stored code.
+	public function test_auth_code_redemption_rejects_client_id_mismatch() {
+		$code     = $this->set_auth_code();
+		$response = $this->create_form(
+			'POST',
+			array(
+				'grant_type'   => 'authorization_code',
+				'code'         => $code,
+				'client_id'    => 'https://evil.example.com',
+				'redirect_uri' => 'https://app.example.com/redirect',
+			)
+		);
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'invalid_grant', $data['error'], wp_json_encode( $data ) );
+	}
+
+	// Redemption must fail when the redirect_uri does not match the stored code.
+	public function test_auth_code_redemption_rejects_redirect_uri_mismatch() {
+		$code     = $this->set_auth_code();
+		$response = $this->create_form(
+			'POST',
+			array(
+				'grant_type'   => 'authorization_code',
+				'code'         => $code,
+				'client_id'    => 'https://app.example.com',
+				'redirect_uri' => 'https://evil.example.com/redirect',
+			)
+		);
+		$this->assertEquals( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertEquals( 'invalid_grant', $data['error'], wp_json_encode( $data ) );
+	}
+
+	// FedCM codes are issued without a redirect, so redemption works without redirect_uri.
+	public function test_fedcm_auth_code_redemption_without_redirect_uri() {
+		$code_verifier  = 'a6128783714cfda1d388e2e98b6ae8221ac31aca31959e59512c59f5';
+		$code_challenge = base64_urlencode( hash( 'sha256', $code_verifier, true ) );
+
+		$tokens = new Token_User( '_indieauth_code_' );
+		$tokens->set_user( self::$author_id );
+		$code = $tokens->set(
+			array(
+				'client_id'             => 'https://app.example.com/',
+				'scope'                 => 'profile',
+				'me'                    => get_author_posts_url( static::$author_id ),
+				'user'                  => static::$author_id,
+				'code_challenge'        => $code_challenge,
+				'code_challenge_method' => 'S256',
+				'fedcm'                 => true,
+			),
+			600
+		);
+
+		$response = $this->create_form(
+			'POST',
+			array(
+				'grant_type'    => 'authorization_code',
+				'code'          => $code,
+				'client_id'     => 'https://app.example.com/',
+				'code_verifier' => $code_verifier,
+			)
+		);
+		$this->assertEquals( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'access_token', $data );
+		$this->assertEquals( 'profile', $data['scope'] );
+	}
+
 	// Sets an Auth Code and Redeems it at the Token Endpoint with Profile
 	public function test_auth_code_redemption_with_profile() {
 		static::$test_auth_code['scope'] = 'create profile';


### PR DESCRIPTION
A review of the FedCM implementation (#299) turned up one functional blocker and several security/spec issues. Every fix was developed test-first; the failing test reproducing each issue was written before the fix.

## Fixes

### FedCM endpoints saw logged-in users as logged out (functional blocker)
`accounts` and `assertion` rely on `is_user_logged_in()`, but core's `rest_cookie_check_errors()` treats any cookie-authenticated REST request without a `_wpnonce`/`X-WP-Nonce` as unauthenticated. The browser's FedCM machinery can never send a REST nonce, so in a real browser the accounts endpoint always answered 401 and the flow dead-ended. (PHPUnit couldn't catch it: `wp_set_current_user()` doesn't set `$wp_rest_auth_cookie`, so the nonce path never ran in tests.)

The fix is a `rest_authentication_errors` filter that exempts requests bearing `Sec-Fetch-Dest: webidentity` — scoped to the plugin's `fedcm/` routes only. `Sec-`-prefixed headers are forbidden for cross-site JavaScript, so this does not open a CSRF hole; non-FedCM routes keep core's strict behavior (covered by tests).

### RPs could obtain arbitrary-scope tokens without scope consent
The assertion endpoint accepted whatever `params.scope` the RP sent and the token endpoint then issued a real access token for it — but the FedCM browser dialog never displays scopes, so a one-click sign-in could silently become a `create update` token. Requested scopes are now clamped to `profile`/`email`; the `indieauth_fedcm_scope` filter still allows deliberate opt-up.

### Code redemption never verified `client_id`/`redirect_uri`
`verify_local_authorization_code()` only checked PKCE — a code could be exchanged with a mismatched `client_id` or `redirect_uri`. Both are now enforced at the token endpoint. FedCM codes are issued without a redirect, so they are redeemable without a `redirect_uri` at both the token and authorization endpoints (keyed off the server-set `fedcm` marker), and the unused `urn:ietf:wg:oauth:2.0:oob` placeholder is no longer stored.

### Smaller fixes
- **Origin validation**: a missing port now counts as the scheme default, so a `client_id` of `https://app.example.com:443/` matches the browser's `Origin: https://app.example.com`.
- **Error shape**: assertion errors follow the FedCM Error API — `{"error": {"code": "invalid_request" | "unauthorized_client" | "access_denied"}}`.
- **CORS**: the public `config.json` and `client_metadata` endpoints send `Access-Control-Allow-Origin: *` without credentials; reflected credentialed CORS remains only on `accounts`/`assertion` where the spec requires it.

## Testing instructions

1. `npm run test:wp-env` — 108 tests, includes new coverage for the nonce exemption (positive + two negative cases), scope clamping, code binding (mismatch rejection + FedCM redemption without redirect_uri), default-port origins, error shape, and public CORS.
2. Manual check of the critical fix on a wp-env site: log in, then
   `curl -b <cookies> -H "Sec-Fetch-Dest: webidentity" <site>/wp-json/indieauth/1.0/fedcm/accounts`
   returns the account list without a nonce; the same request without the header is still rejected, and core routes (e.g. `/wp/v2/users/me`) still 401 without a nonce even with the header.

## Follow-ups (not in this PR)

- `IdentityProvider.register()` still fires on every dashboard load; it should probably move behind an explicit button on the settings page.
- The two code-redemption paths (authorization + token endpoint) still duplicate the verification mechanics; worth unifying into one shared verifier in a separate refactor.
- Worth one manual Chrome run to confirm the auth cookie (default SameSite=Lax) is attached to FedCM fetches; if not, FedCM-enabled sites need `SameSite=None`.
