### PR TITLE
fix the site user setting when it is set to "None"

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -176,9 +176,14 @@ if ( ! function_exists( 'IndieAuth\get_user_by_identifier' ) ) {
 		// Try to save the expense of a search query if the URL is the site URL.
 		if ( \home_url( '/' ) === $identifier ) {
 			// Use the settings to set the root user.
-			if ( 0 !== indieauth_get_root_user() ) {
-				return \get_user_by( 'id', (int) \get_option( 'indieauth_root_user' ) );
+			$root_user = indieauth_get_root_user();
+			if ( 0 !== $root_user ) {
+				$user = \get_user_by( 'id', $root_user );
+				if ( $user instanceof \WP_User ) {
+					return $user;
+				}
 			}
+			// No root user, or the configured one no longer exists, so fall through to the lookups below.
 		}
 
 		// Check if this is a author post URL.
@@ -209,11 +214,12 @@ if ( ! function_exists( 'IndieAuth\get_url_from_user' ) ) {
 	 * @return string|null URL or null.
 	 */
 	function get_url_from_user( $user_id ) {
-		if ( (int) indieauth_get_root_user() === $user_id ) {
-			return \home_url( '/' );
-		}
+		$user_id = (int) $user_id;
 		if ( ! $user_id ) {
 			return null;
+		}
+		if ( indieauth_get_root_user() === $user_id ) {
+			return \home_url( '/' );
 		}
 		return \get_author_posts_url( $user_id );
 	}
@@ -559,17 +565,19 @@ function indieauth_get_user( $user, $email = false ) {
 /**
  * Get the root user for IndieAuth.
  *
- * @return int User ID or 0.
+ * This is the user whose identity is the site's home URL rather than their author URL.
+ *
+ * @return int User ID, or 0 if no user represents the site URL.
  */
 function indieauth_get_root_user() {
 	$default = \get_option( 'indieauth_root_user', null );
-	// Null is only returned if the setting does not exist.
+	// Null is only returned if the setting does not exist. The dropdown stores "None" as the string '0'.
 	if ( ! is_null( $default ) ) {
-		return $default;
+		return (int) $default;
 	}
 	$default = \get_option( 'iw_default_author', null );
 	if ( $default ) {
-		return $default;
+		return (int) $default;
 	}
 	$users = \get_users(
 		array(

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -42,9 +42,10 @@ class Admin {
 			'indieauth',
 			'indieauth_root_user',
 			array(
-				'type'         => 'int',
-				'description'  => \__( 'User Who is Represented by the Site URL', 'indieauth' ),
-				'show_in_rest' => true,
+				'type'              => 'int',
+				'description'       => \__( 'User Who is Represented by the Site URL', 'indieauth' ),
+				'show_in_rest'      => true,
+				'sanitize_callback' => 'absint',
 			)
 		);
 		\register_setting(

--- a/includes/wp-admin/class-admin.php
+++ b/includes/wp-admin/class-admin.php
@@ -42,7 +42,7 @@ class Admin {
 			'indieauth',
 			'indieauth_root_user',
 			array(
-				'type'              => 'int',
+				'type'              => 'integer',
 				'description'       => \__( 'User Who is Represented by the Site URL', 'indieauth' ),
 				'show_in_rest'      => true,
 				'sanitize_callback' => 'absint',

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -102,7 +102,14 @@ class Settings_Fields {
 				'selected'        => \get_option( 'indieauth_root_user' ),
 			)
 		);
-		echo '<p class="description">' . \esc_html__( 'Set a User who will represent the URL of the site', 'indieauth' ) . '</p>';
+		echo '<p class="description">';
+		\printf(
+			/* translators: %s: The home URL of the site. */
+			\esc_html__( 'The user whose identity is this site itself. When that user signs in, they are identified as %s instead of their author URL. Every other user is always identified by their own author URL.', 'indieauth' ),
+			'<code>' . \esc_html( \home_url( '/' ) ) . '</code>'
+		);
+		echo '<br />' . \esc_html__( 'Choose "None" if no single person represents this site — everyone then signs in with their author URL.', 'indieauth' );
+		echo '</p>';
 	}
 
 	/**

--- a/tests/phpunit/tests/includes/class-test-functions.php
+++ b/tests/phpunit/tests/includes/class-test-functions.php
@@ -32,6 +32,46 @@ class Test_Functions extends WP_UnitTestCase {
 		remove_filter( 'site_url', $strip_port );
 	}
 
+	// The "None" choice in the Site User dropdown is stored as the string '0'.
+	public function test_root_user_is_int_when_set_to_none() {
+		update_option( 'indieauth_root_user', '0' );
+
+		$this->assertSame( 0, indieauth_get_root_user() );
+	}
+
+	// With no Site User set, the site URL must still fall through to the user_url lookup.
+	public function test_siteurl_with_no_root_user() {
+		// Remove port from site URL for IndieAuth URL validation compatibility.
+		$strip_port = function ( $url ) {
+			return preg_replace( '/:\d+/', '', $url );
+		};
+		add_filter( 'home_url', $strip_port );
+		add_filter( 'site_url', $strip_port );
+
+		update_option( 'indieauth_root_user', '0' );
+		wp_update_user(
+			array(
+				'ID'       => static::$author_id,
+				'user_url' => home_url( '/' ),
+			)
+		);
+
+		$result = get_user_by_identifier( home_url( '/' ) );
+
+		remove_filter( 'home_url', $strip_port );
+		remove_filter( 'site_url', $strip_port );
+
+		$this->assertInstanceOf( 'WP_User', $result );
+		$this->assertSame( static::$author_id, $result->ID );
+	}
+
+	// A logged-out user must not inherit the site URL when no Site User is set.
+	public function test_url_from_user_without_a_user() {
+		update_option( 'indieauth_root_user', '0' );
+
+		$this->assertNull( get_url_from_user( 0 ) );
+	}
+
 	// Test Getting the Author URL through the url_to_author function directly
 	public function test_urltoauthor() {
 		$result = url_to_author( get_author_posts_url( static::$author_id ) );

--- a/tests/phpunit/tests/includes/rest/class-test-settings.php
+++ b/tests/phpunit/tests/includes/rest/class-test-settings.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Settings Registration Tests file.
+ *
+ * @package IndieAuth
+ */
+
+/**
+ * Settings Registration Tests.
+ */
+class Test_Settings extends WP_UnitTestCase {
+
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( static::$admin_id );
+	}
+
+	public function set_up() {
+		global $wp_rest_server;
+		parent::set_up();
+
+		$wp_rest_server = new Spy_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+	}
+
+	// Settings registered with show_in_rest must use a JSON Schema type core accepts.
+	public function test_settings_are_exposed_in_rest() {
+		wp_set_current_user( static::$admin_id );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp/v2/settings' ) );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'indieauth_root_user', $data );
+	}
+}


### PR DESCRIPTION
@snarfed asked in chat why he still gets `me=https://snarfed.org/author/ryandc` while the "Site User" setting is on "None". That part works as intended. The setting picks the one user whose identity is the site URL, everyone else keeps their author URL. But while looking into it I found a few things that are broken.

The dropdown stores "None" as the string `'0'`, and `indieauth_get_root_user()` returned it unchanged. `get_user_by_identifier()` then checks `0 !== indieauth_get_root_user()`, which is true for a string, so it ran `get_user_by( 'id', 0 )`, got `false` and returned that. With no site user set, an identifier matching the home URL never falls through to the `url_to_author()` and `user_url` lookups below. So a user whose profile URL is the site root can not be resolved at all. It also returns `false` where the docblock promises `WP_User|null`.

The same comparison bites in `get_url_from_user()`, where `(int) '0' === 0` matches before the `! $user_id` check, so a logged out user gets the site URL back. I don't think that is reachable through the current callers, they all pass `$current_user->ID` after an auth check, but it seems wrong anyway.

What changed:

- `indieauth_get_root_user()` always returns an int now, plus `absint` as `sanitize_callback` so the option stops being saved as a string in the first place
- `get_user_by_identifier()` falls through to the normal lookups when there is no root user, or when the configured one was deleted in the meantime
- `get_url_from_user()` checks for an empty user id first
- expanded the description of the setting, which was snarfed's actual suggestion. It names the home URL now and says what happens to everyone else

Three regression tests, the full suite is green.

I left out gRegor's idea of an install question ("are you the only author?"). `indieauth_get_root_user()` already falls back to the single user or the single author, so the question would only ever show up on multi author sites, and there I don't think it has an obvious answer.

/cc @snarfed @gRegorLove
