### PR TITLE
soft fail on unknown bearer tokens

### DIFF
--- a/includes/class-authorize.php
+++ b/includes/class-authorize.php
@@ -21,9 +21,25 @@ class Authorize {
 	/**
 	 * Error object.
 	 *
+	 * Set when a token was positively attributed to this plugin but could not be used,
+	 * for example because the user it belongs to no longer exists. Surfaced via the
+	 * `rest_authentication_errors` filter.
+	 *
 	 * @var \WP_Error|OAuth_Response|null
 	 */
 	public $error = null;
+
+	/**
+	 * Deferred error object.
+	 *
+	 * Set when a Bearer token was presented that is not in the IndieAuth token store.
+	 * Such a token may belong to another plugin, so the request is not rejected outright.
+	 * The error is only attached to responses that reject the request for lack of
+	 * authentication anyway. See `rest_request_after_callbacks()`.
+	 *
+	 * @var OAuth_Response|null
+	 */
+	public $deferred_error = null;
 
 	/**
 	 * Current scopes.
@@ -68,7 +84,38 @@ class Authorize {
 		\add_filter( 'indieauth_scopes', array( $this, 'get_indieauth_scopes' ), 9 );
 		\add_filter( 'indieauth_response', array( $this, 'get_indieauth_response' ), 9 );
 		\add_filter( 'wp_rest_server_class', array( $this, 'wp_rest_server_class' ) );
+		\add_filter( 'rest_request_after_callbacks', array( $this, 'rest_request_after_callbacks' ), 9 );
 		\add_filter( 'rest_request_after_callbacks', array( $this, 'return_oauth_error' ), 10, 3 );
+	}
+
+	/**
+	 * Attaches a deferred `invalid_token` error to responses that reject an unauthenticated request.
+	 *
+	 * A Bearer token that is not in the IndieAuth token store may belong to another plugin,
+	 * so it must not fail the request by itself. If no plugin authenticated the request and the
+	 * route rejects it with a 401, the token was invalid for this site after all. In that case
+	 * the generic error is replaced with the OAuth error, as required by RFC 6750.
+	 *
+	 * Public routes and routes that authenticate through other means are left untouched.
+	 *
+	 * @param \WP_REST_Response|\WP_HTTP_Response|\WP_Error|mixed $response Result to send to the client.
+	 * @return \WP_REST_Response|\WP_Error|mixed Modified response.
+	 */
+	public function rest_request_after_callbacks( $response ) {
+		if ( ! is_oauth_error( $this->deferred_error ) || ! \is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( \is_user_logged_in() ) {
+			return $response;
+		}
+
+		$data = $response->get_error_data();
+		if ( ! isset( $data['status'] ) || 401 !== (int) $data['status'] ) {
+			return $response;
+		}
+
+		return $this->deferred_error->to_wp_error();
 	}
 
 
@@ -174,13 +221,18 @@ class Authorize {
 		if ( ! isset( $token ) ) {
 			return $user_id;
 		}
-		// If there is a token and it is invalid then reject all logins.
 		$params = $this->verify_access_token( $token );
 		if ( ! isset( $params ) ) {
 			return $user_id;
 		}
 		if ( is_oauth_error( $params ) ) {
-			$this->error = $params;
+			/*
+			 * The token is not in the IndieAuth token store. Bearer tokens are an opaque
+			 * namespace shared with every other plugin, so this one may well belong to
+			 * someone else. Do not reject the request here; let the route decide and
+			 * attach the error later if the request fails for lack of authentication.
+			 */
+			$this->deferred_error = $params;
 			return $user_id;
 		}
 		if ( is_array( $params ) ) {

--- a/tests/phpunit/tests/includes/class-test-authorize.php
+++ b/tests/phpunit/tests/includes/class-test-authorize.php
@@ -25,6 +25,11 @@ class Test_Authorize extends WP_UnitTestCase {
 		parent::set_up();
 	}
 
+	public function tear_down() {
+		unset( $_SERVER['HTTP_AUTHORIZATION'], $_POST['access_token'], $_REQUEST['micropub'] );
+		parent::tear_down();
+	}
+
 	public static function wpSetUpBeforeClass( $factory ) {
 		static::$author_id = $factory->user->create(
 			array(
@@ -128,7 +133,119 @@ class Test_Authorize extends WP_UnitTestCase {
 		$user_id = apply_filters( 'determine_current_user', false );
 		$this->assertFalse( $user_id );
 		wp_set_current_user( $user_id );
-		$this->assertTrue( is_wp_error( $authorize->rest_authentication_errors() ) );
+		// A token that is not ours may belong to another plugin, so it must not fail authentication by itself.
+		$this->assertNull( $authorize->rest_authentication_errors() );
+		$this->assertTrue( is_oauth_error( $authorize->deferred_error ) );
+	}
+
+	/**
+	 * Registers two routes for the unknown token tests: one public, one requiring authentication.
+	 */
+	private function register_test_routes() {
+		register_rest_route(
+			'indieauth-test/1.0',
+			'/public',
+			array(
+				'methods'             => 'GET',
+				'callback'            => function () {
+					return array( 'ok' => true );
+				},
+				'permission_callback' => '__return_true',
+			)
+		);
+		register_rest_route(
+			'indieauth-test/1.0',
+			'/protected',
+			array(
+				'methods'             => 'GET',
+				'callback'            => function () {
+					return array( 'ok' => true );
+				},
+				'permission_callback' => function () {
+					return is_user_logged_in();
+				},
+			)
+		);
+		register_rest_route(
+			'indieauth-test/1.0',
+			'/custom-error',
+			array(
+				'methods'             => 'GET',
+				'callback'            => function () {
+					return array( 'ok' => true );
+				},
+				'permission_callback' => function () {
+					return new WP_Error( 'other_plugin_error', 'Custom', array( 'status' => 403 ) );
+				},
+			)
+		);
+	}
+
+	/**
+	 * Authenticates the current request with an unknown Bearer token.
+	 *
+	 * @return Indieauth_Authorize
+	 */
+	private function authorize_with_unknown_token() {
+		$this->register_test_routes();
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ema-health-check';
+		$authorize = new Indieauth_Authorize();
+		$authorize->load();
+		$user_id = apply_filters( 'determine_current_user', false );
+		$this->assertFalse( $user_id );
+		wp_set_current_user( 0 );
+		return $authorize;
+	}
+
+	public function test_unknown_token_does_not_break_public_route() {
+		$this->authorize_with_unknown_token();
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/indieauth-test/1.0/public' ) );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( array( 'ok' => true ), $response->get_data() );
+	}
+
+	public function test_unknown_token_on_protected_route_returns_invalid_token() {
+		$this->authorize_with_unknown_token();
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/indieauth-test/1.0/protected' ) );
+		$this->assertEquals( 401, $response->get_status() );
+		$this->assertEquals( 'invalid_token', $response->get_data()['code'] );
+	}
+
+	public function test_unknown_token_keeps_other_plugins_error() {
+		$this->authorize_with_unknown_token();
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/indieauth-test/1.0/custom-error' ) );
+		$this->assertEquals( 403, $response->get_status() );
+		$this->assertEquals( 'other_plugin_error', $response->get_data()['code'] );
+	}
+
+	public function test_unknown_token_does_not_replace_error_for_authenticated_user() {
+		$this->register_test_routes();
+		$self_author_id = self::$author_id;
+		add_filter( 'determine_current_user', function( $user_id ) use ( $self_author_id ) {
+			if ( 'Bearer other-valid-token' === $_SERVER['HTTP_AUTHORIZATION'] ) {
+				return $self_author_id;
+			}
+			return $user_id;
+		} );
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer other-valid-token';
+		$authorize = new Indieauth_Authorize();
+		$authorize->load();
+		wp_set_current_user( apply_filters( 'determine_current_user', false ) );
+		$this->assertTrue( is_user_logged_in() );
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/indieauth-test/1.0/protected' ) );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_valid_token_on_protected_route() {
+		$this->register_test_routes();
+		$token = self::set_token();
+		$_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+		$authorize = new Indieauth_Authorize();
+		$authorize->load();
+		wp_set_current_user( apply_filters( 'determine_current_user', false ) );
+		$this->assertNull( $authorize->deferred_error );
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/indieauth-test/1.0/protected' ) );
+		$this->assertEquals( 200, $response->get_status() );
 	}
 
 	// Tests map_meta_cap for standard permissions


### PR DESCRIPTION
Fixes #329

Instead of scoping the `determine_current_user` hook to our own routes (which would make IndieAuth tokens useless for Micropub or the core REST API, see the discussion in #329), the plugin now stops claiming an error for tokens it can't attribute to itself.

Bearer tokens are a shared namespace. If a token is not in our store, it may belong to another plugin, so we pass the request through and let the route decide. If nobody authenticates the request and the route rejects it with a 401, we replace the generic error with our `invalid_token` error, so clients still get the RFC 6750 response. Public routes and routes with their own error are not touched.

This is the missing half of #245 and #263 (thanks @akirk). Those handled the case where another plugin succeeds, this one handles the case where nobody recognizes the token.

**TODO (Micropub):** the Micropub plugin returns a 403 `forbidden` when no user is logged in. Before this change an invalid token on a Micropub request got our 401 `invalid_token`, now it gets the Micropub 403. The Micropub spec wants a 401 here, so I think this should be fixed in Micropub (`load_auth()` in `trait-micropub.php`), I will open a follow-up there.

/cc @dshanske @lhero-org @kasparsd
