### PR TITLE
fix classicpress download urls

### DIFF
--- a/.github/workflows/cp-phpunit.yml
+++ b/.github/workflows/cp-phpunit.yml
@@ -10,6 +10,7 @@ on:
       - 'phpunit.xml.dist'
       - 'phpcs.xml'
       - '.github/workflows/cp-phpunit.yml'
+      - 'bin/install-cp-tests.sh'
   pull_request:
     paths:
       - '**/*.php'
@@ -18,6 +19,7 @@ on:
       - 'phpunit.xml.dist'
       - 'phpcs.xml'
       - '.github/workflows/cp-phpunit.yml'
+      - 'bin/install-cp-tests.sh'
 jobs:
   phpunit:
     runs-on: ubuntu-latest

--- a/bin/install-cp-tests.sh
+++ b/bin/install-cp-tests.sh
@@ -62,8 +62,8 @@ fi
 
 if [ $CP_RELEASE = y ]; then
 	# Remote URLs for release and dev packages/files
-	CP_BUILD_ZIP_URL="https://github.com/ClassicPress/ClassicPress-release/archive/$CP_VERSION.zip"
-	CP_DEV_ZIP_URL="https://github.com/ClassicPress/ClassicPress/archive/$CP_VERSION+dev.zip"
+	CP_BUILD_ZIP_URL="https://github.com/ClassicPress/ClassicPress-release/archive/refs/tags/$CP_VERSION.zip"
+	CP_DEV_ZIP_URL="https://github.com/ClassicPress/ClassicPress/archive/refs/tags/$CP_VERSION+dev.zip"
 	CP_DEV_FILE_URL="https://raw.githubusercontent.com/ClassicPress/ClassicPress/$CP_VERSION+dev"
 	# Local paths
 	CP_BUILD_ZIP_PATH="$TMPDIR/classicpress-release-$CP_VERSION.zip"


### PR DESCRIPTION
The ClassicPress tests failed to install, unzip could not open the downloaded dev zip.

It seems the tag names did not change, but GitHub now answers the short archive URL (`archive/2.7.2+dev.zip`) with a 300 "the given path has multiple possibilities", probably because of the `+` in the tag. The script downloaded that error text and tried to unzip it.

Using the `archive/refs/tags/` form fixes it. I also added the script to the workflow paths, otherwise this PR would not trigger the ClassicPress job.